### PR TITLE
Resolve "Fix bugs related to Web FTP"

### DIFF
--- a/cmd/alpamon/command/ftp.go
+++ b/cmd/alpamon/command/ftp.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/alpacanetworks/alpamon-go/pkg/runner"
 	"github.com/spf13/cobra"
@@ -10,13 +9,13 @@ import (
 var ftpCmd = &cobra.Command{
 	Use:   "ftp <url> <homeDirectory>",
 	Short: "Start worker for Web FTP",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		data := runner.FtpConfigData{
 			URL:           args[0],
-			HomeDirectory: args[1],
+			ServerURL:     args[1],
+			HomeDirectory: args[2],
 			Logger:        logger.NewFtpLogger(),
-			Settings:      config.LoadConfig(),
 		}
 
 		RunFtpWorker(data)

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -615,6 +615,7 @@ func (cr *CommandRunner) openFtp(data openFtpData) error {
 		data.HomeDirectory,
 	)
 	cmd.SysProcAttr = sysProcAttr
+	cmd.Dir = data.HomeDirectory
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -615,7 +615,6 @@ func (cr *CommandRunner) openFtp(data openFtpData) error {
 		data.HomeDirectory,
 	)
 	cmd.SysProcAttr = sysProcAttr
-	cmd.Dir = data.HomeDirectory
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -747,7 +747,7 @@ func fileDownload(data CommandData, sysProcAttr *syscall.SysProcAttr) (exitCode 
 
 	isZip := isZipFile(content)
 	if isZip {
-		command := fmt.Sprintf("tee -a %s > /dev/null | unzip -n %s -d %s; rm %s",
+		command := fmt.Sprintf("tee -a %s > /dev/null && unzip -n %s -d %s; rm %s",
 			strings.ReplaceAll(data.Path, " ", "\\ "),
 			strings.ReplaceAll(data.Path, " ", "\\ "),
 			strings.ReplaceAll(filepath.Dir(data.Path), " ", "\\ "),

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -611,6 +611,7 @@ func (cr *CommandRunner) openFtp(data openFtpData) error {
 		executable,
 		"ftp",
 		data.URL,
+		config.GlobalSettings.ServerURL,
 		data.HomeDirectory,
 	)
 	cmd.SysProcAttr = sysProcAttr

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -728,9 +728,11 @@ func makeArchive(paths []string, bulk, recursive bool, sysProcAttr *syscall.SysP
 		}
 	}
 
-	err := cmd.Run()
-	if err != nil {
-		return "", err
+	if bulk || recursive {
+		err := cmd.Run()
+		if err != nil {
+			return "", err
+		}
 	}
 
 	return archiveName, nil

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 	"github.com/gorilla/websocket"
 )
@@ -22,22 +21,19 @@ type FtpClient struct {
 	homeDirectory    string
 	workingDirectory string
 	log              logger.FtpLogger
-	settings         config.Settings
 }
 
 func NewFtpClient(data FtpConfigData) *FtpClient {
 	headers := http.Header{
-		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, data.Settings.ID, data.Settings.Key)},
-		"Origin":        {data.Settings.ServerURL},
+		"Origin": {data.ServerURL},
 	}
 
 	return &FtpClient{
 		requestHeader:    headers,
-		url:              strings.Replace(data.Settings.ServerURL, "http", "ws", 1) + data.URL,
+		url:              strings.Replace(data.ServerURL, "http", "ws", 1) + data.URL,
 		homeDirectory:    data.HomeDirectory,
 		workingDirectory: data.HomeDirectory,
 		log:              data.Logger,
-		settings:         data.Settings,
 	}
 }
 

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alpacanetworks/alpamon-go/pkg/config"
 	"github.com/alpacanetworks/alpamon-go/pkg/logger"
 )
 
@@ -31,9 +30,9 @@ const (
 
 type FtpConfigData struct {
 	URL           string
+	ServerURL     string
 	HomeDirectory string
 	Logger        logger.FtpLogger
-	Settings      config.Settings
 }
 
 type FtpData struct {


### PR DESCRIPTION
As mentioned in https://github.com/alpacanetworks/alpamon/issues/10, The following bugs in the Web FTP system have been addressed:

- The system does not support Korean characters in file paths.

- Downloading large ZIP files is failing.

- Downloading specific files causes a panic.

- The system is unable to load settings for the FtpClient.

- An error occurs during Alpamon installation due to the requirement to select Yes/No.
   - This error has been resolved on the alpacon-server. 