### PR TITLE
Refactor logger to send log records and apply minor fixes

### DIFF
--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -39,10 +39,6 @@ func runAgent() {
 	}
 	defer func() { _ = os.Remove(pidFilePath) }()
 
-	// Logger
-	logFile := logger.InitLogger()
-	defer func() { _ = logFile.Close() }()
-
 	// Config & Settings
 	settings := config.LoadConfig()
 	config.InitSettings(settings)
@@ -54,6 +50,10 @@ func runAgent() {
 
 	// Reporter
 	scheduler.StartReporters(session)
+
+	// Logger
+	logFile := logger.InitLogger()
+	defer func() { _ = logFile.Close() }()
 
 	// Commit
 	runner.CommitAsync(session, commissioned)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,23 +1,29 @@
 package logger
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/alpacanetworks/alpamon-go/pkg/scheduler"
+	"github.com/alpacanetworks/alpamon-go/pkg/version"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
 const (
-	logDir  = "/var/log/alpamon"
-	logFile = "alpamon.log"
+	logDir      = "/var/log/alpamon"
+	logFileName = "alpamon.log"
+	recordURL   = "/api/history/logs/"
 )
 
 func InitLogger() *os.File {
-	fileName := fmt.Sprintf("%s/%s", logDir, logFile)
+	fileName := fmt.Sprintf("%s/%s", logDir, logFileName)
 	if _, err := os.Stat(logDir); os.IsNotExist(err) {
-		fileName = logFile
+		fileName = logFileName
 	}
 
 	logFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
@@ -25,26 +31,100 @@ func InitLogger() *os.File {
 		log.Fatal().Err(err).Msg("Failed to open log file")
 	}
 
-	consoleOutput := zerolog.ConsoleWriter{
-		Out:          os.Stderr,
-		TimeFormat:   time.RFC3339,
-		TimeLocation: time.Local,
-		FormatLevel: func(i interface{}) string {
-			return "[" + strings.ToUpper(i.(string)) + "]"
-		},
-		FormatMessage: func(i interface{}) string {
-			return " " + i.(string)
-		},
-		FormatFieldName: func(i interface{}) string {
-			return "(" + i.(string) + ")"
-		},
-		FormatFieldValue: func(i interface{}) string {
-			return i.(string)
-		},
+	var output io.Writer
+
+	recordWriter := &logRecordWriter{}
+
+	// In development, log to console; in production, log to file
+	if version.Version == "dev" {
+		consoleWriter := zerolog.ConsoleWriter{
+			Out:          os.Stderr,
+			TimeFormat:   time.RFC3339,
+			TimeLocation: time.Local,
+			FormatLevel: func(i interface{}) string {
+				return "[" + strings.ToUpper(i.(string)) + "]"
+			},
+			FormatMessage: func(i interface{}) string {
+				return " " + i.(string)
+			},
+			FormatFieldName: func(i interface{}) string {
+				return "(" + i.(string) + ")"
+			},
+			FormatFieldValue: func(i interface{}) string {
+				return i.(string)
+			},
+		}
+		output = zerolog.MultiLevelWriter(consoleWriter, recordWriter)
+	} else {
+		output = zerolog.MultiLevelWriter(logFile, recordWriter)
 	}
 
-	multi := zerolog.MultiLevelWriter(consoleOutput, logFile)
-	log.Logger = zerolog.New(multi).With().Timestamp().Caller().Logger()
+	log.Logger = zerolog.New(output).With().Timestamp().Caller().Logger()
 
 	return logFile
+}
+
+type logRecord struct {
+	Date    string `json:"date"`
+	Level   int    `json:"level"`
+	Program string `json:"program"`
+	Path    string `json:"path"`
+	Lineno  int    `json:"lineno"`
+	PID     int    `json:"pid"`
+	Msg     string `json:"msg"`
+}
+
+type logRecordWriter struct{}
+
+func (w *logRecordWriter) Write(p []byte) (n int, err error) {
+	var parsedLog map[string]string
+	err = json.Unmarshal(p, &parsedLog)
+	if err != nil {
+		return 0, err
+	}
+
+	caller := parsedLog["caller"]
+	if caller == "" {
+		return len(p), nil
+	}
+
+	lineno := 0
+	if parts := strings.Split(caller, ":"); len(parts) > 1 {
+		lineno, _ = strconv.Atoi(parts[1])
+	}
+
+	record := logRecord{
+		Date:    time.Now().UTC().Format(time.RFC3339),
+		Level:   convertLevelToNumber(parsedLog["level"]),
+		Program: "alpamon",
+		Path:    caller,
+		Lineno:  lineno,
+		PID:     os.Getpid(),
+		Msg:     parsedLog["message"],
+	}
+
+	go func() {
+		scheduler.Rqueue.Post(recordURL, record, 90, time.Time{})
+	}()
+
+	return len(p), nil
+}
+
+// alpacon-server uses Python's logging package, which has different log levels from zerolog.
+// This function maps zerolog log levels to Python logging levels.
+func convertLevelToNumber(level string) int {
+	switch level {
+	case "fatal":
+		return 50 // CRITICAL, FATAL
+	case "error":
+		return 40 // ERROR
+	case "warn", "warning":
+		return 30 // WARNING
+	case "info":
+		return 20 // INFO
+	case "debug":
+		return 10 // DEBUG
+	default:
+		return 0 // NOT SET
+	}
 }

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -172,8 +172,8 @@ func syncSystemInfo(session *scheduler.Session, keys []string) {
 		} else {
 			compareData(entry, currentData.(ComparableData), remoteData.(ComparableData))
 		}
-		log.Info().Msgf("Completed system information synchronization for %s.", key)
 	}
+	log.Info().Msg("Completed system information synchronization")
 }
 
 func compareData(entry commitDef, currentData, remoteData ComparableData) {


### PR DESCRIPTION
### Refactor logger and add the following features:

- Rename ambiguous variables
- Improve logger performance:
  - Production: write logs only to logfile
  - Development: write logs only to console (using `consolewriter`)
- Send system logs to alpacon-server