### PR TITLE
Add PTY recovery to maintain session on unexpected disconnects

### DIFF
--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -152,7 +152,6 @@ func (wc *WebsocketClient) Close() {
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 		deadline,
 	)
-
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to write close message to websocket.")
 		return
@@ -212,7 +211,7 @@ func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
 			10,
 			time.Time{},
 		)
-		commandRunner := NewCommandRunner(wc, content.Command, data)
+		commandRunner := NewCommandRunner(wc, wc.apiSession, content.Command, data)
 		go commandRunner.Run()
 	case "quit":
 		log.Debug().Msgf("Quit requested for reason: %s.", content.Reason)

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -68,7 +68,7 @@ func (wc *WebsocketClient) RunForever(ctx context.Context) {
 			}
 			// Sends "ping" query for Alpacon to verify WebSocket session status without error handling.
 			_ = wc.SendPingQuery()
-			wc.CommandRequestHandler(ctx, message)
+			wc.CommandRequestHandler(message)
 		}
 	}
 }
@@ -181,7 +181,7 @@ func (wc *WebsocketClient) Restart() {
 	close(wc.RestartChan)
 }
 
-func (wc *WebsocketClient) CommandRequestHandler(globalCtx context.Context, message []byte) {
+func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
 	var content Content
 	var data CommandData
 

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -68,7 +68,7 @@ func (wc *WebsocketClient) RunForever(ctx context.Context) {
 			}
 			// Sends "ping" query for Alpacon to verify WebSocket session status without error handling.
 			_ = wc.SendPingQuery()
-			wc.CommandRequestHandler(message)
+			wc.CommandRequestHandler(ctx, message)
 		}
 	}
 }
@@ -182,7 +182,7 @@ func (wc *WebsocketClient) Restart() {
 	close(wc.RestartChan)
 }
 
-func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
+func (wc *WebsocketClient) CommandRequestHandler(globalCtx context.Context, message []byte) {
 	var content Content
 	var data CommandData
 
@@ -212,7 +212,7 @@ func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
 			time.Time{},
 		)
 		commandRunner := NewCommandRunner(wc, wc.apiSession, content.Command, data)
-		go commandRunner.Run()
+		go commandRunner.Run(globalCtx)
 	case "quit":
 		log.Debug().Msgf("Quit requested for reason: %s.", content.Reason)
 		wc.ShutDown()

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -146,11 +146,10 @@ func (wc *WebsocketClient) Close() {
 		return
 	}
 
-	deadline := time.Now().Add(5 * time.Second)
 	err := wc.Conn.WriteControl(
 		websocket.CloseMessage,
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
-		deadline,
+		time.Now().Add(5*time.Second),
 	)
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to write close message to websocket.")
@@ -212,7 +211,7 @@ func (wc *WebsocketClient) CommandRequestHandler(globalCtx context.Context, mess
 			time.Time{},
 		)
 		commandRunner := NewCommandRunner(wc, wc.apiSession, content.Command, data)
-		go commandRunner.Run(globalCtx)
+		go commandRunner.Run()
 	case "quit":
 		log.Debug().Msgf("Quit requested for reason: %s.", content.Reason)
 		wc.ShutDown()

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -49,7 +48,7 @@ func NewCommandRunner(wsClient *WebsocketClient, apiSession *scheduler.Session, 
 	}
 }
 
-func (cr *CommandRunner) Run(globalCtx context.Context) {
+func (cr *CommandRunner) Run() {
 	var exitCode int
 	var result string
 
@@ -58,7 +57,7 @@ func (cr *CommandRunner) Run(globalCtx context.Context) {
 	start := time.Now()
 	switch cr.command.Shell {
 	case "internal":
-		exitCode, result = cr.handleInternalCmd(globalCtx)
+		exitCode, result = cr.handleInternalCmd()
 	case "system":
 		exitCode, result = cr.handleShellCmd(cr.command.Line, cr.command.User, cr.command.Group, cr.command.Env)
 	default:
@@ -78,7 +77,7 @@ func (cr *CommandRunner) Run(globalCtx context.Context) {
 	}
 }
 
-func (cr *CommandRunner) handleInternalCmd(globalCtx context.Context) (int, string) {
+func (cr *CommandRunner) handleInternalCmd() (int, string) {
 	args := strings.Fields(cr.command.Line)
 	if len(args) == 0 {
 		return 1, "No command provided"
@@ -151,7 +150,7 @@ func (cr *CommandRunner) handleInternalCmd(globalCtx context.Context) (int, stri
 		}
 
 		ptyClient := NewPtyClient(cr.data, cr.apiSession)
-		go ptyClient.RunPtyBackground(globalCtx)
+		go ptyClient.RunPtyBackground()
 
 		return 0, "Spawned a pty terminal."
 	case "openftp":

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -32,18 +32,19 @@ const (
 	fileUploadTimeout = 60 * 10
 )
 
-func NewCommandRunner(wsClient *WebsocketClient, command Command, data CommandData) *CommandRunner {
+func NewCommandRunner(wsClient *WebsocketClient, apiSession *scheduler.Session, command Command, data CommandData) *CommandRunner {
 	var name string
 	if command.ID != "" {
 		name = fmt.Sprintf("CommandRunner-%s", strings.Split(command.ID, "-")[0])
 	}
 
 	return &CommandRunner{
-		name:      name,
-		command:   command,
-		data:      data,
-		wsClient:  wsClient,
-		validator: validator.New(),
+		name:       name,
+		command:    command,
+		data:       data,
+		wsClient:   wsClient,
+		apiSession: apiSession,
+		validator:  validator.New(),
 	}
 }
 
@@ -148,7 +149,7 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 			return 1, fmt.Sprintf("openpty: Not enough information. %s", err.Error())
 		}
 
-		ptyClient := NewPtyClient(cr.data)
+		ptyClient := NewPtyClient(cr.data, cr.apiSession)
 		go ptyClient.RunPtyBackground()
 
 		return 0, "Spawned a pty terminal."

--- a/pkg/runner/command_types.go
+++ b/pkg/runner/command_types.go
@@ -1,6 +1,9 @@
 package runner
 
-import "gopkg.in/go-playground/validator.v9"
+import (
+	"github.com/alpacanetworks/alpamon/pkg/scheduler"
+	"gopkg.in/go-playground/validator.v9"
+)
 
 type Content struct {
 	Query   string  `json:"query"`
@@ -54,11 +57,12 @@ type CommandData struct {
 }
 
 type CommandRunner struct {
-	name      string
-	command   Command
-	wsClient  *WebsocketClient
-	data      CommandData
-	validator *validator.Validate
+	name       string
+	command    Command
+	wsClient   *WebsocketClient
+	apiSession *scheduler.Session
+	data       CommandData
+	validator  *validator.Validate
 }
 
 // Structs defining the required input data for command validation purposes. //

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -88,7 +88,7 @@ func (pc *PtyClient) initializePtySession() error {
 	return nil
 }
 
-func (pc *PtyClient) RunPtyBackground() {
+func (pc *PtyClient) RunPtyBackground(globalCtx context.Context) {
 	log.Debug().Msg("Opening websocket for pty session.")
 	defer pc.close()
 
@@ -109,6 +109,8 @@ func (pc *PtyClient) RunPtyBackground() {
 
 	for {
 		select {
+		case <-globalCtx.Done():
+			return
 		case <-ctx.Done():
 			return
 		case <-recoveryChan:
@@ -235,6 +237,7 @@ func (pc *PtyClient) resize(rows, cols uint16) error {
 // close terminates the PTY session and cleans up resources.
 // It ensures that the PTY, command, and WebSocket connection are properly closed.
 func (pc *PtyClient) close() {
+	fmt.Println("pty 에서 close 가 호출됨.")
 	if pc.ptmx != nil {
 		_ = pc.ptmx.Close()
 	}

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -88,7 +88,7 @@ func (pc *PtyClient) initializePtySession() error {
 	return nil
 }
 
-func (pc *PtyClient) RunPtyBackground(globalCtx context.Context) {
+func (pc *PtyClient) RunPtyBackground() {
 	log.Debug().Msg("Opening websocket for pty session.")
 	defer pc.close()
 
@@ -109,8 +109,6 @@ func (pc *PtyClient) RunPtyBackground(globalCtx context.Context) {
 
 	for {
 		select {
-		case <-globalCtx.Done():
-			return
 		case <-ctx.Done():
 			return
 		case <-recoveryChan:

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -244,6 +244,10 @@ func (pc *PtyClient) close() {
 		_ = pc.cmd.Wait()
 	}
 
+	if terminals[pc.sessionID] != nil {
+		delete(terminals, pc.sessionID)
+	}
+
 	if pc.conn != nil {
 		err := pc.conn.WriteControl(
 			websocket.CloseMessage,
@@ -259,10 +263,6 @@ func (pc *PtyClient) close() {
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to close pty websocket connection.")
 		}
-	}
-
-	if terminals[pc.sessionID] != nil {
-		delete(terminals, pc.sessionID)
 	}
 
 	log.Debug().Msg("Websocket connection for pty has been closed.")

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -90,12 +90,12 @@ func (pc *PtyClient) initializePtySession() error {
 
 func (pc *PtyClient) RunPtyBackground() {
 	log.Debug().Msg("Opening websocket for pty session.")
+	defer pc.close()
 
 	err := pc.initializePtySession()
 	if err != nil {
 		return
 	}
-	defer pc.close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -235,7 +235,6 @@ func (pc *PtyClient) resize(rows, cols uint16) error {
 // close terminates the PTY session and cleans up resources.
 // It ensures that the PTY, command, and WebSocket connection are properly closed.
 func (pc *PtyClient) close() {
-	fmt.Println("pty 에서 close 가 호출됨.")
 	if pc.ptmx != nil {
 		_ = pc.ptmx.Close()
 	}

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -269,7 +269,7 @@ func (pc *PtyClient) close() {
 }
 
 // recovery reconnects the WebSocket while keeping the PTY session alive.
-// Note: recovery don't close the existing conn explicitly to avoid breaking the session.
+// Note: recovery doesn't close the existing conn explicitly to avoid breaking the session.
 // The goal is to replace a broken connection, not perform a graceful shutdown.
 func (pc *PtyClient) recovery() error {
 	data := map[string]interface{}{
@@ -293,7 +293,7 @@ func (pc *PtyClient) recovery() error {
 
 	err = json.Unmarshal(body, &resp)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to parse response when reissuing pty websocket url.")
+		log.Error().Err(err).Msg("Failed to parse pty websocket reissue response.")
 		return err
 	}
 
@@ -301,7 +301,7 @@ func (pc *PtyClient) recovery() error {
 	// Assign to pc.conn only if reconnect succeeds to avoid nil panic in concurrent reads/writes.
 	tempConn, _, err := websocket.DefaultDialer.Dial(pc.url, pc.requestHeader)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to reconnect to pty websocket after recovery.")
+		log.Error().Err(err).Msg("Failed to reconnect to pty websocket during recovery.")
 		return err
 	}
 	pc.conn = tempConn

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -298,11 +298,13 @@ func (pc *PtyClient) recovery() error {
 	}
 
 	pc.url = strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1) + resp.WebsocketURL
-	pc.conn, _, err = websocket.DefaultDialer.Dial(pc.url, pc.requestHeader)
+	// Assign to pc.conn only if reconnect succeeds to avoid nil panic in concurrent reads/writes.
+	tempConn, _, err := websocket.DefaultDialer.Dial(pc.url, pc.requestHeader)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to reconnect to pty websocket after recovery.")
 		return err
 	}
+	pc.conn = tempConn
 
 	return nil
 }

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -2,9 +2,11 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/alpacanetworks/alpamon/pkg/config"
+	"github.com/alpacanetworks/alpamon/pkg/scheduler"
 	"github.com/alpacanetworks/alpamon/pkg/utils"
 	"github.com/creack/pty"
 	"github.com/gorilla/websocket"
@@ -15,11 +17,13 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
 type PtyClient struct {
 	conn          *websocket.Conn
+	apiSession    *scheduler.Session
 	requestHeader http.Header
 	cmd           *exec.Cmd
 	ptmx          *os.File
@@ -30,7 +34,10 @@ type PtyClient struct {
 	groupname     string
 	homeDirectory string
 	sessionID     string
+	isRecovering  atomic.Bool // default : false
 }
+
+const reissuePtyWebsocketURL = "/api/websh/pty-channels/"
 
 var terminals map[string]*PtyClient
 
@@ -38,13 +45,14 @@ func init() {
 	terminals = make(map[string]*PtyClient)
 }
 
-func NewPtyClient(data CommandData) *PtyClient {
+func NewPtyClient(data CommandData, apiSession *scheduler.Session) *PtyClient {
 	headers := http.Header{
 		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, config.GlobalSettings.ID, config.GlobalSettings.Key)},
 		"Origin":        {config.GlobalSettings.ServerURL},
 	}
 
 	return &PtyClient{
+		apiSession:    apiSession,
 		requestHeader: headers,
 		url:           strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1) + data.URL,
 		rows:          data.Rows,
@@ -56,50 +64,69 @@ func NewPtyClient(data CommandData) *PtyClient {
 	}
 }
 
-func (pc *PtyClient) RunPtyBackground() {
-	log.Debug().Msg("Opening websocket for pty session.")
-
+func (pc *PtyClient) initializePtySession() error {
 	var err error
 	pc.conn, _, err = websocket.DefaultDialer.Dial(pc.url, pc.requestHeader)
 	if err != nil {
-		log.Error().Err(err).Msgf("Failed to connect to pty websocket at %s.", pc.url)
+		return fmt.Errorf("failed to connect pty websocket: %w", err)
+	}
+
+	pc.cmd = exec.Command("/bin/bash", "-i")
+	uid, gid, groupIds, env, err := pc.getPtyUserAndEnv()
+	if err != nil {
+		return fmt.Errorf("failed to get user/env: %w", err)
+	}
+	pc.setPtyCmdSysProcAttrAndEnv(uid, gid, groupIds, env)
+
+	initialSize := &pty.Winsize{Rows: pc.rows, Cols: pc.cols}
+	pc.ptmx, err = pty.StartWithSize(pc.cmd, initialSize)
+	if err != nil {
+		return fmt.Errorf("failed to start pty: %w", err)
+	}
+
+	terminals[pc.sessionID] = pc
+	return nil
+}
+
+func (pc *PtyClient) RunPtyBackground() {
+	log.Debug().Msg("Opening websocket for pty session.")
+
+	err := pc.initializePtySession()
+	if err != nil {
 		return
 	}
 	defer pc.close()
 
-	pc.cmd = exec.Command("/bin/bash", "-i")
-
-	uid, gid, groupIds, env, err := pc.getPtyUserAndEnv()
-	if err != nil {
-		log.Error().Err(err).Msgf("Failed to get pty user and env.")
-		return
-	}
-
-	pc.setPtyCmdSysProcAttrAndEnv(uid, gid, groupIds, env)
-
-	initialSize := &pty.Winsize{
-		Rows: pc.rows,
-		Cols: pc.cols,
-	}
-
-	pc.ptmx, err = pty.StartWithSize(pc.cmd, initialSize)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to start pty.")
-		return
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go pc.readFromWebsocket(ctx, cancel)
-	go pc.readFromPTY(ctx, cancel)
+	recoveryChan := make(chan struct{}, 1)
+	recoveredWsChan := make(chan struct{}, 1)
+	recoveredPtyChan := make(chan struct{}, 1)
 
-	terminals[pc.sessionID] = pc
+	go pc.readFromWebsocket(ctx, cancel, recoveryChan, recoveredWsChan)
+	go pc.readFromPTY(ctx, cancel, recoveryChan, recoveredPtyChan)
 
-	<-ctx.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-recoveryChan:
+			log.Debug().Msg("Attempting to reconnect pty websocket...")
+			err = pc.recovery()
+			pc.isRecovering.Store(false)
+			if err != nil {
+				cancel()
+				return
+			}
+			log.Debug().Msg("Pty websocket reconnected successfully.")
+			recoveredWsChan <- struct{}{}
+			recoveredPtyChan <- struct{}{}
+		}
+	}
 }
 
-func (pc *PtyClient) readFromWebsocket(ctx context.Context, cancel context.CancelFunc) {
+func (pc *PtyClient) readFromWebsocket(ctx context.Context, cancel context.CancelFunc, recoveryChan, recoveredChan chan struct{}) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -111,11 +138,22 @@ func (pc *PtyClient) readFromWebsocket(ctx context.Context, cancel context.Cance
 				if ctx.Err() != nil {
 					return
 				}
-				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-					log.Debug().Err(err).Msg("Failed to read from pty websocket.")
+
+				if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					log.Debug().Msg("Pty websocket connection closed by peer.")
+					cancel()
+					return
 				}
-				cancel()
-				return
+
+				if pc.isRecovering.CompareAndSwap(false, true) {
+					recoveryChan <- struct{}{}
+				}
+				select {
+				case <-recoveredChan:
+					continue
+				case <-ctx.Done():
+					return
+				}
 			}
 			_, err = pc.ptmx.Write(message)
 			if err != nil {
@@ -133,7 +171,7 @@ func (pc *PtyClient) readFromWebsocket(ctx context.Context, cancel context.Cance
 	}
 }
 
-func (pc *PtyClient) readFromPTY(ctx context.Context, cancel context.CancelFunc) {
+func (pc *PtyClient) readFromPTY(ctx context.Context, cancel context.CancelFunc, recoveryChan, recoveredChan chan struct{}) {
 	buf := make([]byte, 2048)
 
 	for {
@@ -159,11 +197,21 @@ func (pc *PtyClient) readFromPTY(ctx context.Context, cancel context.CancelFunc)
 				if ctx.Err() != nil {
 					return
 				}
-				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-					log.Debug().Err(err).Msg("Failed to write to pty.")
+				if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					log.Debug().Msg("Pty websocket connection closed by peer.")
+					cancel()
+					return
 				}
-				cancel()
-				return
+
+				if pc.isRecovering.CompareAndSwap(false, true) {
+					recoveryChan <- struct{}{}
+				}
+				select {
+				case <-recoveredChan:
+					continue
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}
@@ -218,6 +266,45 @@ func (pc *PtyClient) close() {
 	}
 
 	log.Debug().Msg("Websocket connection for pty has been closed.")
+}
+
+// recovery reconnects the WebSocket while keeping the PTY session alive.
+// Note: recovery don't close the existing conn explicitly to avoid breaking the session.
+// The goal is to replace a broken connection, not perform a graceful shutdown.
+func (pc *PtyClient) recovery() error {
+	data := map[string]interface{}{
+		"session": pc.sessionID,
+	}
+	body, statusCode, err := pc.apiSession.Post(reissuePtyWebsocketURL, data, 5)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to request pty websocket reissue.")
+		return err
+	}
+
+	if statusCode != http.StatusCreated {
+		err = fmt.Errorf("unexpected status code: %d", statusCode)
+		log.Error().Err(err).Msg("Failed to request pty websocket reissue.")
+		return err
+	}
+
+	var resp struct {
+		WebsocketURL string `json:"websocket_url"`
+	}
+
+	err = json.Unmarshal(body, &resp)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to parse response when reissuing pty websocket url.")
+		return err
+	}
+
+	pc.url = strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1) + resp.WebsocketURL
+	pc.conn, _, err = websocket.DefaultDialer.Dial(pc.url, pc.requestHeader)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to reconnect to pty websocket after recovery.")
+		return err
+	}
+
+	return nil
 }
 
 // getPtyUserAndEnv retrieves user information and sets environment variables.


### PR DESCRIPTION
This adds a recovery mechanism to re-establish the PTY WebSocket connection after unexpected termination, allowing sessions to persist.

Other improvements:
- Refined WebSocket and PTY WebSocket close logic