### PR TITLE
Resolve "Refactor Web FTP Command"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,8 @@ nfpms:
     formats:
       - deb
       - rpm
+    dependencies:
+      - zip
     bindir: /usr/local/bin/
 
     scripts:

--- a/cmd/alpamon/command/ftp.go
+++ b/cmd/alpamon/command/ftp.go
@@ -1,15 +1,9 @@
 package command
 
 import (
-	"fmt"
-	"os/user"
-	"strconv"
-	"syscall"
-
 	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/alpacanetworks/alpamon-go/pkg/runner"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,10 +12,12 @@ var ftpCmd = &cobra.Command{
 	Short: "Start worker for Web FTP",
 	Args:  cobra.ExactArgs(4),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		username := args[0]
-		groupname := args[1]
-		url := args[2]
-		homeDirectory := args[3]
+		data := runner.CommandData{
+			Username:      args[0],
+			Groupname:     args[1],
+			URL:           args[2],
+			HomeDirectory: args[3],
+		}
 
 		logFile := logger.InitLogger()
 		defer func() { _ = logFile.Close() }()
@@ -29,57 +25,13 @@ var ftpCmd = &cobra.Command{
 		settings := config.LoadConfig()
 		config.InitFtpSettings(settings)
 
-		if syscall.Getuid() == 0 {
-			if username == "" || groupname == "" {
-				log.Debug().Msg("No username or groupname provided.")
-				return fmt.Errorf("No username or groupname provided.")
-			}
-
-			usr, err := user.Lookup(username)
-			if err != nil {
-				log.Debug().Msgf("There is no corresponding %s username in this server", username)
-				return fmt.Errorf("There is no corresponding %s username in this server", username)
-			}
-
-			group, err := user.LookupGroup(groupname)
-			if err != nil {
-				log.Debug().Msgf("There is no corresponding %s groupname in this server", groupname)
-				return fmt.Errorf("There is no corresponding %s groupname in this server", groupname)
-			}
-
-			uid, err := strconv.Atoi(usr.Uid)
-			if err != nil {
-				return err
-			}
-
-			gid, err := strconv.Atoi(group.Gid)
-			if err != nil {
-				return err
-			}
-
-			err = syscall.Setgroups([]int{})
-			if err != nil {
-				return err
-			}
-
-			err = syscall.Setuid(uid)
-			if err != nil {
-				return err
-			}
-
-			err = syscall.Setgid(gid)
-			if err != nil {
-				return err
-			}
-		}
-
-		RunFtpWorker(url, homeDirectory)
+		RunFtpWorker(data)
 
 		return nil
 	},
 }
 
-func RunFtpWorker(url, homeDirectory string) {
-	ftpClient := runner.NewFtpClient(url, homeDirectory)
+func RunFtpWorker(data runner.CommandData) {
+	ftpClient := runner.NewFtpClient(data)
 	ftpClient.RunFtpBackground()
 }

--- a/cmd/alpamon/command/ftp.go
+++ b/cmd/alpamon/command/ftp.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/alpacanetworks/alpamon-go/pkg/runner"
 	"github.com/spf13/cobra"
@@ -11,22 +10,17 @@ var ftpCmd = &cobra.Command{
 	Use:   "ftp <url> <homeDirectory>",
 	Short: "Start worker for Web FTP",
 	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
 		url := args[0]
 		homeDirectory := args[1]
 
-		logger.InitFtpLogger()
+		ftpLogger := logger.NewFtpLogger()
 
-		settings := config.LoadConfig()
-		config.InitFtpSettings(settings)
-
-		RunFtpWorker(url, homeDirectory)
-
-		return nil
+		RunFtpWorker(url, homeDirectory, ftpLogger)
 	},
 }
 
-func RunFtpWorker(url, homeDirectory string) {
-	ftpClient := runner.NewFtpClient(url, homeDirectory)
+func RunFtpWorker(url, homeDirectory string, ftpLogger logger.FtpLogger) {
+	ftpClient := runner.NewFtpClient(url, homeDirectory, ftpLogger)
 	ftpClient.RunFtpBackground()
 }

--- a/cmd/alpamon/command/ftp.go
+++ b/cmd/alpamon/command/ftp.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"github.com/alpacanetworks/alpamon-go/pkg/config"
+	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/alpacanetworks/alpamon-go/pkg/runner"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +15,8 @@ var ftpCmd = &cobra.Command{
 		url := args[0]
 		homeDirectory := args[1]
 
-		// TODO : Send logs to alpamon's Logserver using a Unix domain socket
+		logger.InitFtpLogger()
+
 		settings := config.LoadConfig()
 		config.InitFtpSettings(settings)
 

--- a/cmd/alpamon/command/ftp.go
+++ b/cmd/alpamon/command/ftp.go
@@ -2,36 +2,29 @@ package command
 
 import (
 	"github.com/alpacanetworks/alpamon-go/pkg/config"
-	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/alpacanetworks/alpamon-go/pkg/runner"
 	"github.com/spf13/cobra"
 )
 
 var ftpCmd = &cobra.Command{
-	Use:   "ftp <username> <groupname> <url> <homeDirectory>",
+	Use:   "ftp <url> <homeDirectory>",
 	Short: "Start worker for Web FTP",
-	Args:  cobra.ExactArgs(4),
+	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		data := runner.CommandData{
-			Username:      args[0],
-			Groupname:     args[1],
-			URL:           args[2],
-			HomeDirectory: args[3],
-		}
+		url := args[0]
+		homeDirectory := args[1]
 
-		logFile := logger.InitLogger()
-		defer func() { _ = logFile.Close() }()
-
+		// TODO : Send logs to alpamon's Logserver using a Unix domain socket
 		settings := config.LoadConfig()
 		config.InitFtpSettings(settings)
 
-		RunFtpWorker(data)
+		RunFtpWorker(url, homeDirectory)
 
 		return nil
 	},
 }
 
-func RunFtpWorker(data runner.CommandData) {
-	ftpClient := runner.NewFtpClient(data)
+func RunFtpWorker(url, homeDirectory string) {
+	ftpClient := runner.NewFtpClient(url, homeDirectory)
 	ftpClient.RunFtpBackground()
 }

--- a/cmd/alpamon/command/ftp.go
+++ b/cmd/alpamon/command/ftp.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"github.com/alpacanetworks/alpamon-go/pkg/config"
+	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/alpacanetworks/alpamon-go/pkg/runner"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,9 @@ var ftpCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		url := args[0]
 		homeDirectory := args[1]
+
+		logFile := logger.InitLogger()
+		defer func() { _ = logFile.Close() }()
 
 		settings := config.LoadConfig()
 		config.InitFtpSettings(settings)

--- a/cmd/alpamon/command/ftp.go
+++ b/cmd/alpamon/command/ftp.go
@@ -1,25 +1,77 @@
 package command
 
 import (
+	"fmt"
+	"os/user"
+	"strconv"
+	"syscall"
+
 	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/alpacanetworks/alpamon-go/pkg/runner"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
 var ftpCmd = &cobra.Command{
-	Use:   "ftp <url> <homeDirectory>",
+	Use:   "ftp <username> <groupname> <url> <homeDirectory>",
 	Short: "Start worker for Web FTP",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.ExactArgs(4),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		url := args[0]
-		homeDirectory := args[1]
+		username := args[0]
+		groupname := args[1]
+		url := args[2]
+		homeDirectory := args[3]
 
 		logFile := logger.InitLogger()
 		defer func() { _ = logFile.Close() }()
 
 		settings := config.LoadConfig()
 		config.InitFtpSettings(settings)
+
+		if syscall.Getuid() == 0 {
+			if username == "" || groupname == "" {
+				log.Debug().Msg("No username or groupname provided.")
+				return fmt.Errorf("No username or groupname provided.")
+			}
+
+			usr, err := user.Lookup(username)
+			if err != nil {
+				log.Debug().Msgf("There is no corresponding %s username in this server", username)
+				return fmt.Errorf("There is no corresponding %s username in this server", username)
+			}
+
+			group, err := user.LookupGroup(groupname)
+			if err != nil {
+				log.Debug().Msgf("There is no corresponding %s groupname in this server", groupname)
+				return fmt.Errorf("There is no corresponding %s groupname in this server", groupname)
+			}
+
+			uid, err := strconv.Atoi(usr.Uid)
+			if err != nil {
+				return err
+			}
+
+			gid, err := strconv.Atoi(group.Gid)
+			if err != nil {
+				return err
+			}
+
+			err = syscall.Setgroups([]int{})
+			if err != nil {
+				return err
+			}
+
+			err = syscall.Setuid(uid)
+			if err != nil {
+				return err
+			}
+
+			err = syscall.Setgid(gid)
+			if err != nil {
+				return err
+			}
+		}
 
 		RunFtpWorker(url, homeDirectory)
 

--- a/cmd/alpamon/command/ftp.go
+++ b/cmd/alpamon/command/ftp.go
@@ -1,0 +1,29 @@
+package command
+
+import (
+	"github.com/alpacanetworks/alpamon-go/pkg/config"
+	"github.com/alpacanetworks/alpamon-go/pkg/runner"
+	"github.com/spf13/cobra"
+)
+
+var ftpCmd = &cobra.Command{
+	Use:   "ftp <url> <homeDirectory>",
+	Short: "Start worker for Web FTP",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url := args[0]
+		homeDirectory := args[1]
+
+		settings := config.LoadConfig()
+		config.InitFtpSettings(settings)
+
+		RunFtpWorker(url, homeDirectory)
+
+		return nil
+	},
+}
+
+func RunFtpWorker(url, homeDirectory string) {
+	ftpClient := runner.NewFtpClient(url, homeDirectory)
+	ftpClient.RunFtpBackground()
+}

--- a/cmd/alpamon/command/ftp.go
+++ b/cmd/alpamon/command/ftp.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/alpacanetworks/alpamon-go/pkg/runner"
 	"github.com/spf13/cobra"
@@ -11,16 +12,18 @@ var ftpCmd = &cobra.Command{
 	Short: "Start worker for Web FTP",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		url := args[0]
-		homeDirectory := args[1]
+		data := runner.FtpConfigData{
+			URL:           args[0],
+			HomeDirectory: args[1],
+			Logger:        logger.NewFtpLogger(),
+			Settings:      config.LoadConfig(),
+		}
 
-		ftpLogger := logger.NewFtpLogger()
-
-		RunFtpWorker(url, homeDirectory, ftpLogger)
+		RunFtpWorker(data)
 	},
 }
 
-func RunFtpWorker(url, homeDirectory string, ftpLogger logger.FtpLogger) {
-	ftpClient := runner.NewFtpClient(url, homeDirectory, ftpLogger)
+func RunFtpWorker(data runner.FtpConfigData) {
+	ftpClient := runner.NewFtpClient(data)
 	ftpClient.RunFtpBackground()
 }

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -2,6 +2,9 @@ package command
 
 import (
 	"fmt"
+	"os"
+	"syscall"
+
 	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/alpacanetworks/alpamon-go/pkg/pidfile"
@@ -11,8 +14,6 @@ import (
 	"github.com/alpacanetworks/alpamon-go/pkg/version"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"os"
-	"syscall"
 )
 
 var RootCmd = &cobra.Command{
@@ -24,7 +25,7 @@ var RootCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(installCmd)
+	RootCmd.AddCommand(installCmd, ftpCmd)
 }
 
 func runAgent() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,13 +2,14 @@ package config
 
 import (
 	"crypto/tls"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"gopkg.in/ini.v1"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/ini.v1"
 )
 
 var (
@@ -18,6 +19,7 @@ var (
 	}
 
 	GlobalSettings Settings
+	FtpSettings    Settings
 )
 
 const (
@@ -28,6 +30,10 @@ const (
 
 func InitSettings(settings Settings) {
 	GlobalSettings = settings
+}
+
+func InitFtpSettings(settings Settings) {
+	FtpSettings = settings
 }
 
 func LoadConfig() Settings {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,6 @@ var (
 	}
 
 	GlobalSettings Settings
-	FtpSettings    Settings
 )
 
 const (
@@ -30,10 +29,6 @@ const (
 
 func InitSettings(settings Settings) {
 	GlobalSettings = settings
-}
-
-func InitFtpSettings(settings Settings) {
-	FtpSettings = settings
 }
 
 func LoadConfig() Settings {

--- a/pkg/logger/ftp_logger.go
+++ b/pkg/logger/ftp_logger.go
@@ -1,0 +1,60 @@
+package logger
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type FtpLogger struct {
+	log zerolog.Logger
+}
+
+// TODO : Send logs to alpamon's Logserver using a Unix domain socket
+func NewFtpLogger() FtpLogger {
+	consoleOutput := zerolog.ConsoleWriter{
+		Out:          os.Stderr,
+		TimeFormat:   time.RFC3339,
+		TimeLocation: time.Local,
+		FormatLevel: func(i interface{}) string {
+			return "[" + strings.ToUpper(i.(string)) + "]"
+		},
+		FormatMessage: func(i interface{}) string {
+			return " " + i.(string)
+		},
+		FormatFieldName: func(i interface{}) string {
+			return "(" + i.(string) + ")"
+		},
+		FormatFieldValue: func(i interface{}) string {
+			return i.(string)
+		},
+	}
+
+	logger := zerolog.New(consoleOutput).With().Timestamp().Caller().Logger()
+
+	return FtpLogger{
+		log: logger,
+	}
+}
+
+func (l *FtpLogger) Debug() *zerolog.Event {
+	return l.log.Debug()
+}
+
+func (l *FtpLogger) Info() *zerolog.Event {
+	return l.log.Info()
+}
+
+func (l *FtpLogger) Warn() *zerolog.Event {
+	return l.log.Warn()
+}
+
+func (l *FtpLogger) Error() *zerolog.Event {
+	return l.log.Error()
+}
+
+func (l *FtpLogger) Fatal() *zerolog.Event {
+	return l.log.Fatal()
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -65,29 +65,6 @@ func InitLogger() *os.File {
 	return logFile
 }
 
-// TODO : Send logs to alpamon's Logserver using a Unix domain socket
-func InitFtpLogger() {
-	consoleOutput := zerolog.ConsoleWriter{
-		Out:          os.Stderr,
-		TimeFormat:   time.RFC3339,
-		TimeLocation: time.Local,
-		FormatLevel: func(i interface{}) string {
-			return "[" + strings.ToUpper(i.(string)) + "]"
-		},
-		FormatMessage: func(i interface{}) string {
-			return " " + i.(string)
-		},
-		FormatFieldName: func(i interface{}) string {
-			return "(" + i.(string) + ")"
-		},
-		FormatFieldValue: func(i interface{}) string {
-			return i.(string)
-		},
-	}
-
-	log.Logger = zerolog.New(consoleOutput).With().Timestamp().Caller().Logger()
-}
-
 type logRecord struct {
 	Date    string `json:"date"`
 	Level   int    `json:"level"`

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,11 +2,12 @@ package logger
 
 import (
 	"fmt"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -47,4 +48,27 @@ func InitLogger() *os.File {
 	log.Logger = zerolog.New(multi).With().Timestamp().Caller().Logger()
 
 	return logFile
+}
+
+// TODO : Send logs to alpamon's Logserver using a Unix domain socket
+func InitFtpLogger() {
+	consoleOutput := zerolog.ConsoleWriter{
+		Out:          os.Stderr,
+		TimeFormat:   time.RFC3339,
+		TimeLocation: time.Local,
+		FormatLevel: func(i interface{}) string {
+			return "[" + strings.ToUpper(i.(string)) + "]"
+		},
+		FormatMessage: func(i interface{}) string {
+			return " " + i.(string)
+		},
+		FormatFieldName: func(i interface{}) string {
+			return "(" + i.(string) + ")"
+		},
+		FormatFieldValue: func(i interface{}) string {
+			return i.(string)
+		},
+	}
+
+	log.Logger = zerolog.New(consoleOutput).With().Timestamp().Caller().Logger()
 }

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -153,6 +153,13 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 			return 1, fmt.Sprintf("openftp: Not enough information. %s", err.Error())
 		}
 
+		sysProcAttr, err := demote(data.Username, data.Groupname)
+		if err != nil {
+			log.Debug().Err(err).Msg("Failed to get demote permission")
+
+			return 1, fmt.Sprintf("openftp: Failed to get demoted permission. %s", err.Error())
+		}
+
 		executable, err := os.Executable()
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to get executable path")
@@ -163,11 +170,10 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		cmd := exec.Command(
 			executable,
 			"ftp",
-			data.Username,
-			data.Groupname,
 			data.URL,
 			data.HomeDirectory,
 		)
+		cmd.SysProcAttr = sysProcAttr
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -153,13 +153,6 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 			return 1, fmt.Sprintf("openftp: Not enough information. %s", err.Error())
 		}
 
-		// sysProcAttr, err := demote(data.Username, data.Groupname)
-		// if err != nil {
-		// 	log.Debug().Err(err).Msg("Failed to get demote permission")
-
-		// 	return 1, fmt.Sprintf("openftp: Failed to get demoted permission. %s", err.Error())
-		// }
-
 		executable, err := os.Executable()
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to get executable path")
@@ -175,7 +168,6 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 			data.URL,
 			data.HomeDirectory,
 		)
-		// cmd.SysProcAttr = sysProcAttr
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -153,12 +153,12 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 			return 1, fmt.Sprintf("openftp: Not enough information. %s", err.Error())
 		}
 
-		sysProcAttr, err := demote(data.Username, data.Groupname)
-		if err != nil {
-			log.Debug().Err(err).Msg("Failed to get demote permission")
+		// sysProcAttr, err := demote(data.Username, data.Groupname)
+		// if err != nil {
+		// 	log.Debug().Err(err).Msg("Failed to get demote permission")
 
-			return 1, fmt.Sprintf("openftp: Failed to get demoted permission. %s", err.Error())
-		}
+		// 	return 1, fmt.Sprintf("openftp: Failed to get demoted permission. %s", err.Error())
+		// }
 
 		executable, err := os.Executable()
 		if err != nil {
@@ -170,10 +170,12 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		cmd := exec.Command(
 			executable,
 			"ftp",
+			data.Username,
+			data.Groupname,
 			data.URL,
 			data.HomeDirectory,
 		)
-		cmd.SysProcAttr = sysProcAttr
+		// cmd.SysProcAttr = sysProcAttr
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -289,7 +289,7 @@ func (cr *CommandRunner) addUser() (exitCode int, result string) {
 
 	err := cr.validateData(data)
 	if err != nil {
-		return 1, fmt.Sprintf("adduser: Not enough information. %s", err.Error())
+		return 1, fmt.Sprintf("adduser: Not enough information. %s", err)
 	}
 
 	if utils.PlatformLike == "debian" {
@@ -366,7 +366,7 @@ func (cr *CommandRunner) addGroup() (exitCode int, result string) {
 
 	err := cr.validateData(data)
 	if err != nil {
-		return 1, fmt.Sprintf("addgroup: Not enough information. %s", err.Error())
+		return 1, fmt.Sprintf("addgroup: Not enough information. %s", err)
 	}
 
 	if utils.PlatformLike == "debian" {
@@ -408,7 +408,7 @@ func (cr *CommandRunner) delUser() (exitCode int, result string) {
 
 	err := cr.validateData(data)
 	if err != nil {
-		return 1, fmt.Sprintf("deluser: Not enough information. %s", err.Error())
+		return 1, fmt.Sprintf("deluser: Not enough information. %s", err)
 	}
 
 	if utils.PlatformLike == "debian" {
@@ -448,7 +448,7 @@ func (cr *CommandRunner) delGroup() (exitCode int, result string) {
 
 	err := cr.validateData(data)
 	if err != nil {
-		return 1, fmt.Sprintf("delgroup: Not enough information. %s", err.Error())
+		return 1, fmt.Sprintf("delgroup: Not enough information. %s", err)
 	}
 
 	if utils.PlatformLike == "debian" {

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -132,6 +132,7 @@ func (fc *FtpClient) close() {
 	}
 
 	fc.log.Debug().Msg("Websocket connection for ftp has been closed.")
+	os.Exit(1)
 }
 
 func (fc *FtpClient) handleFtpCommand(command FtpCommand, data FtpData) (CommandResult, error) {

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/gorilla/websocket"
@@ -180,6 +181,7 @@ func (fc *FtpClient) listRecursive(path string, depth, current int) (CommandResu
 		Type:     "folder",
 		Path:     path,
 		Size:     int64(0),
+		ModTime:  time.Time{},
 		Children: []CommandResult{},
 	}
 
@@ -200,9 +202,10 @@ func (fc *FtpClient) listRecursive(path string, depth, current int) (CommandResu
 		}
 
 		child := CommandResult{
-			Name: entry.Name(),
-			Path: fullPath,
-			Size: info.Size(),
+			Name:    entry.Name(),
+			Path:    fullPath,
+			Size:    info.Size(),
+			ModTime: info.ModTime(),
 		}
 
 		if entry.IsDir() {
@@ -221,6 +224,13 @@ func (fc *FtpClient) listRecursive(path string, depth, current int) (CommandResu
 
 		result.Children = append(result.Children, child)
 		result.Size += child.Size
+	}
+
+	dirInfo, err := os.Stat(path)
+	if err != nil {
+		result.Message = err.Error()
+	} else {
+		result.ModTime = dirInfo.ModTime()
 	}
 
 	return result, nil

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -233,7 +233,7 @@ func (fc *FtpClient) listRecursive(path string, depth, current int) (CommandResu
 func (fc *FtpClient) mkd(path string) (CommandResult, error) {
 	path = fc.parsePath(path)
 
-	err := os.MkdirAll(path, 0755)
+	err := os.Mkdir(path, 0755)
 	if err != nil {
 		return CommandResult{
 			Message: err.Error(),
@@ -292,6 +292,12 @@ func (fc *FtpClient) dele(path string) (CommandResult, error) {
 
 func (fc *FtpClient) rmd(path string, recursive bool) (CommandResult, error) {
 	path = fc.parsePath(path)
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return CommandResult{
+			Message: err.Error(),
+		}, err
+	}
 
 	var err error
 	if recursive {
@@ -404,6 +410,10 @@ func copyFile(src, dst string) error {
 }
 
 func copyDir(src, dst string) error {
+	if strings.HasPrefix(dst, src) {
+		return fmt.Errorf("%s is inside %s, causing infinite recursion", dst, src)
+	}
+
 	srcInfo, err := os.Stat(src)
 	if err != nil {
 		return err

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -23,21 +23,22 @@ type FtpClient struct {
 	homeDirectory    string
 	workingDirectory string
 	log              logger.FtpLogger
+	settings         config.Settings
 }
 
-func NewFtpClient(url, homeDirectory string, ftpLogger logger.FtpLogger) *FtpClient {
-	settings := config.LoadConfig()
+func NewFtpClient(data FtpConfigData) *FtpClient {
 	headers := http.Header{
-		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, settings.ID, settings.Key)},
-		"Origin":        {settings.ServerURL},
+		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, data.Settings.ID, data.Settings.Key)},
+		"Origin":        {data.Settings.ServerURL},
 	}
 
 	return &FtpClient{
 		requestHeader:    headers,
-		url:              strings.Replace(settings.ServerURL, "http", "ws", 1) + url,
-		homeDirectory:    homeDirectory,
-		workingDirectory: homeDirectory,
-		log:              ftpLogger,
+		url:              strings.Replace(data.Settings.ServerURL, "http", "ws", 1) + data.URL,
+		homeDirectory:    data.HomeDirectory,
+		workingDirectory: data.HomeDirectory,
+		log:              data.Logger,
+		settings:         data.Settings,
 	}
 }
 

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -39,8 +39,7 @@ func NewFtpClient(url, homeDirectory string) *FtpClient {
 }
 
 func (fc *FtpClient) RunFtpBackground() {
-	// TODO : Send logs to alpamon's Logserver using a Unix domain socket
-	// log.Debug().Msg("Opening websocket for ftp session.")
+	log.Debug().Msg("Opening websocket for ftp session.")
 
 	var err error
 	fc.conn, _, err = websocket.DefaultDialer.Dial(fc.url, fc.requestHeader)
@@ -128,8 +127,7 @@ func (fc *FtpClient) close() {
 		_ = fc.conn.Close()
 	}
 
-	// TODO : Send logs to alpamon's Logserver using a Unix domain socket
-	// log.Debug().Msg("Websocket connection for ftp has been closed.")
+	log.Debug().Msg("Websocket connection for ftp has been closed.")
 }
 
 func (fc *FtpClient) handleFtpCommand(command FtpCommand, data FtpData) (CommandResult, error) {

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
-	"os/exec"
+	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/gorilla/websocket"
@@ -18,29 +18,22 @@ import (
 type FtpClient struct {
 	conn             *websocket.Conn
 	requestHeader    http.Header
-	sysProcAttr      *syscall.SysProcAttr
 	url              string
-	username         string
-	groupname        string
 	homeDirectory    string
 	workingDirectory string
-	sessionID        string
 }
 
-func NewFtpClient(data CommandData) *FtpClient {
+func NewFtpClient(url, homeDirectory string) *FtpClient {
 	headers := http.Header{
-		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, config.GlobalSettings.ID, config.GlobalSettings.Key)},
-		"Origin":        {config.GlobalSettings.ServerURL},
+		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, config.FtpSettings.ID, config.FtpSettings.Key)},
+		"Origin":        {config.FtpSettings.ServerURL},
 	}
 
 	return &FtpClient{
 		requestHeader:    headers,
-		url:              strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1) + data.URL,
-		username:         data.Username,
-		groupname:        data.Groupname,
-		homeDirectory:    data.HomeDirectory,
-		workingDirectory: data.HomeDirectory,
-		sessionID:        data.SessionID,
+		url:              strings.Replace(config.FtpSettings.ServerURL, "http", "ws", 1) + url,
+		homeDirectory:    homeDirectory,
+		workingDirectory: homeDirectory,
 	}
 }
 
@@ -55,7 +48,6 @@ func (fc *FtpClient) RunFtpBackground() {
 	}
 	defer fc.close()
 
-	fc.sysProcAttr, err = demote(fc.username, fc.groupname)
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to demote user.")
 		fc.close()
@@ -180,35 +172,6 @@ func (fc *FtpClient) parsePath(path string) string {
 	return parsedPath
 }
 
-func (fc *FtpClient) size(path string) (int64, error) {
-	cmd := exec.Command("du", "-sk", path)
-	cmd.SysProcAttr = fc.sysProcAttr
-	output, err := cmd.Output()
-	if err != nil {
-		return 0, err
-	}
-
-	parts := strings.Fields(string(output))
-	if len(parts) < 1 {
-		return 0, fmt.Errorf("could not retrieve size for path: %s", path)
-	}
-
-	size := int64(0)
-	if _, err = fmt.Sscanf(parts[0], "%d", &size); err != nil {
-		return size, err
-	}
-
-	return size * 1024, nil
-}
-
-func (fc *FtpClient) isDir(path string) bool {
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("ls -ld \"%s\" | awk '{print $1}'", path))
-	cmd.SysProcAttr = fc.sysProcAttr
-	output, _ := cmd.Output()
-
-	return strings.HasPrefix(string(output), "d")
-}
-
 func (fc *FtpClient) list(rootDir string, depth int) (CommandResult, error) {
 	path := fc.parsePath(rootDir)
 	cmdResult, err := fc.listRecursive(path, depth, 0)
@@ -224,45 +187,34 @@ func (fc *FtpClient) listRecursive(path string, depth, current int) (CommandResu
 		Children: []CommandResult{},
 	}
 
-	cmd := exec.Command("find", path, "-mindepth", "1", "-maxdepth", "1")
-	cmd.SysProcAttr = fc.sysProcAttr
-	output, err := cmd.CombinedOutput()
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		return CommandResult{
 			Name:    filepath.Base(path),
 			Path:    path,
-			Message: string(output),
+			Message: err.Error(),
 		}, nil
 	}
 
-	paths := strings.Split(string(output), "\n")
-	for _, foundPath := range paths {
-		if foundPath == "" {
+	for _, entry := range entries {
+		fullPath := filepath.Join(path, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
 			continue
 		}
 
-		size, err := fc.size(foundPath)
-		if err != nil {
-			return CommandResult{
-				Name:    filepath.Base(path),
-				Path:    path,
-				Message: string(output),
-			}, nil
-		}
-
 		child := CommandResult{
-			Name: filepath.Base(foundPath),
-			Path: foundPath,
-			Size: size,
+			Name: entry.Name(),
+			Path: fullPath,
+			Size: info.Size(),
 		}
 
-		if fc.isDir(foundPath) {
+		if entry.IsDir() {
 			child.Type = "folder"
-
 			if current < depth-1 {
-				childResult, err := fc.listRecursive(foundPath, depth, current+1)
+				childResult, err := fc.listRecursive(fullPath, depth, current+1)
 				if err != nil {
-					return result, nil
+					continue
 				}
 				child.Children = childResult.Children
 				child.Size = childResult.Size
@@ -272,7 +224,7 @@ func (fc *FtpClient) listRecursive(path string, depth, current int) (CommandResu
 		}
 
 		result.Children = append(result.Children, child)
-		result.Size += size
+		result.Size += child.Size
 	}
 
 	return result, nil
@@ -281,12 +233,10 @@ func (fc *FtpClient) listRecursive(path string, depth, current int) (CommandResu
 func (fc *FtpClient) mkd(path string) (CommandResult, error) {
 	path = fc.parsePath(path)
 
-	cmd := exec.Command("mkdir", path)
-	cmd.SysProcAttr = fc.sysProcAttr
-	output, err := cmd.CombinedOutput()
+	err := os.MkdirAll(path, 0755)
 	if err != nil {
 		return CommandResult{
-			Message: strings.ToLower(string(output)),
+			Message: err.Error(),
 		}, err
 	}
 
@@ -297,13 +247,18 @@ func (fc *FtpClient) mkd(path string) (CommandResult, error) {
 
 func (fc *FtpClient) cwd(path string) (CommandResult, error) {
 	path = fc.parsePath(path)
-	cmd := exec.Command("test", "-r", path, "-a", "-w", path, "-a", "-x", path)
-	cmd.SysProcAttr = fc.sysProcAttr
-	output, err := cmd.CombinedOutput()
+
+	info, err := os.Stat(path)
 	if err != nil {
 		return CommandResult{
-			Message: strings.ToLower(string(output)),
+			Message: err.Error(),
 		}, err
+	}
+
+	if !info.IsDir() {
+		return CommandResult{
+			Message: "not a directory",
+		}, fmt.Errorf("not a directory")
 	}
 
 	fc.workingDirectory = path
@@ -323,11 +278,10 @@ func (fc *FtpClient) pwd() (CommandResult, error) {
 func (fc *FtpClient) dele(path string) (CommandResult, error) {
 	path = fc.parsePath(path)
 
-	cmd := exec.Command("rm", path)
-	cmd.SysProcAttr = fc.sysProcAttr
-	if output, err := cmd.CombinedOutput(); err != nil {
+	err := os.Remove(path)
+	if err != nil {
 		return CommandResult{
-			Message: strings.ToLower(string(output)),
+			Message: err.Error(),
 		}, err
 	}
 
@@ -339,17 +293,16 @@ func (fc *FtpClient) dele(path string) (CommandResult, error) {
 func (fc *FtpClient) rmd(path string, recursive bool) (CommandResult, error) {
 	path = fc.parsePath(path)
 
-	var cmd *exec.Cmd
+	var err error
 	if recursive {
-		cmd = exec.Command("rm", "-r", path)
+		err = os.RemoveAll(path)
 	} else {
-		cmd = exec.Command("rmdir", path)
+		err = os.Remove(path)
 	}
 
-	cmd.SysProcAttr = fc.sysProcAttr
-	if output, err := cmd.CombinedOutput(); err != nil {
+	if err != nil {
 		return CommandResult{
-			Message: strings.ToLower(string(output)),
+			Message: err.Error(),
 		}, err
 	}
 
@@ -362,11 +315,10 @@ func (fc *FtpClient) mv(src, dst string) (CommandResult, error) {
 	src = fc.parsePath(src)
 	dst = filepath.Join(fc.parsePath(dst), filepath.Base(src))
 
-	cmd := exec.Command("mv", src, dst)
-	cmd.SysProcAttr = fc.sysProcAttr
-	if output, err := cmd.CombinedOutput(); err != nil {
+	err := os.Rename(src, dst)
+	if err != nil {
 		return CommandResult{
-			Message: strings.ToLower(string(output)),
+			Message: err.Error(),
 		}, err
 	}
 
@@ -379,18 +331,24 @@ func (fc *FtpClient) cp(src, dst string) (CommandResult, error) {
 	src = fc.parsePath(src)
 	dst = filepath.Join(fc.parsePath(dst), filepath.Base(src))
 
-	if fc.isDir(src) {
+	info, err := os.Stat(src)
+	if err != nil {
+		return CommandResult{
+			Message: err.Error(),
+		}, err
+	}
+
+	if info.IsDir() {
 		return fc.cpDir(src, dst)
 	}
 	return fc.cpFile(src, dst)
 }
 
 func (fc *FtpClient) cpDir(src, dst string) (CommandResult, error) {
-	cmd := exec.Command("cp", "-r", src, dst)
-	cmd.SysProcAttr = fc.sysProcAttr
-	if output, err := cmd.CombinedOutput(); err != nil {
+	err := copyDir(src, dst)
+	if err != nil {
 		return CommandResult{
-			Message: strings.ToLower(string(output)),
+			Message: err.Error(),
 		}, err
 	}
 
@@ -400,15 +358,81 @@ func (fc *FtpClient) cpDir(src, dst string) (CommandResult, error) {
 }
 
 func (fc *FtpClient) cpFile(src, dst string) (CommandResult, error) {
-	cmd := exec.Command("cp", src, dst)
-	cmd.SysProcAttr = fc.sysProcAttr
-	if output, err := cmd.CombinedOutput(); err != nil {
+	err := copyFile(src, dst)
+	if err != nil {
 		return CommandResult{
-			Message: strings.ToLower(string(output)),
+			Message: err.Error(),
 		}, err
 	}
 
 	return CommandResult{
 		Message: fmt.Sprintf("Copy %s to %s", src, dst),
 	}, nil
+}
+
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	if _, err = io.Copy(dstFile, srcFile); err != nil {
+		return err
+	}
+
+	if err = dstFile.Close(); err != nil {
+		return err
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if err = os.Chmod(dst, srcInfo.Mode()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copyDir(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(dst, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			if err = copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			if err = copyFile(srcPath, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -387,29 +387,18 @@ func (fc *FtpClient) cpFile(src, dst string) (CommandResult, error) {
 	}, nil
 }
 
-func copyFile(src, dst string) (finalErr error) {
-	finalErr = nil
+func copyFile(src, dst string) error {
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if err = srcFile.Close(); err != nil && finalErr == nil {
-			finalErr = err
-		}
-	}()
+	defer func() { _ = srcFile.Close() }()
 
 	dstFile, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if err := dstFile.Close(); err != nil && finalErr == nil {
-			finalErr = err
-		}
-	}()
+	defer func() { _ = dstFile.Close() }()
 
 	if _, err = io.Copy(dstFile, srcFile); err != nil {
 		return err
@@ -424,7 +413,7 @@ func copyFile(src, dst string) (finalErr error) {
 		return err
 	}
 
-	return finalErr
+	return nil
 }
 
 func copyDir(src, dst string) error {

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -388,6 +388,7 @@ func (fc *FtpClient) cpFile(src, dst string) (CommandResult, error) {
 }
 
 func copyFile(src, dst string) (finalErr error) {
+	finalErr = nil
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return err
@@ -423,7 +424,7 @@ func copyFile(src, dst string) (finalErr error) {
 		return err
 	}
 
-	return nil
+	return finalErr
 }
 
 func copyDir(src, dst string) error {

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -394,7 +394,7 @@ func copyFile(src, dst string) (finalErr error) {
 	}
 
 	defer func() {
-		if err := srcFile.Close(); err != nil && finalErr == nil {
+		if err = srcFile.Close(); err != nil && finalErr == nil {
 			finalErr = err
 		}
 	}()

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -7,11 +7,8 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/user"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/gorilla/websocket"
@@ -22,13 +19,11 @@ type FtpClient struct {
 	conn             *websocket.Conn
 	requestHeader    http.Header
 	url              string
-	username         string
-	groupname        string
 	homeDirectory    string
 	workingDirectory string
 }
 
-func NewFtpClient(data CommandData) *FtpClient {
+func NewFtpClient(url, homeDirectory string) *FtpClient {
 	headers := http.Header{
 		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, config.FtpSettings.ID, config.FtpSettings.Key)},
 		"Origin":        {config.FtpSettings.ServerURL},
@@ -36,72 +31,17 @@ func NewFtpClient(data CommandData) *FtpClient {
 
 	return &FtpClient{
 		requestHeader:    headers,
-		url:              strings.Replace(config.FtpSettings.ServerURL, "http", "ws", 1) + data.URL,
-		username:         data.Username,
-		groupname:        data.Groupname,
-		homeDirectory:    data.HomeDirectory,
-		workingDirectory: data.HomeDirectory,
+		url:              strings.Replace(config.FtpSettings.ServerURL, "http", "ws", 1) + url,
+		homeDirectory:    homeDirectory,
+		workingDirectory: homeDirectory,
 	}
-}
-
-func (fc *FtpClient) demote() error {
-	if syscall.Getuid() == 0 {
-		if fc.username == "" || fc.groupname == "" {
-			log.Debug().Msg("No username or groupname provided.")
-			return fmt.Errorf("no username or groupname provided")
-		}
-
-		usr, err := user.Lookup(fc.username)
-		if err != nil {
-			log.Debug().Msgf("There is no corresponding %s username in this server", fc.username)
-			return fmt.Errorf("there is no corresponding %s username in this server", fc.username)
-		}
-
-		group, err := user.LookupGroup(fc.groupname)
-		if err != nil {
-			log.Debug().Msgf("There is no corresponding %s groupname in this server", fc.groupname)
-			return fmt.Errorf("there is no corresponding %s groupname in this server", fc.groupname)
-		}
-
-		uid, err := strconv.Atoi(usr.Uid)
-		if err != nil {
-			return err
-		}
-
-		gid, err := strconv.Atoi(group.Gid)
-		if err != nil {
-			return err
-		}
-
-		err = syscall.Setgroups([]int{})
-		if err != nil {
-			return err
-		}
-
-		err = syscall.Setuid(uid)
-		if err != nil {
-			return err
-		}
-
-		err = syscall.Setgid(gid)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (fc *FtpClient) RunFtpBackground() {
-	log.Debug().Msg("Opening websocket for ftp session.")
+	// TODO : Send logs to alpamon's Logserver using a Unix domain socket
+	// log.Debug().Msg("Opening websocket for ftp session.")
 
 	var err error
-	err = fc.demote()
-	if err != nil {
-		log.Debug().Err(err).Msg("Failed to get demote permission")
-		return
-	}
-
 	fc.conn, _, err = websocket.DefaultDialer.Dial(fc.url, fc.requestHeader)
 	if err != nil {
 		log.Debug().Err(err).Msgf("Failed to connect to pty websocket at %s", fc.url)
@@ -187,7 +127,8 @@ func (fc *FtpClient) close() {
 		_ = fc.conn.Close()
 	}
 
-	log.Debug().Msg("Websocket connection for ftp has been closed.")
+	// TODO : Send logs to alpamon's Logserver using a Unix domain socket
+	// log.Debug().Msg("Websocket connection for ftp has been closed.")
 }
 
 func (fc *FtpClient) handleFtpCommand(command FtpCommand, data FtpData) (CommandResult, error) {

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -48,12 +48,6 @@ func (fc *FtpClient) RunFtpBackground() {
 	}
 	defer fc.close()
 
-	if err != nil {
-		log.Debug().Err(err).Msg("Failed to demote user.")
-		fc.close()
-		return
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -1,6 +1,9 @@
 package runner
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 type FtpCommand string
 
@@ -49,6 +52,7 @@ type CommandResult struct {
 	Path     string          `json:"path,omitempty"`
 	Size     int64           `json:"size,omitempty"`
 	Children []CommandResult `json:"children,omitempty"`
+	ModTime  time.Time       `json:"mod_time,omitempty"`
 	Message  string          `json:"message,omitempty"`
 }
 

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -62,7 +62,7 @@ type CommandResult struct {
 	Path     string          `json:"path,omitempty"`
 	Size     int64           `json:"size,omitempty"`
 	Children []CommandResult `json:"children,omitempty"`
-	ModTime  time.Time       `json:"mod_time,omitempty"`
+	ModTime  *time.Time      `json:"mod_time,omitempty"`
 	Message  string          `json:"message,omitempty"`
 }
 

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -3,6 +3,9 @@ package runner
 import (
 	"strings"
 	"time"
+
+	"github.com/alpacanetworks/alpamon-go/pkg/config"
+	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 )
 
 type FtpCommand string
@@ -25,6 +28,13 @@ const (
 	ErrFileExists            = "file exists"
 	ErrDirectoryNotEmpty     = "directory not empty"
 )
+
+type FtpConfigData struct {
+	URL           string
+	HomeDirectory string
+	Logger        logger.FtpLogger
+	Settings      config.Settings
+}
 
 type FtpData struct {
 	Path      string `json:"path,omitempty"`


### PR DESCRIPTION
As mentioned in https://github.com/alpacanetworks/alpamon-go/issues/3, we have improved the performance and reduced the error rate of `Web FTP command` by implementing the following changes:

- Refactor `Web FTP Command` to utilize Go's built-in packages.
   - To address the performance issue caused by using the `os/exec` package to execute Linux commands, the logic has been refactored to leverage Go's built-in packages.
   
- Add `ftp` alpamon command
   - Given the inefficiency of creating a new, less privileged process for each command using `os/exec`, we have decided to execute `Web FTP Command` in a separate process.
      - To achieve this, we have added the `ftp` command to alpamon, allowing `Web FTP Command` to be executed in a new, less privileged process.
      
- Add `zip` package dependency
   - As mentioned in https://github.com/alpacanetworks/alpamon-go/issues/4, `zip` package dependency has been added to `.goreleaser.yaml` file.
