### PR TITLE
Refactor collector related test casas

### DIFF
--- a/pkg/collector/check/batch/daily/disk/io/daily_io_test.go
+++ b/pkg/collector/check/batch/daily/disk/io/daily_io_test.go
@@ -3,61 +3,73 @@ package io
 import (
 	"context"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/collector/check/base"
 	"github.com/alpacanetworks/alpamon-go/pkg/db"
+	"github.com/alpacanetworks/alpamon-go/pkg/db/ent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func setUp() *Check {
+type DailyDiskIOCheckSuite struct {
+	suite.Suite
+	client *ent.Client
+	check  *Check
+	ctx    context.Context
+}
+
+func (suite *DailyDiskIOCheckSuite) SetupSuite() {
+	suite.client = db.InitTestDB()
 	buffer := base.NewCheckBuffer(10)
 	args := &base.CheckArgs{
 		Type:     base.DAILY_DISK_IO,
 		Name:     string(base.DAILY_DISK_IO) + "_" + uuid.NewString(),
 		Interval: time.Duration(1 * time.Second),
 		Buffer:   buffer,
-		Client:   db.InitTestDB(),
+		Client:   suite.client,
 	}
-
-	check := NewCheck(args).(*Check)
-
-	return check
+	suite.check = NewCheck(args).(*Check)
+	suite.ctx = context.Background()
 }
 
-func TestGetHourlyDiskIO(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *DailyDiskIOCheckSuite) TearDownSuite() {
+	err := os.Remove("alpamon.db")
+	suite.Require().NoError(err, "failed to delete test db file")
+}
 
-	err := check.GetClient().HourlyDiskIO.Create().
+func (suite *DailyDiskIOCheckSuite) TestGetHourlyDiskIO() {
+	err := suite.check.GetClient().HourlyDiskIO.Create().
 		SetTimestamp(time.Now()).
 		SetDevice(uuid.NewString()).
 		SetPeakReadBps(rand.Float64()).
 		SetPeakWriteBps(rand.Float64()).
 		SetAvgReadBps(rand.Float64()).
-		SetAvgWriteBps(rand.Float64()).Exec(ctx)
-	assert.NoError(t, err, "Failed to create hourly disk io.")
+		SetAvgWriteBps(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create hourly disk io.")
 
-	querySet, err := check.getHourlyDiskIO(ctx)
-	assert.NoError(t, err, "Failed to get hourly disk io.")
-	assert.NotEmpty(t, querySet, "HourlyDiskIO queryset should not be empty")
+	querySet, err := suite.check.getHourlyDiskIO(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to get hourly disk io.")
+	assert.NotEmpty(suite.T(), querySet, "HourlyDiskIO queryset should not be empty")
 }
 
-func TestDeleteHourlyDiskIO(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
-
-	err := check.GetClient().HourlyDiskIO.Create().
+func (suite *DailyDiskIOCheckSuite) TestDeleteHourlyDiskIO() {
+	err := suite.check.GetClient().HourlyDiskIO.Create().
 		SetTimestamp(time.Now().Add(-25 * time.Hour)).
 		SetDevice(uuid.NewString()).
 		SetPeakReadBps(rand.Float64()).
 		SetPeakWriteBps(rand.Float64()).
 		SetAvgReadBps(rand.Float64()).
-		SetAvgWriteBps(rand.Float64()).Exec(ctx)
-	assert.NoError(t, err, "Failed to create hourly disk io.")
+		SetAvgWriteBps(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create hourly disk io.")
 
-	err = check.deleteHourlyDiskIO(ctx)
-	assert.NoError(t, err, "Failed to delete hourly disk io.")
+	err = suite.check.deleteHourlyDiskIO(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to delete hourly disk io.")
+}
+
+func TestDailyDiskIOCheckSuite(t *testing.T) {
+	suite.Run(t, new(DailyDiskIOCheckSuite))
 }

--- a/pkg/collector/check/batch/daily/disk/usage/daily_usage_test.go
+++ b/pkg/collector/check/batch/daily/disk/usage/daily_usage_test.go
@@ -2,57 +2,69 @@ package usage
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/collector/check/base"
 	"github.com/alpacanetworks/alpamon-go/pkg/db"
+	"github.com/alpacanetworks/alpamon-go/pkg/db/ent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func setUp() *Check {
+type DailyDiskUsageCheckSuite struct {
+	suite.Suite
+	client *ent.Client
+	check  *Check
+	ctx    context.Context
+}
+
+func (suite *DailyDiskUsageCheckSuite) SetupSuite() {
+	suite.client = db.InitTestDB()
 	buffer := base.NewCheckBuffer(10)
 	args := &base.CheckArgs{
 		Type:     base.DAILY_DISK_USAGE,
 		Name:     string(base.DAILY_DISK_USAGE) + "_" + uuid.NewString(),
 		Interval: time.Duration(1 * time.Second),
 		Buffer:   buffer,
-		Client:   db.InitTestDB(),
+		Client:   suite.client,
 	}
-
-	check := NewCheck(args).(*Check)
-
-	return check
+	suite.check = NewCheck(args).(*Check)
+	suite.ctx = context.Background()
 }
 
-func TestGetHourlyDiskUsage(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *DailyDiskUsageCheckSuite) TearDownSuite() {
+	err := os.Remove("alpamon.db")
+	suite.Require().NoError(err, "failed to delete test db file")
+}
 
-	err := check.GetClient().HourlyDiskUsage.Create().
+func (suite *DailyDiskUsageCheckSuite) TestGetHourlyDiskUsage() {
+	err := suite.check.GetClient().HourlyDiskUsage.Create().
 		SetTimestamp(time.Now()).
 		SetDevice(uuid.NewString()).
 		SetPeak(50.0).
-		SetAvg(50.0).Exec(ctx)
-	assert.NoError(t, err, "Failed to create hourly disk usage.")
+		SetAvg(50.0).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create hourly disk usage.")
 
-	querySet, err := check.getHourlyDiskUsage(ctx)
-	assert.NoError(t, err, "Failed to get hourly disk usage.")
-	assert.NotEmpty(t, querySet, "HourlyDiskUsage queryset should not be empty")
+	querySet, err := suite.check.getHourlyDiskUsage(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to get hourly disk usage.")
+	assert.NotEmpty(suite.T(), querySet, "HourlyDiskUsage queryset should not be empty")
 }
 
-func TestDeleteHourlyDiskUsage(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
-
-	err := check.GetClient().HourlyDiskUsage.Create().
+func (suite *DailyDiskUsageCheckSuite) TestDeleteHourlyDiskUsage() {
+	err := suite.check.GetClient().HourlyDiskUsage.Create().
 		SetTimestamp(time.Now().Add(-25 * time.Hour)).
 		SetDevice(uuid.NewString()).
 		SetPeak(50.0).
-		SetAvg(50.0).Exec(ctx)
-	assert.NoError(t, err, "Failed to create hourly disk usage.")
+		SetAvg(50.0).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create hourly disk usage.")
 
-	err = check.deleteHourlyDiskUsage(ctx)
-	assert.NoError(t, err, "Failed to delete hourly disk usage.")
+	err = suite.check.deleteHourlyDiskUsage(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to delete hourly disk usage.")
+}
+
+func TestDailyDiskUsageCheckSuite(t *testing.T) {
+	suite.Run(t, new(DailyDiskUsageCheckSuite))
 }

--- a/pkg/collector/check/batch/hourly/cpu/hourly_cpu_test.go
+++ b/pkg/collector/check/batch/hourly/cpu/hourly_cpu_test.go
@@ -3,66 +3,76 @@ package cpu
 import (
 	"context"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/collector/check/base"
 	"github.com/alpacanetworks/alpamon-go/pkg/db"
+	"github.com/alpacanetworks/alpamon-go/pkg/db/ent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func setUp() *Check {
+type HourlyCPUUsageCheckSuite struct {
+	suite.Suite
+	client *ent.Client
+	check  *Check
+	ctx    context.Context
+}
+
+func (suite *HourlyCPUUsageCheckSuite) SetupSuite() {
+	suite.client = db.InitTestDB()
 	buffer := base.NewCheckBuffer(10)
 	args := &base.CheckArgs{
 		Type:     base.HOURLY_CPU_USAGE,
 		Name:     string(base.HOURLY_CPU_USAGE) + "_" + uuid.NewString(),
 		Interval: time.Duration(1 * time.Second),
 		Buffer:   buffer,
-		Client:   db.InitTestDB(),
+		Client:   suite.client,
 	}
-
-	check := NewCheck(args).(*Check)
-
-	return check
+	suite.check = NewCheck(args).(*Check)
+	suite.ctx = context.Background()
 }
 
-func TestGetCPU(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *HourlyCPUUsageCheckSuite) TearDownSuite() {
+	err := os.Remove("alpamon.db")
+	suite.Require().NoError(err, "failed to delete test db file")
+}
 
-	err := check.GetClient().CPU.Create().
+func (suite *HourlyCPUUsageCheckSuite) TestGetCPU() {
+	err := suite.check.GetClient().CPU.Create().
 		SetTimestamp(time.Now()).
-		SetUsage(rand.Float64()).Exec(ctx)
-	assert.NoError(t, err, "Failed to create cpu usage.")
+		SetUsage(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create cpu usage.")
 
-	querySet, err := check.getCPU(ctx)
-	assert.NoError(t, err, "Failed to get cpu usage.")
-	assert.NotEmpty(t, querySet, "CPU queryset should not be empty")
+	querySet, err := suite.check.getCPU(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to get cpu usage.")
+	assert.NotEmpty(suite.T(), querySet, "CPU queryset should not be empty")
 }
 
-func TestSaveHourlyCPUUsage(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *HourlyCPUUsageCheckSuite) TestSaveHourlyCPUUsage() {
 	data := base.CheckResult{
 		Timestamp: time.Now(),
 		Peak:      50.0,
 		Avg:       50.0,
 	}
 
-	err := check.saveHourlyCPUUsage(data, ctx)
-	assert.NoError(t, err, "Failed to save hourly cpu usage.")
+	err := suite.check.saveHourlyCPUUsage(data, suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to save hourly cpu usage.")
 }
 
-func TestDeleteCPU(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
-
-	err := check.GetClient().CPU.Create().
+func (suite *HourlyCPUUsageCheckSuite) TestDeleteCPU() {
+	err := suite.check.GetClient().CPU.Create().
 		SetTimestamp(time.Now().Add(-2 * time.Hour)).
-		SetUsage(rand.Float64()).Exec(ctx)
-	assert.NoError(t, err, "Failed to create cpu usage.")
+		SetUsage(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create cpu usage.")
 
-	err = check.deleteCPU(ctx)
-	assert.NoError(t, err, "Failed to delete cpu usage.")
+	err = suite.check.deleteCPU(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to delete cpu usage.")
+}
+
+func TestHourlyCPUUsageCheckSuite(t *testing.T) {
+	suite.Run(t, new(HourlyCPUUsageCheckSuite))
 }

--- a/pkg/collector/check/batch/hourly/disk/io/hourly_io_test.go
+++ b/pkg/collector/check/batch/hourly/disk/io/hourly_io_test.go
@@ -3,49 +3,58 @@ package io
 import (
 	"context"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/collector/check/base"
 	"github.com/alpacanetworks/alpamon-go/pkg/db"
+	"github.com/alpacanetworks/alpamon-go/pkg/db/ent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func setUp() *Check {
+type HourlyDiskIOCheckSuite struct {
+	suite.Suite
+	client *ent.Client
+	check  *Check
+	ctx    context.Context
+}
+
+func (suite *HourlyDiskIOCheckSuite) SetupSuite() {
+	suite.client = db.InitTestDB()
 	buffer := base.NewCheckBuffer(10)
 	args := &base.CheckArgs{
 		Type:     base.HOURLY_DISK_IO,
 		Name:     string(base.HOURLY_DISK_IO) + "_" + uuid.NewString(),
 		Interval: time.Duration(1 * time.Second),
 		Buffer:   buffer,
-		Client:   db.InitTestDB(),
+		Client:   suite.client,
 	}
-
-	check := NewCheck(args).(*Check)
-
-	return check
+	suite.check = NewCheck(args).(*Check)
+	suite.ctx = context.Background()
 }
 
-func TestGetDiskIO(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *HourlyDiskIOCheckSuite) TearDownSuite() {
+	err := os.Remove("alpamon.db")
+	suite.Require().NoError(err, "failed to delete test db file")
+}
 
-	err := check.GetClient().DiskIO.Create().
+func (suite *HourlyDiskIOCheckSuite) TestGetDiskIO() {
+	err := suite.check.GetClient().DiskIO.Create().
 		SetTimestamp(time.Now()).
 		SetDevice(uuid.NewString()).
 		SetReadBps(rand.Float64()).
-		SetWriteBps(rand.Float64()).Exec(ctx)
-	assert.NoError(t, err, "Failed to create disk io.")
+		SetWriteBps(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create disk io.")
 
-	querySet, err := check.getDiskIO(ctx)
-	assert.NoError(t, err, "Failed to get disk io.")
-	assert.NotEmpty(t, querySet, "Disk io queryset should not be empty")
+	querySet, err := suite.check.getDiskIO(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to get disk io.")
+	assert.NotEmpty(suite.T(), querySet, "Disk io queryset should not be empty")
 }
 
-func TestSaveHourlyDiskIO(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *HourlyDiskIOCheckSuite) TestSaveHourlyDiskIO() {
 	data := []base.CheckResult{
 		{
 			Timestamp:    time.Now(),
@@ -65,21 +74,22 @@ func TestSaveHourlyDiskIO(t *testing.T) {
 		},
 	}
 
-	err := check.saveHourlyDiskIO(data, ctx)
-	assert.NoError(t, err, "Failed to save hourly disk io.")
+	err := suite.check.saveHourlyDiskIO(data, suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to save hourly disk io.")
 }
 
-func TestDeleteDiskIO(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
-
-	err := check.GetClient().DiskIO.Create().
+func (suite *HourlyDiskIOCheckSuite) TestDeleteDiskIO() {
+	err := suite.check.GetClient().DiskIO.Create().
 		SetTimestamp(time.Now().Add(-2 * time.Hour)).
 		SetDevice(uuid.NewString()).
 		SetReadBps(rand.Float64()).
-		SetWriteBps(rand.Float64()).Exec(ctx)
-	assert.NoError(t, err, "Failed to create disk io.")
+		SetWriteBps(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create disk io.")
 
-	err = check.deleteDiskIO(ctx)
-	assert.NoError(t, err, "Failed to delete disk io.")
+	err = suite.check.deleteDiskIO(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to delete disk io.")
+}
+
+func TestHourlyDiskIOCheckSuite(t *testing.T) {
+	suite.Run(t, new(HourlyDiskIOCheckSuite))
 }

--- a/pkg/collector/check/batch/hourly/memory/hourly_memory_test.go
+++ b/pkg/collector/check/batch/hourly/memory/hourly_memory_test.go
@@ -3,66 +3,76 @@ package memory
 import (
 	"context"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/collector/check/base"
 	"github.com/alpacanetworks/alpamon-go/pkg/db"
+	"github.com/alpacanetworks/alpamon-go/pkg/db/ent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func setUp() *Check {
+type HourlyMemoryUsageCheckSuite struct {
+	suite.Suite
+	client *ent.Client
+	check  *Check
+	ctx    context.Context
+}
+
+func (suite *HourlyMemoryUsageCheckSuite) SetupSuite() {
+	suite.client = db.InitTestDB()
 	buffer := base.NewCheckBuffer(10)
 	args := &base.CheckArgs{
 		Type:     base.HOURLY_MEM_USAGE,
 		Name:     string(base.HOURLY_MEM_USAGE) + "_" + uuid.NewString(),
 		Interval: time.Duration(1 * time.Second),
 		Buffer:   buffer,
-		Client:   db.InitTestDB(),
+		Client:   suite.client,
 	}
-
-	check := NewCheck(args).(*Check)
-
-	return check
+	suite.check = NewCheck(args).(*Check)
+	suite.ctx = context.Background()
 }
 
-func TestGetMemory(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *HourlyMemoryUsageCheckSuite) TearDownSuite() {
+	err := os.Remove("alpamon.db")
+	suite.Require().NoError(err, "failed to delete test db file")
+}
 
-	err := check.GetClient().CPU.Create().
+func (suite *HourlyMemoryUsageCheckSuite) TestGetMemory() {
+	err := suite.check.GetClient().CPU.Create().
 		SetTimestamp(time.Now()).
-		SetUsage(rand.Float64()).Exec(ctx)
-	assert.NoError(t, err, "Failed to create memory usage.")
+		SetUsage(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create memory usage.")
 
-	querySet, err := check.getMemory(ctx)
-	assert.NoError(t, err, "Failed to get memory usage.")
-	assert.NotEmpty(t, querySet, "Memory queryset should not be empty")
+	querySet, err := suite.check.getMemory(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to get memory usage.")
+	assert.NotEmpty(suite.T(), querySet, "Memory queryset should not be empty")
 }
 
-func TestSaveMemoryPerHour(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *HourlyMemoryUsageCheckSuite) TestSaveMemoryPerHour() {
 	data := base.CheckResult{
 		Timestamp: time.Now(),
 		Peak:      50.0,
 		Avg:       50.0,
 	}
 
-	err := check.saveHourlyMemoryUsage(data, ctx)
-	assert.NoError(t, err, "Failed to save memory usage per hour.")
+	err := suite.check.saveHourlyMemoryUsage(data, suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to save memory usage per hour.")
 }
 
-func TestDeleteMemory(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
-
-	err := check.GetClient().Memory.Create().
+func (suite *HourlyMemoryUsageCheckSuite) TestDeleteMemory() {
+	err := suite.check.GetClient().Memory.Create().
 		SetTimestamp(time.Now().Add(-2 * time.Hour)).
-		SetUsage(rand.Float64()).Exec(ctx)
-	assert.NoError(t, err, "Failed to create memory usage.")
+		SetUsage(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create memory usage.")
 
-	err = check.deleteMemory(ctx)
-	assert.NoError(t, err, "Failed to delete memory usage.")
+	err = suite.check.deleteMemory(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to delete memory usage.")
+}
+
+func TestHourlyMemoryCheckSuite(t *testing.T) {
+	suite.Run(t, new(HourlyMemoryUsageCheckSuite))
 }

--- a/pkg/collector/check/realtime/cpu/cpu_test.go
+++ b/pkg/collector/check/realtime/cpu/cpu_test.go
@@ -2,49 +2,63 @@ package cpu
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/collector/check/base"
 	"github.com/alpacanetworks/alpamon-go/pkg/db"
+	"github.com/alpacanetworks/alpamon-go/pkg/db/ent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func setUp() *Check {
+type CPUCheckSuite struct {
+	suite.Suite
+	client *ent.Client
+	check  *Check
+	ctx    context.Context
+}
+
+func (suite *CPUCheckSuite) SetupSuite() {
+	suite.client = db.InitTestDB()
 	buffer := base.NewCheckBuffer(10)
 	args := &base.CheckArgs{
 		Type:     base.CPU,
 		Name:     string(base.CPU) + "_" + uuid.NewString(),
 		Interval: time.Duration(1 * time.Second),
 		Buffer:   buffer,
-		Client:   db.InitTestDB(),
+		Client:   suite.client,
 	}
-
-	check := NewCheck(args).(*Check)
-
-	return check
+	suite.check = NewCheck(args).(*Check)
+	suite.ctx = context.Background()
 }
 
-func TestCollectCPUUsage(t *testing.T) {
-	check := setUp()
-
-	usage, err := check.collectCPUUsage()
-
-	assert.NoError(t, err, "Failed to get cpu usage.")
-	assert.GreaterOrEqual(t, usage, 0.0, "CPU usage should be non-negative.")
-	assert.LessOrEqual(t, usage, 100.0, "CPU usage should not exceed 100%.")
+func (suite *CPUCheckSuite) TearDownSuite() {
+	err := os.Remove("alpamon.db")
+	suite.Require().NoError(err, "failed to delete test db file")
 }
 
-func TestSaveCPUUsage(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *CPUCheckSuite) TestCollectCPUUsage() {
+	usage, err := suite.check.collectCPUUsage()
+
+	assert.NoError(suite.T(), err, "Failed to get cpu usage.")
+	assert.GreaterOrEqual(suite.T(), usage, 0.0, "CPU usage should be non-negative.")
+	assert.LessOrEqual(suite.T(), usage, 100.0, "CPU usage should not exceed 100%.")
+}
+
+func (suite *CPUCheckSuite) TestSaveCPUUsage() {
 	data := base.CheckResult{
 		Timestamp: time.Now(),
 		Usage:     50.0,
 	}
 
-	err := check.saveCPUUsage(data, ctx)
+	err := suite.check.saveCPUUsage(data, suite.ctx)
 
-	assert.NoError(t, err, "Failed to save cpu usage.")
+	assert.NoError(suite.T(), err, "Failed to save cpu usage.")
+}
+
+func TestCPUCheckSuite(t *testing.T) {
+	suite.Run(t, new(CPUCheckSuite))
 }

--- a/pkg/collector/check/realtime/disk/io/io_test.go
+++ b/pkg/collector/check/realtime/disk/io/io_test.go
@@ -3,69 +3,88 @@ package diskio
 import (
 	"context"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/collector/check/base"
 	"github.com/alpacanetworks/alpamon-go/pkg/db"
+	"github.com/alpacanetworks/alpamon-go/pkg/db/ent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func setUp(checkType base.CheckType) base.CheckStrategy {
+type DiskIOCheckSuite struct {
+	suite.Suite
+	client       *ent.Client
+	collectCheck *CollectCheck
+	sendCheck    *SendCheck
+	ctx          context.Context
+}
+
+func (suite *DiskIOCheckSuite) SetupSuite() {
+	suite.client = db.InitTestDB()
 	buffer := base.NewCheckBuffer(10)
-	args := &base.CheckArgs{
-		Type:     checkType,
-		Name:     string(checkType) + "_" + uuid.NewString(),
+	collect_args := &base.CheckArgs{
+		Type:     base.DISK_IO_COLLECTOR,
+		Name:     string(base.DISK_IO_COLLECTOR) + "_" + uuid.NewString(),
 		Interval: time.Duration(1 * time.Second),
 		Buffer:   buffer,
-		Client:   db.InitTestDB(),
+		Client:   suite.client,
 	}
-
-	check := NewCheck(args)
-
-	return check
+	send_args := &base.CheckArgs{
+		Type:     base.DISK_IO,
+		Name:     string(base.DISK_IO) + "_" + uuid.NewString(),
+		Interval: time.Duration(1 * time.Second),
+		Buffer:   buffer,
+		Client:   suite.client,
+	}
+	suite.collectCheck = NewCheck(collect_args).(*CollectCheck)
+	suite.sendCheck = NewCheck(send_args).(*SendCheck)
+	suite.ctx = context.Background()
 }
 
-func TestCollectDiskIO(t *testing.T) {
-	check := setUp(base.DISK_IO_COLLECTOR).(*CollectCheck)
+func (suite *DiskIOCheckSuite) TearDownSuite() {
+	err := os.Remove("alpamon.db")
+	suite.Require().NoError(err, "failed to delete test db file")
+}
 
-	ioCounters, err := check.collectDiskIO()
-	assert.NoError(t, err, "Failed to get disk io.")
+func (suite *DiskIOCheckSuite) TestCollectDiskIO() {
+	ioCounters, err := suite.collectCheck.collectDiskIO()
+	assert.NoError(suite.T(), err, "Failed to get disk io.")
 
-	assert.NotEmpty(t, ioCounters, "Disk IO should not be empty")
+	assert.NotEmpty(suite.T(), ioCounters, "Disk IO should not be empty")
 	for name, ioCounter := range ioCounters {
-		assert.NotEmpty(t, name, "Device name should not be empty")
-		assert.True(t, ioCounter.ReadBytes > 0, "Read bytes should be non-negative.")
-		assert.True(t, ioCounter.WriteBytes > 0, "Write bytes should be non-negative.")
+		assert.NotEmpty(suite.T(), name, "Device name should not be empty")
+		assert.True(suite.T(), ioCounter.ReadBytes > 0, "Read bytes should be non-negative.")
+		assert.True(suite.T(), ioCounter.WriteBytes > 0, "Write bytes should be non-negative.")
 	}
 }
 
-func TestSaveDiskIO(t *testing.T) {
-	check := setUp(base.DISK_IO_COLLECTOR).(*CollectCheck)
-	ctx := context.Background()
+func (suite *DiskIOCheckSuite) TestSaveDiskIO() {
+	ioCounters, err := suite.collectCheck.collectDiskIO()
+	assert.NoError(suite.T(), err, "Failed to get disk io.")
 
-	ioCounters, err := check.collectDiskIO()
-	assert.NoError(t, err, "Failed to get disk io.")
+	data := suite.collectCheck.parseDiskIO(ioCounters)
 
-	data := check.parseDiskIO(ioCounters)
-
-	err = check.saveDiskIO(data, ctx)
-	assert.NoError(t, err, "Failed to save cpu usage.")
+	err = suite.collectCheck.saveDiskIO(data, suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to save cpu usage.")
 }
 
-func TestGetDiskIO(t *testing.T) {
-	check := setUp(base.DISK_IO).(*SendCheck)
-	ctx := context.Background()
-
-	err := check.GetClient().DiskIO.Create().
+func (suite *DiskIOCheckSuite) TestGetDiskIO() {
+	err := suite.collectCheck.GetClient().DiskIO.Create().
 		SetTimestamp(time.Now()).
 		SetDevice(uuid.NewString()).
 		SetReadBps(rand.Float64()).
-		SetWriteBps(rand.Float64()).Exec(ctx)
-	assert.NoError(t, err, "Failed to create disk io.")
+		SetWriteBps(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create disk io.")
 
-	querySet, err := check.getDiskIO(ctx)
-	assert.NoError(t, err, "Failed to get disk io queryset.")
-	assert.NotEmpty(t, querySet, "Disk IO queryset should not be empty")
+	querySet, err := suite.sendCheck.getDiskIO(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to get disk io queryset.")
+	assert.NotEmpty(suite.T(), querySet, "Disk IO queryset should not be empty")
+}
+
+func TestDiskIOCheckSuite(t *testing.T) {
+	suite.Run(t, new(DiskIOCheckSuite))
 }

--- a/pkg/collector/check/realtime/disk/io/io_test.go
+++ b/pkg/collector/check/realtime/disk/io/io_test.go
@@ -57,8 +57,8 @@ func (suite *DiskIOCheckSuite) TestCollectDiskIO() {
 	assert.NotEmpty(suite.T(), ioCounters, "Disk IO should not be empty")
 	for name, ioCounter := range ioCounters {
 		assert.NotEmpty(suite.T(), name, "Device name should not be empty")
-		assert.True(suite.T(), ioCounter.ReadBytes > 0, "Read bytes should be non-negative.")
-		assert.True(suite.T(), ioCounter.WriteBytes > 0, "Write bytes should be non-negative.")
+		assert.GreaterOrEqual(suite.T(), ioCounter.ReadBytes, 0, "Read bytes should be non-negative.")
+		assert.GreaterOrEqual(suite.T(), ioCounter.WriteBytes, 0, "Write bytes should be non-negative.")
 	}
 }
 

--- a/pkg/collector/check/realtime/disk/io/io_test.go
+++ b/pkg/collector/check/realtime/disk/io/io_test.go
@@ -57,8 +57,8 @@ func (suite *DiskIOCheckSuite) TestCollectDiskIO() {
 	assert.NotEmpty(suite.T(), ioCounters, "Disk IO should not be empty")
 	for name, ioCounter := range ioCounters {
 		assert.NotEmpty(suite.T(), name, "Device name should not be empty")
-		assert.GreaterOrEqual(suite.T(), ioCounter.ReadBytes, 0, "Read bytes should be non-negative.")
-		assert.GreaterOrEqual(suite.T(), ioCounter.WriteBytes, 0, "Write bytes should be non-negative.")
+		assert.GreaterOrEqual(suite.T(), ioCounter.ReadBytes, uint64(0), "Read bytes should be non-negative.")
+		assert.GreaterOrEqual(suite.T(), ioCounter.WriteBytes, uint64(0), "Write bytes should be non-negative.")
 	}
 }
 

--- a/pkg/collector/check/realtime/disk/usage/usage_test.go
+++ b/pkg/collector/check/realtime/disk/usage/usage_test.go
@@ -2,61 +2,72 @@ package diskusage
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/collector/check/base"
 	"github.com/alpacanetworks/alpamon-go/pkg/db"
+	"github.com/alpacanetworks/alpamon-go/pkg/db/ent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func setUp() *Check {
+type DiskUsageCheckSuite struct {
+	suite.Suite
+	client *ent.Client
+	check  *Check
+	ctx    context.Context
+}
+
+func (suite *DiskUsageCheckSuite) SetupSuite() {
+	suite.client = db.InitTestDB()
 	buffer := base.NewCheckBuffer(10)
 	args := &base.CheckArgs{
 		Type:     base.DISK_USAGE,
 		Name:     string(base.DISK_USAGE) + "_" + uuid.NewString(),
 		Interval: time.Duration(1 * time.Second),
 		Buffer:   buffer,
-		Client:   db.InitTestDB(),
+		Client:   suite.client,
 	}
-
-	check := NewCheck(args).(*Check)
-
-	return check
+	suite.check = NewCheck(args).(*Check)
+	suite.ctx = context.Background()
 }
 
-func TestCollectDiskPartitions(t *testing.T) {
-	check := setUp()
-
-	partitions, err := check.collectDiskPartitions()
-
-	assert.NoError(t, err, "Failed to get disk partitions.")
-	assert.NotEmpty(t, partitions, "Disk partitions should not be empty")
+func (suite *DiskUsageCheckSuite) TearDownSuite() {
+	err := os.Remove("alpamon.db")
+	suite.Require().NoError(err, "failed to delete test db file")
 }
 
-func TestCollectDiskUsage(t *testing.T) {
-	check := setUp()
+func (suite *DiskUsageCheckSuite) TestCollectDiskPartitions() {
+	partitions, err := suite.check.collectDiskPartitions()
 
-	partitions, err := check.collectDiskPartitions()
-	assert.NoError(t, err, "Failed to get disk partitions.")
+	assert.NoError(suite.T(), err, "Failed to get disk partitions.")
+	assert.NotEmpty(suite.T(), partitions, "Disk partitions should not be empty")
+}
 
-	assert.NotEmpty(t, partitions, "Disk partitions should not be empty")
+func (suite *DiskUsageCheckSuite) TestCollectDiskUsage() {
+	partitions, err := suite.check.collectDiskPartitions()
+	assert.NoError(suite.T(), err, "Failed to get disk partitions.")
+
+	assert.NotEmpty(suite.T(), partitions, "Disk partitions should not be empty")
 	for _, partition := range partitions {
-		usage, err := check.collectDiskUsage(partition.Mountpoint)
-		assert.NoError(t, err, "Failed to get disk usage.")
-		assert.GreaterOrEqual(t, usage.UsedPercent, 0.0, "Disk usage should be non-negative.")
-		assert.LessOrEqual(t, usage.UsedPercent, 100.0, "Disk usage should not exceed 100%.")
+		usage, err := suite.check.collectDiskUsage(partition.Mountpoint)
+		assert.NoError(suite.T(), err, "Failed to get disk usage.")
+		assert.GreaterOrEqual(suite.T(), usage.UsedPercent, 0.0, "Disk usage should be non-negative.")
+		assert.LessOrEqual(suite.T(), usage.UsedPercent, 100.0, "Disk usage should not exceed 100%.")
 	}
 }
 
-func TestSaveDiskUsage(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *DiskUsageCheckSuite) TestSaveDiskUsage() {
+	partitions, err := suite.check.collectDiskPartitions()
+	assert.NoError(suite.T(), err, "Failed to get disk partitions.")
 
-	partitions, err := check.collectDiskPartitions()
-	assert.NoError(t, err, "Failed to get disk partitions.")
+	err = suite.check.saveDiskUsage(suite.check.parseDiskUsage(partitions), suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to save disk usage.")
+}
 
-	err = check.saveDiskUsage(check.parseDiskUsage(partitions), ctx)
-	assert.NoError(t, err, "Failed to save disk usage.")
+func TestDiskUsageCheckSuite(t *testing.T) {
+	suite.Run(t, new(DiskUsageCheckSuite))
 }

--- a/pkg/collector/check/realtime/memory/memory_test.go
+++ b/pkg/collector/check/realtime/memory/memory_test.go
@@ -2,49 +2,63 @@ package memory
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/alpacanetworks/alpamon-go/pkg/collector/check/base"
 	"github.com/alpacanetworks/alpamon-go/pkg/db"
+	"github.com/alpacanetworks/alpamon-go/pkg/db/ent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func setUp() *Check {
+type MemoryCheckSuite struct {
+	suite.Suite
+	client *ent.Client
+	check  *Check
+	ctx    context.Context
+}
+
+func (suite *MemoryCheckSuite) SetupSuite() {
+	suite.client = db.InitTestDB()
 	buffer := base.NewCheckBuffer(10)
 	args := &base.CheckArgs{
 		Type:     base.MEM,
 		Name:     string(base.MEM) + "_" + uuid.NewString(),
 		Interval: time.Duration(1 * time.Second),
 		Buffer:   buffer,
-		Client:   db.InitTestDB(),
+		Client:   suite.client,
 	}
-
-	check := NewCheck(args).(*Check)
-
-	return check
+	suite.check = NewCheck(args).(*Check)
+	suite.ctx = context.Background()
 }
 
-func TestCollectMemoryUsage(t *testing.T) {
-	check := setUp()
-
-	usage, err := check.collectMemoryUsage()
-
-	assert.NoError(t, err, "Failed to get memory usage.")
-	assert.GreaterOrEqual(t, usage, 0.0, "Memory usage should be non-negative.")
-	assert.LessOrEqual(t, usage, 100.0, "Memory usage should not exceed 100%.")
+func (suite *MemoryCheckSuite) TearDownSuite() {
+	err := os.Remove("alpamon.db")
+	suite.Require().NoError(err, "failed to delete test db file")
 }
 
-func TestSaveMemoryUsage(t *testing.T) {
-	check := setUp()
-	ctx := context.Background()
+func (suite *MemoryCheckSuite) TestCollectMemoryUsage() {
+	usage, err := suite.check.collectMemoryUsage()
+
+	assert.NoError(suite.T(), err, "Failed to get memory usage.")
+	assert.GreaterOrEqual(suite.T(), usage, 0.0, "Memory usage should be non-negative.")
+	assert.LessOrEqual(suite.T(), usage, 100.0, "Memory usage should not exceed 100%.")
+}
+
+func (suite *MemoryCheckSuite) TestSaveMemoryUsage() {
 	data := base.CheckResult{
 		Timestamp: time.Now(),
 		Usage:     50.0,
 	}
 
-	err := check.saveMemoryUsage(data, ctx)
+	err := suite.check.saveMemoryUsage(data, suite.ctx)
 
-	assert.NoError(t, err, "Failed to save memory usage.")
+	assert.NoError(suite.T(), err, "Failed to save memory usage.")
+}
+
+func TestMemoryCheckSuite(t *testing.T) {
+	suite.Run(t, new(MemoryCheckSuite))
 }


### PR DESCRIPTION
To prevent redundant database migrations and SQL driver registrations, 
refactor collector related test cases using `github.com/stretchr/testify/suite` 
to ensure these operations occur only once per test case.