### PR TITLE
Refactor Alpamon for External Plugin Support 

### DIFF
--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -26,6 +26,8 @@ var RootCmd = &cobra.Command{
 	},
 }
 
+const name = "alpamon"
+
 func init() {
 	RootCmd.AddCommand(setupCmd, ftpCmd)
 }
@@ -35,7 +37,7 @@ func runAgent() {
 	utils.InitPlatform()
 
 	// Pid
-	pidFilePath, err := pidfile.WritePID(pidfile.FilePath("alpamon"))
+	pidFilePath, err := pidfile.WritePID(pidfile.FilePath(name))
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "Failed to create PID file", err.Error())
 		os.Exit(1)
@@ -45,7 +47,7 @@ func runAgent() {
 	fmt.Printf("alpamon version %s starting.\n", version.Version)
 
 	// Config & Settings
-	settings := config.LoadConfig()
+	settings := config.LoadConfig(config.Files(name))
 	config.InitSettings(settings)
 
 	// Session

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -89,9 +89,7 @@ func runAgent() {
 			return
 		}
 
-		args := os.Args
-
-		err = syscall.Exec(executable, args, os.Environ())
+		err = syscall.Exec(executable, os.Args, os.Environ())
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to restart the program")
 		}

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -35,7 +35,7 @@ func runAgent() {
 	utils.InitPlatform()
 
 	// Pid
-	pidFilePath, err := pidfile.WritePID()
+	pidFilePath, err := pidfile.WritePID(pidfile.FilePath("alpamon"))
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "Failed to create PID file", err.Error())
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/tls"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,11 +14,6 @@ import (
 )
 
 var (
-	configFiles = []string{
-		"/etc/alpamon/alpamon.conf",
-		filepath.Join(os.Getenv("HOME"), ".alpamon.conf"),
-	}
-
 	GlobalSettings Settings
 )
 
@@ -31,7 +27,7 @@ func InitSettings(settings Settings) {
 	GlobalSettings = settings
 }
 
-func LoadConfig() Settings {
+func LoadConfig(configFiles []string) Settings {
 	var iniData *ini.File
 	var err error
 	var validConfigFile string
@@ -138,4 +134,11 @@ func validateConfig(config Config) (bool, Settings) {
 		}
 	}
 	return valid, settings
+}
+
+func Files(name string) []string {
+	return []string{
+		fmt.Sprintf("/etc/alpamon/%s.conf", name),
+		filepath.Join(os.Getenv("HOME"), fmt.Sprintf(".%s.conf", name)),
+	}
 }

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -2,7 +2,6 @@ package pidfile
 
 import (
 	"fmt"
-	"github.com/alpacanetworks/alpamon-go/pkg/utils"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,22 +9,12 @@ import (
 	"syscall"
 )
 
-const (
-	pidFilePathDarwin  = "/tmp/alpamon.pid"
-	pidFilePathDefault = "/var/run/alpamon.pid"
-)
-
 // WritePID writes the current PID to a file, ensuring that the file
 // doesn't exist or doesn't contain a PID for a running process.
 //
 // Based on a function from the Datadog Agent.
 // Reference : https://github.com/DataDog/datadog-agent
-func WritePID() (string, error) {
-	pidFilePath, err := setupPIDFilePath()
-	if err != nil {
-		return "", err
-	}
-
+func WritePID(pidFilePath string) (string, error) {
 	// check whether the pidfile exists and contains the PID for a running proc...
 	if byteContent, err := os.ReadFile(pidFilePath); err == nil {
 		pidStr := strings.TrimSpace(string(byteContent))
@@ -53,17 +42,4 @@ func WritePID() (string, error) {
 // isProcess uses `kill -0` to check whether a process is running
 func isProcess(pid int) bool {
 	return syscall.Kill(pid, 0) == nil
-}
-
-func setupPIDFilePath() (string, error) {
-	var pidFilePath string
-
-	switch utils.PlatformLike {
-	case "darwin":
-		pidFilePath = pidFilePathDarwin
-	default:
-		pidFilePath = pidFilePathDefault
-	}
-
-	return pidFilePath, nil
 }

--- a/pkg/pidfile/pidfile_darwin.go
+++ b/pkg/pidfile/pidfile_darwin.go
@@ -1,0 +1,8 @@
+package pidfile
+
+import "fmt"
+
+// Use /tmp for testing on macOS.
+func FilePath(name string) string {
+	return fmt.Sprintf("/tmp/%s", name)
+}

--- a/pkg/pidfile/pidfile_linux.go
+++ b/pkg/pidfile/pidfile_linux.go
@@ -1,5 +1,7 @@
 package pidfile
 
+import "fmt"
+
 func FilePath(name string) string {
 	return fmt.Sprintf("/var/run/%s", name)
 }

--- a/pkg/pidfile/pidfile_linux.go
+++ b/pkg/pidfile/pidfile_linux.go
@@ -1,0 +1,5 @@
+package pidfile
+
+func FilePath(name string) string {
+	return fmt.Sprintf("/var/run/%s", name)
+}

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -37,7 +37,7 @@ func NewWebsocketClient(session *scheduler.Session) *WebsocketClient {
 	headers := http.Header{
 		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, config.GlobalSettings.ID, config.GlobalSettings.Key)},
 		"Origin":        {config.GlobalSettings.ServerURL},
-		"User-Agent":    {utils.GetUserAgent()},
+		"User-Agent":    {utils.GetUserAgent("alpamon")},
 	}
 
 	return &WebsocketClient{
@@ -186,8 +186,8 @@ func (wc *WebsocketClient) commandRequestHandler(message []byte) {
 			10,
 			time.Time{},
 		)
-		runner := NewCommandRunner(wc, content.Command, data)
-		go runner.Run()
+		commandRunner := NewCommandRunner(wc, content.Command, data)
+		go commandRunner.Run()
 	case "quit":
 		log.Debug().Msgf("Quit requested for reason: %s", content.Reason)
 		wc.Quit()

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -18,7 +18,7 @@ import (
 const (
 	minConnectInterval    = 5 * time.Second
 	maxConnectInterval    = 60 * time.Second
-	connectionReadTimeout = 35 * time.Minute
+	ConnectionReadTimeout = 35 * time.Minute
 	maxRetryTimeout       = 3 * 24 * time.Hour
 
 	eventCommandAckURL = "/api/events/commands/%s/ack/"
@@ -26,11 +26,11 @@ const (
 )
 
 type WebsocketClient struct {
-	conn             *websocket.Conn
+	Conn             *websocket.Conn
 	requestHeader    http.Header
 	apiSession       *scheduler.Session
 	RestartRequested bool
-	quitChan         chan struct{}
+	QuitChan         chan struct{}
 }
 
 func NewWebsocketClient(session *scheduler.Session) *WebsocketClient {
@@ -44,35 +44,35 @@ func NewWebsocketClient(session *scheduler.Session) *WebsocketClient {
 		requestHeader:    headers,
 		apiSession:       session,
 		RestartRequested: false,
-		quitChan:         make(chan struct{}),
+		QuitChan:         make(chan struct{}),
 	}
 }
 
 func (wc *WebsocketClient) RunForever() {
-	wc.connect()
-	defer wc.close()
+	wc.Connect()
+	defer wc.Close()
 
 	for {
 		select {
-		case <-wc.quitChan:
+		case <-wc.QuitChan:
 			return
 		default:
-			err := wc.conn.SetReadDeadline(time.Now().Add(connectionReadTimeout))
+			err := wc.Conn.SetReadDeadline(time.Now().Add(ConnectionReadTimeout))
 			if err != nil {
-				wc.closeAndReconnect()
+				wc.CloseAndReconnect()
 			}
-			_, message, err := wc.readMessage()
+			_, message, err := wc.ReadMessage()
 			if err != nil {
-				wc.closeAndReconnect()
+				wc.CloseAndReconnect()
 			}
 			// Sends "ping" query for Alpacon to verify WebSocket session status without error handling.
-			_ = wc.sendPingQuery()
+			_ = wc.SendPingQuery()
 			wc.commandRequestHandler(message)
 		}
 	}
 }
 
-func (wc *WebsocketClient) sendPingQuery() error {
+func (wc *WebsocketClient) SendPingQuery() error {
 	pingQuery := map[string]string{"query": "ping"}
 	err := wc.writeJSON(pingQuery)
 	if err != nil {
@@ -82,8 +82,8 @@ func (wc *WebsocketClient) sendPingQuery() error {
 	return nil
 }
 
-func (wc *WebsocketClient) readMessage() (messageType int, message []byte, err error) {
-	messageType, message, err = wc.conn.ReadMessage()
+func (wc *WebsocketClient) ReadMessage() (messageType int, message []byte, err error) {
+	messageType, message, err = wc.Conn.ReadMessage()
 	if err != nil {
 		return 0, nil, err
 	}
@@ -91,7 +91,7 @@ func (wc *WebsocketClient) readMessage() (messageType int, message []byte, err e
 	return messageType, message, nil
 }
 
-func (wc *WebsocketClient) connect() {
+func (wc *WebsocketClient) Connect() {
 	log.Info().Msgf("Connecting to websocket at %s...", config.GlobalSettings.WSPath)
 
 	ctx, cancel := context.WithTimeout(context.Background(), maxRetryTimeout)
@@ -116,7 +116,7 @@ func (wc *WebsocketClient) connect() {
 				return err
 			}
 
-			wc.conn = conn
+			wc.Conn = conn
 			log.Debug().Msg("Backhaul connection established.")
 			return nil
 		}
@@ -129,32 +129,32 @@ func (wc *WebsocketClient) connect() {
 	}
 }
 
-func (wc *WebsocketClient) closeAndReconnect() {
-	wc.close()
-	wc.connect()
+func (wc *WebsocketClient) CloseAndReconnect() {
+	wc.Close()
+	wc.Connect()
 }
 
 // Cleanly close the websocket connection by sending a close message
 // Do not close quitChan, as the purpose here is to disconnect the WebSocket,
 // not to terminate RunForever.
-func (wc *WebsocketClient) close() {
-	if wc.conn != nil {
-		err := wc.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+func (wc *WebsocketClient) Close() {
+	if wc.Conn != nil {
+		err := wc.Conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to write close message to websocket.")
 		}
-		_ = wc.conn.Close()
+		_ = wc.Conn.Close()
 	}
 }
 
-func (wc *WebsocketClient) quit() {
-	wc.close()
-	close(wc.quitChan)
+func (wc *WebsocketClient) Quit() {
+	wc.Close()
+	close(wc.QuitChan)
 }
 
 func (wc *WebsocketClient) restart() {
 	wc.RestartRequested = true
-	wc.quit()
+	wc.Quit()
 }
 
 func (wc *WebsocketClient) commandRequestHandler(message []byte) {
@@ -190,17 +190,17 @@ func (wc *WebsocketClient) commandRequestHandler(message []byte) {
 		go runner.Run()
 	case "quit":
 		log.Debug().Msgf("Quit requested for reason: %s", content.Reason)
-		wc.quit()
+		wc.Quit()
 	case "reconnect":
 		log.Debug().Msgf("Reconnect requested for reason: %s", content.Reason)
-		wc.close()
+		wc.Close()
 	default:
 		log.Warn().Msgf("Not implemented query: %s", content.Query)
 	}
 }
 
 func (wc *WebsocketClient) writeJSON(data interface{}) error {
-	err := wc.conn.WriteJSON(data)
+	err := wc.Conn.WriteJSON(data)
 	if err != nil {
 		log.Debug().Err(err).Msgf("Failed to write json data to websocket.")
 		return err

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -197,7 +197,7 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		return 0, "Alpamon will restart in 1 second."
 	case "quit":
 		time.AfterFunc(1*time.Second, func() {
-			cr.wsClient.quit()
+			cr.wsClient.Quit()
 		})
 		return 0, "Alpamon will quit in 1 second."
 	case "reboot":

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -257,7 +257,7 @@ func (cr *CommandRunner) handleShellCmd(command, user, group string, env map[str
 	for _, arg := range spl {
 		switch arg {
 		case "&&":
-			exitCode, result = runCmd(args, user, group, env, 0)
+			exitCode, result = runCmdWithOutput(args, user, group, env, 0)
 			results += result
 			// stop executing if command fails
 			if exitCode != 0 {
@@ -265,7 +265,7 @@ func (cr *CommandRunner) handleShellCmd(command, user, group string, env map[str
 			}
 			args = []string{}
 		case "||":
-			exitCode, result = runCmd(args, user, group, env, 0)
+			exitCode, result = runCmdWithOutput(args, user, group, env, 0)
 			results += result
 			// execute next only if command fails
 			if exitCode == 0 {
@@ -273,13 +273,13 @@ func (cr *CommandRunner) handleShellCmd(command, user, group string, env map[str
 			}
 			args = []string{}
 		case ";":
-			exitCode, result = runCmd(args, user, group, env, 0)
+			exitCode, result = runCmdWithOutput(args, user, group, env, 0)
 			results += result
 			args = []string{}
 		default:
 			if strings.HasSuffix(arg, ";") {
 				args = append(args, strings.TrimSuffix(arg, ";"))
-				exitCode, result = runCmd(args, user, group, env, 0)
+				exitCode, result = runCmdWithOutput(args, user, group, env, 0)
 				results += result
 				args = []string{}
 			} else {
@@ -290,7 +290,7 @@ func (cr *CommandRunner) handleShellCmd(command, user, group string, env map[str
 
 	if len(args) > 0 {
 		log.Debug().Msgf("Running '%s'", strings.Join(args, " "))
-		exitCode, result = runCmd(args, user, group, env, 0)
+		exitCode, result = runCmdWithOutput(args, user, group, env, 0)
 		results += result
 	}
 
@@ -322,7 +322,7 @@ func (cr *CommandRunner) addUser() (exitCode int, result string) {
 	}
 
 	if utils.PlatformLike == "debian" {
-		exitCode, result = runCmd(
+		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/adduser",
 				"--home", data.HomeDirectory,
@@ -350,7 +350,7 @@ func (cr *CommandRunner) addUser() (exitCode int, result string) {
 			}
 
 			// invoke adduser
-			exitCode, result = runCmd(
+			exitCode, result = runCmdWithOutput(
 				[]string{
 					"/usr/sbin/adduser",
 					data.Username,
@@ -363,7 +363,7 @@ func (cr *CommandRunner) addUser() (exitCode int, result string) {
 			}
 		}
 	} else if utils.PlatformLike == "rhel" {
-		exitCode, result = runCmd(
+		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/useradd",
 				"--home-dir", data.HomeDirectory,
@@ -399,7 +399,7 @@ func (cr *CommandRunner) addGroup() (exitCode int, result string) {
 	}
 
 	if utils.PlatformLike == "debian" {
-		exitCode, result = runCmd(
+		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/addgroup",
 				"--gid", strconv.FormatUint(data.GID, 10),
@@ -411,7 +411,7 @@ func (cr *CommandRunner) addGroup() (exitCode int, result string) {
 			return exitCode, result
 		}
 	} else if utils.PlatformLike == "rhel" {
-		exitCode, result = runCmd(
+		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/groupadd",
 				"--gid", strconv.FormatUint(data.GID, 10),
@@ -441,7 +441,7 @@ func (cr *CommandRunner) delUser() (exitCode int, result string) {
 	}
 
 	if utils.PlatformLike == "debian" {
-		exitCode, result = runCmd(
+		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/deluser",
 				data.Username,
@@ -452,7 +452,7 @@ func (cr *CommandRunner) delUser() (exitCode int, result string) {
 			return exitCode, result
 		}
 	} else if utils.PlatformLike == "rhel" {
-		exitCode, result = runCmd(
+		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/userdel",
 				data.Username,
@@ -481,7 +481,7 @@ func (cr *CommandRunner) delGroup() (exitCode int, result string) {
 	}
 
 	if utils.PlatformLike == "debian" {
-		exitCode, result = runCmd(
+		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/delgroup",
 				data.Groupname,
@@ -492,7 +492,7 @@ func (cr *CommandRunner) delGroup() (exitCode int, result string) {
 			return exitCode, result
 		}
 	} else if utils.PlatformLike == "rhel" {
-		exitCode, result = runCmd(
+		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/groupdel",
 				data.Groupname,

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -91,8 +91,8 @@ func (pc *PtyClient) RunPtyBackground() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pc.readFromWebsocket(ctx, cancel)
-	pc.readFromPTY(ctx, cancel)
+	go pc.readFromWebsocket(ctx, cancel)
+	go pc.readFromPTY(ctx, cancel)
 
 	terminals[pc.sessionID] = pc
 

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -91,12 +91,8 @@ func (pc *PtyClient) RunPtyBackground() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go func() {
-		pc.readFromWebsocket(ctx, cancel)
-	}()
-	go func() {
-		pc.readFromPTY(ctx, cancel)
-	}()
+	pc.readFromWebsocket(ctx, cancel)
+	pc.readFromPTY(ctx, cancel)
 
 	terminals[pc.sessionID] = pc
 

--- a/pkg/runner/shell.go
+++ b/pkg/runner/shell.go
@@ -57,7 +57,7 @@ func demote(username, groupname string) (*syscall.SysProcAttr, error) {
 	}, nil
 }
 
-func runCmd(args []string, username, groupname string, env map[string]string, timeout int) (exitCode int, result string) {
+func runCmdWithOutput(args []string, username, groupname string, env map[string]string, timeout int) (exitCode int, result string) {
 	if env != nil {
 		defaultEnv := getDefaultEnv()
 		for key, value := range defaultEnv {
@@ -133,6 +133,19 @@ func runCmd(args []string, username, groupname string, env map[string]string, ti
 	}
 
 	return 0, string(output)
+}
+
+func RunCmd(command string, args ...string) int {
+	cmd := exec.Command(command, args...)
+
+	err := cmd.Run()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return exitError.ExitCode()
+		}
+		return -1
+	}
+	return 0
 }
 
 // && and || operators are handled separately in handleShellCmd

--- a/pkg/runner/shell.go
+++ b/pkg/runner/shell.go
@@ -126,7 +126,10 @@ func runCmd(args []string, username, groupname string, env map[string]string, ti
 
 	output, err := cmd.Output()
 	if err != nil {
-		return 1, err.Error()
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return exitError.ExitCode(), err.Error()
+		}
+		return -1, err.Error()
 	}
 
 	return 0, string(output)

--- a/pkg/scheduler/session.go
+++ b/pkg/scheduler/session.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	checkSessionURL = "/api/servers/servers/-/"
-	maxRetryTimeout = 3 * 24 * time.Hour
+	MaxRetryTimeout = 3 * 24 * time.Hour
 )
 
 func InitSession() *Session {
@@ -54,7 +54,7 @@ func InitSession() *Session {
 
 func (session *Session) CheckSession() bool {
 	timeout := config.MinConnectInterval
-	ctx, cancel := context.WithTimeout(context.Background(), maxRetryTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), MaxRetryTimeout)
 	defer cancel()
 
 	for {
@@ -112,7 +112,11 @@ func (session *Session) newRequest(method, url string, rawBody interface{}) (*ht
 }
 
 func (session *Session) do(req *http.Request, timeout time.Duration) ([]byte, int, error) {
-	session.Client.Timeout = timeout * time.Second
+	ctx, cancel := context.WithTimeout(req.Context(), timeout*time.Second)
+	defer cancel()
+
+	req = req.WithContext(ctx)
+
 	req.Header.Set("Authorization", session.authorization)
 	req.Header.Set("User-Agent", utils.GetUserAgent())
 
@@ -167,8 +171,17 @@ func (session *Session) Post(url string, rawBody interface{}, timeout time.Durat
 	return session.do(req, timeout)
 }
 
-func (session *Session) Put(url string, body bytes.Buffer, timeout time.Duration) ([]byte, int, error) {
-	req, err := session.newRequest(http.MethodPut, url, body)
+func (session *Session) Put(url string, rawBody interface{}, timeout time.Duration) ([]byte, int, error) {
+	req, err := session.newRequest(http.MethodPut, url, rawBody)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return session.do(req, timeout)
+}
+
+func (session *Session) Patch(url string, rawBody interface{}, timeout time.Duration) ([]byte, int, error) {
+	req, err := session.newRequest(http.MethodPatch, url, rawBody)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -182,7 +195,11 @@ func (session *Session) MultipartRequest(url string, body bytes.Buffer, contentT
 		return nil, 0, err
 	}
 
-	session.Client.Timeout = timeout * time.Second
+	ctx, cancel := context.WithTimeout(req.Context(), timeout*time.Second)
+	defer cancel()
+
+	req = req.WithContext(ctx)
+
 	req.Header.Set("Authorization", session.authorization)
 	req.Header.Set("User-Agent", utils.GetUserAgent())
 	req.Header.Set("Content-Type", contentType)

--- a/pkg/scheduler/session.go
+++ b/pkg/scheduler/session.go
@@ -118,7 +118,7 @@ func (session *Session) do(req *http.Request, timeout time.Duration) ([]byte, in
 	req = req.WithContext(ctx)
 
 	req.Header.Set("Authorization", session.authorization)
-	req.Header.Set("User-Agent", utils.GetUserAgent())
+	req.Header.Set("User-Agent", utils.GetUserAgent("alpamon"))
 
 	if req.Method == http.MethodPost || req.Method == http.MethodPut || req.Method == http.MethodPatch {
 		req.Header.Set("Content-Type", "application/json")
@@ -201,7 +201,7 @@ func (session *Session) MultipartRequest(url string, body bytes.Buffer, contentT
 	req = req.WithContext(ctx)
 
 	req.Header.Set("Authorization", session.authorization)
-	req.Header.Set("User-Agent", utils.GetUserAgent())
+	req.Header.Set("User-Agent", utils.GetUserAgent("alpamon"))
 	req.Header.Set("Content-Type", contentType)
 
 	resp, err := session.Client.Do(req)

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -1,0 +1,80 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func CopyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = srcFile.Close() }()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dstFile.Close() }()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	err = os.Chmod(dst, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func CopyDir(src, dst string) error {
+	if strings.HasPrefix(dst, src) {
+		return fmt.Errorf("%s is inside %s, causing infinite recursion", dst, src)
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(dst, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			err = CopyDir(srcPath, dstPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = CopyFile(srcPath, dstPath)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/shirou/gopsutil/v4/net"
+	"time"
+)
+
+func CalculateNetworkBps(current net.IOCountersStat, last net.IOCountersStat, interval time.Duration) (inputBps float64, outputBps float64) {
+	if interval == 0 {
+		return 0, 0
+	}
+
+	inputBytesDiff := float64(current.BytesRecv - last.BytesRecv)
+	outputBytesDiff := float64(current.BytesSent - last.BytesSent)
+	seconds := interval.Seconds()
+
+	inputBps = (inputBytesDiff * 8) / seconds
+	outputBps = (outputBytesDiff * 8) / seconds
+
+	return inputBps, outputBps
+}
+
+func CalculateNetworkPps(current net.IOCountersStat, last net.IOCountersStat, interval time.Duration) (inputPps float64, outputPps float64) {
+	if interval == 0 {
+		return 0, 0
+	}
+
+	inputPktsDiff := float64(current.PacketsRecv - last.PacketsRecv)
+	outputPktsDiff := float64(current.PacketsSent - last.PacketsSent)
+	seconds := interval.Seconds()
+
+	inputPps = inputPktsDiff / seconds
+	outputPps = outputPktsDiff / seconds
+
+	return inputPps, outputPps
+}
+
+func CalculateDiskIOBps(current disk.IOCountersStat, last disk.IOCountersStat, interval time.Duration) (readBps float64, writeBps float64) {
+	if interval == 0 {
+		return 0, 0
+	}
+
+	readBytesDiff := float64(current.ReadBytes - last.ReadBytes)
+	writeBytesDiff := float64(current.WriteBytes - last.WriteBytes)
+	seconds := interval.Seconds()
+
+	readBps = readBytesDiff / seconds
+	writeBps = writeBytesDiff / seconds
+
+	return readBps, writeBps
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/alpacanetworks/alpamon-go/pkg/version"
+	"github.com/google/go-github/github"
+	"github.com/rs/zerolog/log"
+	"github.com/shirou/gopsutil/v4/host"
 	"net/url"
 	"os"
 	"os/user"
@@ -12,13 +15,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
-
-	"github.com/google/go-github/github"
-	"github.com/rs/zerolog/log"
-	"github.com/shirou/gopsutil/v4/disk"
-	"github.com/shirou/gopsutil/v4/host"
-	"github.com/shirou/gopsutil/v4/net"
 )
 
 var (
@@ -116,51 +112,6 @@ func ConvertGroupIds(groupIds []string) []uint32 {
 	return gids
 }
 
-func CalculateNetworkBps(current net.IOCountersStat, last net.IOCountersStat, interval time.Duration) (inputBps float64, outputBps float64) {
-	if interval == 0 {
-		return 0, 0
-	}
-
-	inputBytesDiff := float64(current.BytesRecv - last.BytesRecv)
-	outputBytesDiff := float64(current.BytesSent - last.BytesSent)
-	seconds := interval.Seconds()
-
-	inputBps = (inputBytesDiff * 8) / seconds
-	outputBps = (outputBytesDiff * 8) / seconds
-
-	return inputBps, outputBps
-}
-
-func CalculateNetworkPps(current net.IOCountersStat, last net.IOCountersStat, interval time.Duration) (inputPps float64, outputPps float64) {
-	if interval == 0 {
-		return 0, 0
-	}
-
-	inputPktsDiff := float64(current.PacketsRecv - last.PacketsRecv)
-	outputPktsDiff := float64(current.PacketsSent - last.PacketsSent)
-	seconds := interval.Seconds()
-
-	inputPps = inputPktsDiff / seconds
-	outputPps = outputPktsDiff / seconds
-
-	return inputPps, outputPps
-}
-
-func CalculateDiskIOBps(current disk.IOCountersStat, last disk.IOCountersStat, interval time.Duration) (readBps float64, writeBps float64) {
-	if interval == 0 {
-		return 0, 0
-	}
-
-	readBytesDiff := float64(current.ReadBytes - last.ReadBytes)
-	writeBytesDiff := float64(current.WriteBytes - last.WriteBytes)
-	seconds := interval.Seconds()
-
-	readBps = readBytesDiff / seconds
-	writeBps = writeBytesDiff / seconds
-
-	return readBps, writeBps
-}
-
 func Quote(s string) string {
 	if len(s) == 0 {
 		return "''"
@@ -204,6 +155,6 @@ func GetLatestVersion() string {
 	return release.GetTagName()
 }
 
-func GetUserAgent() string {
-	return fmt.Sprintf("%s/%s", "alpamon", version.Version)
+func GetUserAgent(name string) string {
+	return fmt.Sprintf("%s/%s", name, version.Version)
 }


### PR DESCRIPTION
Closes #28
 
This PR refactors Alpamon to be modular, allowing external plugins (alpamon-plugin) to import and use its core functionalities.


