### PR TITLE
Add TCP log server to receive logs from agents

### DIFF
--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -53,10 +53,6 @@ func runAgent() {
 
 	// Logger
 	logFile := logger.InitLogger()
-	logServer := logger.NewLogServer()
-	if logServer != nil {
-		go logServer.StartLogServer()
-	}
 
 	// platform
 	utils.InitPlatform()
@@ -80,6 +76,12 @@ func runAgent() {
 
 	// Reporter
 	scheduler.StartReporters(session)
+
+	// Log server
+	logServer := logger.NewLogServer()
+	if logServer != nil {
+		go logServer.StartLogServer()
+	}
 
 	log.Info().Msg("alpamon initialized and running.")
 

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -53,6 +53,10 @@ func runAgent() {
 
 	// Logger
 	logFile := logger.InitLogger()
+	logServer := logger.NewLogServer()
+	if logServer != nil {
+		go logServer.StartLogServer()
+	}
 
 	// platform
 	utils.InitPlatform()
@@ -104,12 +108,12 @@ func runAgent() {
 	case <-wsClient.RestartChan:
 		log.Info().Msg("Restart command received. Restarting... ")
 		cancel()
-		gracefulShutdown(metricCollector, wsClient, logFile, pidFilePath)
+		gracefulShutdown(metricCollector, wsClient, logFile, logServer, pidFilePath)
 		restartAgent()
 		return
 	}
 
-	gracefulShutdown(metricCollector, wsClient, logFile, pidFilePath)
+	gracefulShutdown(metricCollector, wsClient, logFile, logServer, pidFilePath)
 }
 
 func restartAgent() {
@@ -121,18 +125,23 @@ func restartAgent() {
 
 	err = syscall.Exec(executable, os.Args, os.Environ())
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to restart the program.")
+		log.Error().Err(err).Msg("Failed to restart the alpamon.")
 	}
 }
 
-func gracefulShutdown(collector *collector.Collector, wsClient *runner.WebsocketClient, logFile *os.File, pidPath string) {
+func gracefulShutdown(collector *collector.Collector, wsClient *runner.WebsocketClient, logFile *os.File, logServer *logger.LogServer, pidPath string) {
 	if collector != nil {
 		collector.Stop()
 	}
 	if wsClient != nil {
 		wsClient.Close()
 	}
+	if logServer != nil {
+		logServer.Stop()
+	}
+
 	log.Debug().Msg("Bye.")
+
 	if logFile != nil {
 		_ = logFile.Close()
 	}

--- a/pkg/logger/server.go
+++ b/pkg/logger/server.go
@@ -43,6 +43,9 @@ func (ls *LogServer) StartLogServer() {
 		default:
 			conn, err := ls.listener.Accept()
 			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					return
+				}
 				log.Error().Err(err).Msg("Failed to accept socket.")
 				continue
 			}

--- a/pkg/logger/server.go
+++ b/pkg/logger/server.go
@@ -1,0 +1,98 @@
+package logger
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"github.com/alpacanetworks/alpamon/pkg/scheduler"
+	"github.com/rs/zerolog/log"
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	address = "0.0.0.0:9020"
+)
+
+type LogServer struct {
+	listener     net.Listener
+	shutDownChan chan struct{}
+}
+
+func NewLogServer() *LogServer {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		log.Error().Err(err).Msgf("Log server startup failed: cannot bind to %s.", address)
+		return nil
+	}
+
+	return &LogServer{
+		listener:     listener,
+		shutDownChan: make(chan struct{}),
+	}
+}
+
+func (ls *LogServer) StartLogServer() {
+	log.Debug().Msgf("Started log server on %s", address)
+
+	for {
+		select {
+		case <-ls.shutDownChan:
+			return
+		default:
+			conn, err := ls.listener.Accept()
+			if err != nil {
+				log.Error().Err(err).Msg("Failed to accept socket.")
+				continue
+			}
+			go ls.handleConnection(conn)
+		}
+	}
+}
+
+func (ls *LogServer) handleConnection(conn net.Conn) {
+	for {
+		lengthBuf := make([]byte, 4)
+		_, err := io.ReadFull(conn, lengthBuf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return // connection closed by client, terminating read loop
+			}
+			log.Warn().Err(err).Msg("Couldn't read message length from connection.")
+			return
+		}
+
+		length := binary.BigEndian.Uint32(lengthBuf)
+		body := make([]byte, length)
+		_, err = io.ReadFull(conn, body)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return // connection closed by client, terminating read loop
+			}
+			log.Warn().Err(err).Msg("Failed to read log body.")
+			return
+		}
+
+		var record LogRecord
+		err = json.Unmarshal(body, &record)
+		if err != nil {
+			log.Debug().Err(err).Msg("Failed to unmarshal log record.")
+			continue
+		}
+
+		go ls.handleRecord(record)
+	}
+}
+
+func (ls *LogServer) handleRecord(record LogRecord) {
+	if scheduler.Rqueue == nil {
+		return
+	}
+	scheduler.Rqueue.Post(recordURL, record, 90, time.Time{})
+}
+
+func (ls *LogServer) Stop() {
+	close(ls.shutDownChan)
+	_ = ls.listener.Close()
+}


### PR DESCRIPTION
- Add a TCP socket-based log server to receive logs from agents
- Apply graceful shutdown to the log server
- Improve existing log `Write` logic