### PR TITLE
Resolve "Add exception handling to list of Web FTP Command"

### DIFF
--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -177,9 +177,8 @@ func (fc *FtpClient) list(rootDir string, depth int) (CommandResult, error) {
 func (fc *FtpClient) listRecursive(path string, depth, current int) (CommandResult, error) {
 	if depth > 3 {
 		return CommandResult{
-			Code:    550,
-			Message: "The depth has reached its limit. Please try a lower depth.",
-		}, nil
+			Message: ErrTooLargeDepth,
+		}, fmt.Errorf(ErrTooLargeDepth)
 	}
 
 	result := CommandResult{
@@ -362,6 +361,7 @@ func (fc *FtpClient) mv(src, dst string) (CommandResult, error) {
 	}
 
 	return CommandResult{
+		Dst:     dst,
 		Message: fmt.Sprintf("Move %s to %s", src, dst),
 	}, nil
 }
@@ -392,6 +392,7 @@ func (fc *FtpClient) cpDir(src, dst string) (CommandResult, error) {
 	}
 
 	return CommandResult{
+		Dst:     dst,
 		Message: fmt.Sprintf("Copy %s to %s", src, dst),
 	}, nil
 }
@@ -405,6 +406,7 @@ func (fc *FtpClient) cpFile(src, dst string) (CommandResult, error) {
 	}
 
 	return CommandResult{
+		Dst:     dst,
 		Message: fmt.Sprintf("Copy %s to %s", src, dst),
 	}, nil
 }

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -178,7 +178,7 @@ func (fc *FtpClient) listRecursive(path string, depth, current int) (CommandResu
 	if depth > 3 {
 		return CommandResult{
 			Message: ErrTooLargeDepth,
-		}, fmt.Errorf(ErrTooLargeDepth)
+		}, fmt.Errorf("%s", ErrTooLargeDepth)
 	}
 
 	result := CommandResult{

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -22,6 +22,8 @@ const (
 
 const (
 	ErrPermissionDenied      = "permission denied"
+	ErrOperationNotPermitted = "operation not permitted"
+	ErrTooLargeDepth         = "depth has reached its limit. please try a lower depth"
 	ErrInvalidArgument       = "invalid argument"
 	ErrNoSuchFileOrDirectory = "no such file or directory"
 	ErrFileExists            = "file exists"
@@ -59,6 +61,8 @@ type CommandResult struct {
 	Name     string          `json:"name,omitempty"`
 	Type     string          `json:"type,omitempty"`
 	Path     string          `json:"path,omitempty"`
+	Dst      string          `json:"dst,omitempty"`
+	Code     int             `json:"code,omitempty"`
 	Size     int64           `json:"size,omitempty"`
 	Children []CommandResult `json:"children,omitempty"`
 	ModTime  *time.Time      `json:"mod_time,omitempty"`
@@ -73,12 +77,18 @@ type returnCode struct {
 var returnCodes = map[FtpCommand]returnCode{
 	List: {
 		Success: 250,
-		Error:   map[string]int{},
+		Error: map[string]int{
+			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
+			ErrTooLargeDepth:         452,
+			ErrNoSuchFileOrDirectory: 550,
+		},
 	},
 	Mkd: {
 		Success: 250,
 		Error: map[string]int{
 			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
 			ErrInvalidArgument:       452,
 			ErrNoSuchFileOrDirectory: 550,
 			ErrFileExists:            552,
@@ -88,6 +98,7 @@ var returnCodes = map[FtpCommand]returnCode{
 		Success: 250,
 		Error: map[string]int{
 			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
 			ErrNoSuchFileOrDirectory: 550,
 		},
 	},
@@ -95,6 +106,7 @@ var returnCodes = map[FtpCommand]returnCode{
 		Success: 250,
 		Error: map[string]int{
 			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
 			ErrNoSuchFileOrDirectory: 550,
 		},
 	},
@@ -102,6 +114,7 @@ var returnCodes = map[FtpCommand]returnCode{
 		Success: 250,
 		Error: map[string]int{
 			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
 			ErrInvalidArgument:       452,
 			ErrNoSuchFileOrDirectory: 550,
 		},
@@ -110,6 +123,7 @@ var returnCodes = map[FtpCommand]returnCode{
 		Success: 250,
 		Error: map[string]int{
 			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
 			ErrInvalidArgument:       452,
 			ErrNoSuchFileOrDirectory: 550,
 			ErrDirectoryNotEmpty:     552,
@@ -119,6 +133,7 @@ var returnCodes = map[FtpCommand]returnCode{
 		Success: 250,
 		Error: map[string]int{
 			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
 			ErrInvalidArgument:       452,
 			ErrNoSuchFileOrDirectory: 550,
 			ErrFileExists:            552,
@@ -128,6 +143,7 @@ var returnCodes = map[FtpCommand]returnCode{
 		Success: 250,
 		Error: map[string]int{
 			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
 			ErrInvalidArgument:       452,
 			ErrNoSuchFileOrDirectory: 550,
 			ErrFileExists:            552,


### PR DESCRIPTION
As mentioned in https://github.com/alpacanetworks/alpamon/issues/12, The following bugs in the Web FTP system have been addressed:

- `list` command could cause a **stack overflow** if there is no `depth` limit.
   - Exception handling has been added for cases where `depth` exceeds the limit.
- The absence of exception handling for **symbolic links** could lead to a **stack overflow**.
   - Exception handling for **symbolic links** has been added.