### PR TITLE
Improve logging by excluding unnecessary logs in PTY and FTP

### DIFF
--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -81,7 +81,9 @@ func (fc *FtpClient) read(ctx context.Context, cancel context.CancelFunc) {
 				if ctx.Err() != nil {
 					return
 				}
-				log.Debug().Err(err).Msg("Failed to read from ftp websocket")
+				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					log.Debug().Err(err).Msg("Failed to read from ftp websocket")
+				}
 				cancel()
 				return
 			}
@@ -123,7 +125,9 @@ func (fc *FtpClient) read(ctx context.Context, cancel context.CancelFunc) {
 				if ctx.Err() != nil {
 					return
 				}
-				log.Debug().Err(err).Msg("Failed to send websocket message")
+				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					log.Debug().Err(err).Msg("Failed to send websocket message")
+				}
 				cancel()
 				return
 			}
@@ -133,10 +137,7 @@ func (fc *FtpClient) read(ctx context.Context, cancel context.CancelFunc) {
 
 func (fc *FtpClient) close() {
 	if fc.conn != nil {
-		err := fc.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-		if err != nil {
-			log.Debug().Err(err).Msg("Failed to write close message to ftp websocket")
-		}
+		_ = fc.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 		_ = fc.conn.Close()
 	}
 


### PR DESCRIPTION
This PR enhances the logging system by preventing errors caused by normal `close` events in WebSocket connections (like PTY and FTP) from being recorded. This reduces unnecessary log noise and focuses on significant errors.