### PR TITLE
Resolve "Refactor the process of initializing collector"

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -52,7 +51,7 @@ func InitCollector(session *session.Session, client *ent.Client) *Collector {
 	conf, err := fetchConfig(session)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to fetch collector config.")
-		os.Exit(1)
+		return nil
 	}
 
 	checkFactory := &check.DefaultCheckFactory{}
@@ -69,7 +68,7 @@ func InitCollector(session *session.Session, client *ent.Client) *Collector {
 	collector, err := NewCollector(args)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create collector.")
-		os.Exit(1)
+		return nil
 	}
 
 	return collector
@@ -81,7 +80,7 @@ func fetchConfig(session *session.Session) ([]collectConf, error) {
 		return nil, err
 	}
 	if statusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get collection config: %d status code.", statusCode)
+		return nil, fmt.Errorf("failed to get collection config: %d status code", statusCode)
 	}
 
 	var conf []collectConf
@@ -135,6 +134,8 @@ func (c *Collector) initTasks(args collectorArgs) error {
 }
 
 func (c *Collector) Start() {
+	log.Debug().Msg("Started collector")
+
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 
 	go c.scheduler.Start(c.ctx, c.buffer.Capacity)

--- a/pkg/collector/transporter/transporter.go
+++ b/pkg/collector/transporter/transporter.go
@@ -55,7 +55,7 @@ func (t *Transporter) Send(data base.MetricData) error {
 		return nil
 	} else {
 		if statusCode == http.StatusBadRequest {
-			return fmt.Errorf("%d Bad Request: %s", statusCode, resp)
+			return nil
 		} else {
 			return fmt.Errorf("%s %s Error: %d %s", http.MethodPost, url, statusCode, resp)
 		}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -181,11 +181,24 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		}
 		return 1, "Invalid session ID"
 	case "restart":
-		time.AfterFunc(1*time.Second, func() {
-			cr.wsClient.Restart()
-		})
+		target := "alpamon"
+		message := "Alpamon will restart in 1 second."
+		if len(args) >= 2 {
+			target = args[1]
+		}
 
-		return 0, "Alpamon will restart in 1 second."
+		switch target {
+		case "collector":
+			log.Info().Msg("Restart collector.")
+			cr.wsClient.RestartCollector()
+			message = "Collector will be restarted."
+		default:
+			time.AfterFunc(1*time.Second, func() {
+				cr.wsClient.Restart()
+			})
+		}
+
+		return 0, message
 	case "quit":
 		time.AfterFunc(1*time.Second, func() {
 			cr.wsClient.ShutDown()

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -218,6 +218,11 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		}
 
 		return cr.handleShellCmd(cmd, "root", "root", nil)
+	case "restartcoll":
+		log.Info().Msg("Restart collector.")
+		cr.wsClient.RestartCollector()
+
+		return 0, "Collector will be restarted."
 	case "help":
 		helpMessage := `
 		Available commands:


### PR DESCRIPTION
As mentioned in https://github.com/alpacanetworks/alpamon/issues/56, refactor collector initialization process.
Additionally, Modify Transporter to not retry metric transmissions when 400 error occurs.

Closes https://github.com/alpacanetworks/alpamon/issues/56