### PR TITLE
Resolve "Implement additional features for webftp"

### DIFF
--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -154,7 +154,7 @@ func (fc *FtpClient) handleFtpCommand(command FtpCommand, data FtpData) (Command
 	case Chmod:
 		return fc.chmod(data.Path, data.Mode)
 	case Chown:
-		return fc.chown(data.Path, &data.UID, &data.GID)
+		return fc.chown(data.Path, data.UID, data.GID)
 	default:
 		return CommandResult{}, fmt.Errorf("unknown FTP command: %s", command)
 	}
@@ -440,20 +440,10 @@ func (fc *FtpClient) chmod(path string, mode string) (CommandResult, error) {
 	}, nil
 }
 
-func (fc *FtpClient) chown(path string, uid, gid *int) (CommandResult, error) {
+func (fc *FtpClient) chown(path string, uid, gid int) (CommandResult, error) {
 	path = fc.parsePath(path)
 
-	finalUID := -1
-	if uid != nil {
-		finalUID = *uid
-	}
-
-	finalGID := -1
-	if gid != nil {
-		finalGID = *gid
-	}
-
-	err := os.Chown(path, finalUID, finalGID)
+	err := os.Chown(path, uid, gid)
 	if err != nil {
 		return CommandResult{
 			Message: err.Error(),

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -465,10 +465,24 @@ func (fc *FtpClient) chmod(path string, mode string) (CommandResult, error) {
 	}, nil
 }
 
-func (fc *FtpClient) chown(path string, uid, gid int) (CommandResult, error) {
+func (fc *FtpClient) chown(path, uidStr, gidStr string) (CommandResult, error) {
 	path = fc.parsePath(path)
 
-	err := os.Chown(path, uid, gid)
+	uid, err := strconv.Atoi(uidStr)
+	if err != nil {
+		return CommandResult{
+			Message: err.Error(),
+		}, err
+	}
+
+	gid, err := strconv.Atoi(gidStr)
+	if err != nil {
+		return CommandResult{
+			Message: err.Error(),
+		}, err
+	}
+
+	err = os.Chown(path, uid, gid)
 	if err != nil {
 		return CommandResult{
 			Message: err.Error(),

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/alpacanetworks/alpamon/pkg/logger"
@@ -418,11 +419,16 @@ func (fc *FtpClient) cpFile(src, dst string) (CommandResult, error) {
 	}, nil
 }
 
-func (fc *FtpClient) chmod(path string, mode int) (CommandResult, error) {
+func (fc *FtpClient) chmod(path string, mode string) (CommandResult, error) {
 	path = fc.parsePath(path)
-	fileMode := os.FileMode(mode)
+	fileMode, err := strconv.ParseUint(mode, 8, 32)
+	if err != nil {
+		return CommandResult{
+			Message: err.Error(),
+		}, err
+	}
 
-	err := os.Chmod(path, fileMode)
+	err = os.Chmod(path, os.FileMode(fileMode))
 	if err != nil {
 		return CommandResult{
 			Message: err.Error(),

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -154,7 +154,7 @@ func (fc *FtpClient) handleFtpCommand(command FtpCommand, data FtpData) (Command
 	case Chmod:
 		return fc.chmod(data.Path, data.Mode)
 	case Chown:
-		return fc.chown(data.Path, data.UID, data.GID)
+		return fc.chown(data.Path, &data.UID, &data.GID)
 	default:
 		return CommandResult{}, fmt.Errorf("unknown FTP command: %s", command)
 	}
@@ -440,10 +440,20 @@ func (fc *FtpClient) chmod(path string, mode string) (CommandResult, error) {
 	}, nil
 }
 
-func (fc *FtpClient) chown(path string, uid, gid int) (CommandResult, error) {
+func (fc *FtpClient) chown(path string, uid, gid *int) (CommandResult, error) {
 	path = fc.parsePath(path)
 
-	err := os.Chown(path, uid, gid)
+	finalUID := -1
+	if uid != nil {
+		finalUID = *uid
+	}
+
+	finalGID := -1
+	if gid != nil {
+		finalGID = *gid
+	}
+
+	err := os.Chown(path, finalUID, finalGID)
 	if err != nil {
 		return CommandResult{
 			Message: err.Error(),

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -64,15 +64,19 @@ type FtpResult struct {
 }
 
 type CommandResult struct {
-	Name     string          `json:"name,omitempty"`
-	Type     string          `json:"type,omitempty"`
-	Path     string          `json:"path,omitempty"`
-	Dst      string          `json:"dst,omitempty"`
-	Code     int             `json:"code,omitempty"`
-	Size     int64           `json:"size,omitempty"`
-	Children []CommandResult `json:"children,omitempty"`
-	ModTime  *time.Time      `json:"mod_time,omitempty"`
-	Message  string          `json:"message,omitempty"`
+	Name             string          `json:"name,omitempty"`
+	Type             string          `json:"type,omitempty"`
+	Path             string          `json:"path,omitempty"`
+	Dst              string          `json:"dst,omitempty"`
+	Code             int             `json:"code,omitempty"`
+	Size             int64           `json:"size,omitempty"`
+	Children         []CommandResult `json:"children,omitempty"`
+	ModTime          *time.Time      `json:"mod_time,omitempty"`
+	Message          string          `json:"message,omitempty"`
+	PermissionString string          `json:"permission_str,omitempty"`
+	PermissionOctal  string          `json:"permission_octal,omitempty"`
+	Owner            string          `json:"owner,omitempty"`
+	Group            string          `json:"group,omitempty"`
 }
 
 type returnCode struct {

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -46,7 +46,7 @@ type FtpData struct {
 	ShowHidden bool   `json:"show_hidden,omitempty"`
 	Src        string `json:"src,omitempty"`
 	Dst        string `json:"dst,omitempty"`
-	Mode       int    `json:"mode,omitempty"`
+	Mode       string `json:"mode,omitempty"`
 	UID        int    `json:"uid,omitempty"`
 	GID        int    `json:"gid,omitempty"`
 }

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -47,8 +47,8 @@ type FtpData struct {
 	Src        string `json:"src,omitempty"`
 	Dst        string `json:"dst,omitempty"`
 	Mode       string `json:"mode,omitempty"`
-	UID        int    `json:"uid,omitempty"`
-	GID        int    `json:"gid,omitempty"`
+	UID        string `json:"uid,omitempty"`
+	GID        string `json:"gid,omitempty"`
 }
 
 type FtpContent struct {

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -10,14 +10,16 @@ import (
 type FtpCommand string
 
 const (
-	List FtpCommand = "list"
-	Mkd  FtpCommand = "mkd"
-	Cwd  FtpCommand = "cwd"
-	Pwd  FtpCommand = "pwd"
-	Dele FtpCommand = "dele"
-	Rmd  FtpCommand = "rmd"
-	Mv   FtpCommand = "mv"
-	Cp   FtpCommand = "cp"
+	List  FtpCommand = "list"
+	Mkd   FtpCommand = "mkd"
+	Cwd   FtpCommand = "cwd"
+	Pwd   FtpCommand = "pwd"
+	Dele  FtpCommand = "dele"
+	Rmd   FtpCommand = "rmd"
+	Mv    FtpCommand = "mv"
+	Cp    FtpCommand = "cp"
+	Chmod FtpCommand = "chmod"
+	Chown FtpCommand = "chown"
 )
 
 const (
@@ -44,6 +46,9 @@ type FtpData struct {
 	ShowHidden bool   `json:"show_hidden,omitempty"`
 	Src        string `json:"src,omitempty"`
 	Dst        string `json:"dst,omitempty"`
+	Mode       int    `json:"mode,omitempty"`
+	UID        int    `json:"uid,omitempty"`
+	GID        int    `json:"gid,omitempty"`
 }
 
 type FtpContent struct {
@@ -148,6 +153,24 @@ var returnCodes = map[FtpCommand]returnCode{
 			ErrInvalidArgument:       452,
 			ErrNoSuchFileOrDirectory: 550,
 			ErrFileExists:            552,
+		},
+	},
+	Chmod: {
+		Success: 250,
+		Error: map[string]int{
+			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
+			ErrInvalidArgument:       452,
+			ErrNoSuchFileOrDirectory: 550,
+		},
+	},
+	Chown: {
+		Success: 250,
+		Error: map[string]int{
+			ErrPermissionDenied:      450,
+			ErrOperationNotPermitted: 450,
+			ErrInvalidArgument:       452,
+			ErrNoSuchFileOrDirectory: 550,
 		},
 	},
 }

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 )
 
 func CopyFile(src, dst string) error {
@@ -117,4 +120,28 @@ func FormatPermissions(mode os.FileMode) string {
 	}
 
 	return string(permissions)
+}
+
+func GetFileInfo(info os.FileInfo, path string) (permString, permOctal, owner, group string, err error) {
+	permString = FormatPermissions(info.Mode())
+	permOctal = fmt.Sprintf("%o", info.Mode().Perm())
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", "", "", "", fmt.Errorf("failed to get system stat information")
+	}
+
+	uidStr := strconv.Itoa(int(stat.Uid))
+	gidStr := strconv.Itoa(int(stat.Gid))
+
+	ownerInfo, err := user.LookupId(uidStr)
+	if err != nil {
+		return "", "", "", "", err
+	}
+	groupInfo, err := user.LookupGroupId(gidStr)
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	return permString, permOctal, ownerInfo.Username, groupInfo.Name, nil
 }


### PR DESCRIPTION
As mentioned in https://github.com/alpacanetworks/alpamon/issues/49, implement the following `webftp`'s additional features:
- list command
    - Refactor the list command due to its large logic, improving readability.
    - The following fields have been added to the list command.
        - PermissionString
        - PermissionOctal
        - Owner
        - Group
- chown command
- chmod command

Due to the need for multipart upload to integrate with alpacon, it will be addressed in a separate issue.

Closes #49  