### PR TITLE
Fix write config directly to target file without using temp file

### DIFF
--- a/cmd/alpamon/command/setup/setup.go
+++ b/cmd/alpamon/command/setup/setup.go
@@ -93,26 +93,20 @@ func writeConfig() error {
 		return fmt.Errorf("environment variables ALPACON_URL, PLUGIN_ID, PLUGIN_KEY must be set")
 	}
 
-	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s.conf", name))
-	if err != nil {
-		return fmt.Errorf("failed to create temp file: %v", err)
-	}
-	defer func() { _ = tmpFile.Close() }()
-
-	err = tmpl.Execute(tmpFile, configData)
-	if err != nil {
-		_ = os.Remove(tmpFile.Name())
-		return fmt.Errorf("failed to execute template: %v", err)
-	}
-
 	err = os.MkdirAll(filepath.Dir(configTarget), 0755)
 	if err != nil {
 		return fmt.Errorf("failed to create config directory: %v", err)
 	}
 
-	err = os.Rename(tmpFile.Name(), configTarget)
+	targetFile, err := os.Create(configTarget)
 	if err != nil {
-		return fmt.Errorf("failed to move temp file to target: %v", err)
+		return fmt.Errorf("failed to create target config file: %v", err)
+	}
+	defer func() { _ = targetFile.Close() }()
+
+	err = tmpl.Execute(targetFile, configData)
+	if err != nil {
+		return fmt.Errorf("failed to execute template into target file: %v", err)
 	}
 
 	return nil

--- a/pkg/logger/server.go
+++ b/pkg/logger/server.go
@@ -34,7 +34,7 @@ func NewLogServer() *LogServer {
 }
 
 func (ls *LogServer) StartLogServer() {
-	log.Debug().Msgf("Started log server on %s", address)
+	log.Debug().Msgf("Started log server on %s.", address)
 
 	for {
 		select {


### PR DESCRIPTION
Fix invalid cross device link error by writing config directly to target file