### PR TITLE
Refactor WebSocket shutdown flow and logger init timing

### DIFF
--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -53,6 +53,9 @@ func runAgent() {
 		}
 	}()
 
+	// Logger
+	logFile := logger.InitLogger()
+
 	// platform
 	utils.InitPlatform()
 
@@ -63,7 +66,7 @@ func runAgent() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("alpamon version %s starting.\n", version.Version)
+	log.Info().Msgf("Starting alpamon... (version: %s)", version.Version)
 
 	// Config & Settings
 	settings := config.LoadConfig(config.Files(name), wsPath)
@@ -76,8 +79,6 @@ func runAgent() {
 	// Reporter
 	scheduler.StartReporters(session)
 
-	// Logger
-	logFile := logger.InitLogger()
 	log.Info().Msg("alpamon initialized and running.")
 
 	// Commit

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -93,7 +93,7 @@ func runAgent() {
 
 	// Websocket Client
 	wsClient := runner.NewWebsocketClient(session)
-	go wsClient.RunForever()
+	go wsClient.RunForever(ctx)
 
 	select {
 	case <-ctx.Done():
@@ -101,9 +101,11 @@ func runAgent() {
 		break
 	case <-wsClient.ShutDownChan:
 		log.Info().Msg("Shutdown command received. Shutting down...")
+		cancel()
 		break
 	case <-wsClient.RestartChan:
-		log.Info().Msg("Restart requested internally.")
+		log.Info().Msg("Restart command received. Restarting... ")
+		cancel()
 		gracefulShutdown(metricCollector, wsClient, logFile, pidFilePath)
 		restartAgent()
 		return

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -47,10 +47,8 @@ func runAgent() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		select {
-		case <-sigChan:
-			cancel()
-		}
+		<-sigChan
+		cancel()
 	}()
 
 	// Logger

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -192,9 +192,9 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		return 0, "Alpamon will restart in 1 second."
 	case "quit":
 		time.AfterFunc(1*time.Second, func() {
-			cr.wsClient.Quit()
+			cr.wsClient.ShutDown()
 		})
-		return 0, "Alpamon will quit in 1 second."
+		return 0, "Alpamon will shutdown in 1 second."
 	case "reboot":
 		log.Info().Msg("Reboot request received.")
 		time.AfterFunc(1*time.Second, func() {

--- a/pkg/scheduler/session.go
+++ b/pkg/scheduler/session.go
@@ -77,8 +77,7 @@ func (session *Session) CheckSession(ctx context.Context) bool {
 					}
 				}
 			}
-			// time.Sleep(timeout)
-			if timeout == 0 {
+			if timeout == 0 { // first time
 				timeout = config.MinConnectInterval
 			}
 			timeout *= 2

--- a/pkg/scheduler/session.go
+++ b/pkg/scheduler/session.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	checkSessionURL = "/api/servers/servers/-/"
-	MaxRetryTimeout = 3 * 24 * time.Second
+	MaxRetryTimeout = 3 * 24 * time.Hour
 )
 
 func InitSession() *Session {

--- a/pkg/scheduler/session.go
+++ b/pkg/scheduler/session.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	checkSessionURL = "/api/servers/servers/-/"
-	MaxRetryTimeout = 3 * 24 * time.Hour
+	MaxRetryTimeout = 3 * 24 * time.Second
 )
 
 func InitSession() *Session {
@@ -52,40 +52,38 @@ func InitSession() *Session {
 	return session
 }
 
-func (session *Session) CheckSession() bool {
-	timeout := config.MinConnectInterval
-	ctx, cancel := context.WithTimeout(context.Background(), MaxRetryTimeout)
+func (session *Session) CheckSession(ctx context.Context) bool {
+	timeout := 0 * time.Second
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, MaxRetryTimeout)
 	defer cancel()
 
 	for {
 		select {
-		case <-ctx.Done():
-			log.Error().Msg("Maximum retry duration reached. Shutting down.")
+		case <-ctxWithTimeout.Done():
+			log.Error().Msg("Session check cancelled or timed out.")
 			os.Exit(1)
-		default:
-			resp, _, err := session.Get(checkSessionURL, 5)
-			if err != nil {
+		case <-time.After(timeout):
+			resp, statusCode, err := session.Get(checkSessionURL, 5)
+			if err != nil || statusCode != http.StatusOK {
 				log.Debug().Err(err).Msgf("Failed to connect to %s, will try again in %ds", config.GlobalSettings.ServerURL, int(timeout.Seconds()))
-				time.Sleep(timeout)
-				timeout *= 2
-				if timeout > config.MaxConnectInterval {
-					timeout = config.MaxConnectInterval
-				}
-				continue
-			}
-
-			var response map[string]interface{}
-			err = json.Unmarshal(resp, &response)
-			if err != nil {
-				log.Debug().Err(err).Msg("Failed to unmarshal JSON")
-				continue
-			}
-
-			if commissioned, ok := response["commissioned"].(bool); ok {
-				return commissioned
 			} else {
-				log.Error().Msg("Unable to find 'commissioned' field in the response")
-				continue
+				var response map[string]interface{}
+				err = json.Unmarshal(resp, &response)
+				if err != nil {
+					log.Debug().Err(err).Msgf("Failed to unmarshal JSON, will try again in %ds", int(timeout.Seconds()))
+				} else {
+					if commissioned, ok := response["commissioned"].(bool); ok {
+						return commissioned
+					}
+				}
+			}
+			// time.Sleep(timeout)
+			if timeout == 0 {
+				timeout = config.MinConnectInterval
+			}
+			timeout *= 2
+			if timeout > config.MaxConnectInterval {
+				timeout = config.MaxConnectInterval
 			}
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -30,10 +30,12 @@ func getPlatformLike() {
 	system := runtime.GOOS
 
 	switch system {
+	case "darwin":
+		PlatformLike = system
 	case "linux":
 		platformInfo, err := host.Info()
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to get platform information")
+			log.Error().Err(err).Msg("Failed to retrieve platform information.")
 			os.Exit(1)
 		}
 		switch platformInfo.Platform {
@@ -42,19 +44,17 @@ func getPlatformLike() {
 		case "centos", "rhel", "redhat", "amazon", "amzn", "fedora", "rocky", "oracle", "ol":
 			PlatformLike = "rhel"
 		default:
-			log.Fatal().Msgf("Platform %s not supported", platformInfo.Platform)
+			log.Fatal().Msgf("Platform %s not supported.", platformInfo.Platform)
 		}
-	case "windows", "darwin":
-		PlatformLike = system
 	default:
-		log.Fatal().Msgf("Platform %s not supported", system)
+		log.Fatal().Msgf("unsupported os: %s", runtime.GOOS)
 	}
 }
 
 func JoinPath(base string, paths ...string) string {
 	fullURL, err := url.JoinPath(base, paths...)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to join path")
+		log.Error().Err(err).Msg("Failed to join path.")
 		return ""
 	}
 


### PR DESCRIPTION
- Refactor WebSocket client for graceful shutdown
   - Use context to safely handle shutdown and prevent reconnect during termination

- Initialize logger earlier to capture startup logs and minor fix

- Improve CheckSession retry logic with timeout-aware graceful exit