### PR TITLE
 Improve postinstall script and setup command to prevent dpkg errors during upgrade

### DIFF
--- a/cmd/alpamon/command/configs/alpamon-restart.service
+++ b/cmd/alpamon/command/configs/alpamon-restart.service
@@ -1,0 +1,6 @@
+[Unit]
+Description= Restart Alpamon service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/systemctl restart alpamon.service

--- a/cmd/alpamon/command/configs/alpamon-restart.timer
+++ b/cmd/alpamon/command/configs/alpamon-restart.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description= Timer to restart Alpamon service 5 minutes after activation
+
+[Timer]
+OnActiveSec=5min
+Unit=alpamon-restart.service
+Persistent=false
+
+[Install]
+WantedBy=multi-user.target

--- a/cmd/alpamon/command/setup/setup.go
+++ b/cmd/alpamon/command/setup/setup.go
@@ -47,7 +47,7 @@ func SetConfigPaths(serviceName string, fs embed.FS) {
 	servicePath = fmt.Sprintf("configs/%s.service", name)
 	serviceTarget = fmt.Sprintf("/lib/systemd/system/%s.service", name)
 	restartServicePath = fmt.Sprintf("configs/%s-restart.service", name)
-	restartServiceTarget = fmt.Sprintf("lib/systemd/system/%s-restart.service", name)
+	restartServiceTarget = fmt.Sprintf("/lib/systemd/system/%s-restart.service", name)
 	timerPath = fmt.Sprintf("configs/%s-restart.timer", name)
 	timerTarget = fmt.Sprintf("/lib/systemd/system/%s-restart.timer", name)
 }

--- a/cmd/alpamon/command/setup/setup.go
+++ b/cmd/alpamon/command/setup/setup.go
@@ -15,14 +15,18 @@ import (
 )
 
 var (
-	name                string
-	configFiles         embed.FS
-	configTemplatePath  string
-	configTarget        string
-	tmpFilePath         = "configs/tmpfile.conf"
-	tmpFileTarget       string
-	serviceTemplatePath string
-	serviceTarget       string
+	name                 string
+	configFiles          embed.FS
+	configPath           string
+	configTarget         string
+	tmpFilePath          = "configs/tmpfile.conf"
+	tmpFileTarget        string
+	servicePath          string
+	restartServicePath   string
+	serviceTarget        string
+	restartServiceTarget string
+	timerPath            string
+	timerTarget          string
 )
 
 type ConfigData struct {
@@ -37,11 +41,15 @@ type ConfigData struct {
 func SetConfigPaths(serviceName string, fs embed.FS) {
 	name = serviceName
 	configFiles = fs
-	configTemplatePath = fmt.Sprintf("configs/%s.conf", name)
+	configPath = fmt.Sprintf("configs/%s.conf", name)
 	configTarget = fmt.Sprintf("/etc/alpamon/%s.conf", name)
 	tmpFileTarget = fmt.Sprintf("/usr/lib/tmpfiles.d/%s.conf", name)
-	serviceTemplatePath = fmt.Sprintf("configs/%s.service", name)
+	servicePath = fmt.Sprintf("configs/%s.service", name)
 	serviceTarget = fmt.Sprintf("/lib/systemd/system/%s.service", name)
+	restartServicePath = fmt.Sprintf("configs/%s-restart.service", name)
+	restartServiceTarget = fmt.Sprintf("lib/systemd/system/%s-restart.service", name)
+	timerPath = fmt.Sprintf("configs/%s-restart.timer", name)
+	timerTarget = fmt.Sprintf("/lib/systemd/system/%s-restart.timer", name)
 }
 
 var SetupCmd = &cobra.Command{
@@ -79,7 +87,7 @@ var SetupCmd = &cobra.Command{
 			return err
 		}
 
-		err = writeService()
+		err = writeSystemdFiles()
 		if err != nil {
 			return err
 		}
@@ -90,9 +98,9 @@ var SetupCmd = &cobra.Command{
 }
 
 func writeConfig() error {
-	tmplData, err := configFiles.ReadFile(configTemplatePath)
+	tmplData, err := configFiles.ReadFile(configPath)
 	if err != nil {
-		return fmt.Errorf("failed to read template file (%s): %v", configTemplatePath, err)
+		return fmt.Errorf("failed to read template file (%s): %v", configPath, err)
 	}
 
 	tmpl, err := template.New(fmt.Sprintf("%s.conf", name)).Parse(string(tmplData))
@@ -138,11 +146,22 @@ func writeConfig() error {
 	return nil
 }
 
-func writeService() error {
-	err := copyEmbeddedFile(serviceTemplatePath, serviceTarget)
+func writeSystemdFiles() error {
+	err := copyEmbeddedFile(servicePath, serviceTarget)
 	if err != nil {
 		return fmt.Errorf("failed to write target file: %v", err)
 	}
+
+	err = copyEmbeddedFile(restartServicePath, restartServiceTarget)
+	if err != nil {
+		return fmt.Errorf("failed to write target file: %v", err)
+	}
+
+	err = copyEmbeddedFile(timerPath, timerTarget)
+	if err != nil {
+		return fmt.Errorf("failed to write target file: %v", err)
+	}
+
 	return nil
 }
 

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -112,7 +112,6 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		}
 		log.Debug().Msgf("Upgrading alpamon from %s to %s using command: '%s'...", version.Version, latestVersion, cmd)
 		return cr.handleShellCmd(cmd, "root", "root", nil)
-
 	case "commit":
 		cr.commit()
 		return 0, "Committed system information."

--- a/scripts/postremove.sh
+++ b/scripts/postremove.sh
@@ -1,17 +1,19 @@
 #!/bin/sh
 
-CONF_FILE_PATH="/etc/alpamon/alpamon.conf"
-TMP_FILE_PATH="/usr/lib/tmpfiles.d/alpamon.conf"
-SVC_FILE_PATH="/lib/systemd/system/alpamon.service"
-LOG_FILE_PATH="/var/log/alpamon/alpamon.log"
-DB_FILE_PATH="/var/lib/alpamon/alpamon.db"
+FILES_TO_REMOVE="
+  /etc/alpamon/alpamon.conf
+  /usr/lib/tmpfiles.d/alpamon.conf
+  /lib/systemd/system/alpamon.service
+  /lib/systemd/system/alpamon-restart.service
+  /lib/systemd/system/alpamon-restart.timer
+  /var/log/alpamon/alpamon.log
+  /var/lib/alpamon/alpamon.db
+"
 
 if [ "$1" = 'purge' ]; then
-    rm -f "$CONF_FILE_PATH" || true
-    rm -f "$TMP_FILE_PATH" || true
-    rm -f "$SVC_FILE_PATH" || true
-    rm -f "$LOG_FILE_PATH" || true
-    rm -f "$DB_FILE_PATH" || true
+    for file in $FILES_TO_REMOVE; do
+        rm -f "$file" || true
+    done
 
     echo "All related configuration, service, and log files have been deleted."
 fi


### PR DESCRIPTION
### Description
- Updated `postinstall.sh` to ensure proper handling of systemd services and timers during upgrade.
  - Excluded atlas-cli installation during upgrades to avoid unnecessary installations 
- Modified `setup` command to generate additional required files.
- Prevents potential dpkg errors by ensuring all necessary files are correctly written and systemd units are properly managed.
