### PR TITLE
feat: Add internal `chmod` command

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -672,12 +672,6 @@ func (cr *CommandRunner) openFtp(data openFtpData) error {
 	return nil
 }
 
-// chmodCmdData holds the validated arguments for the chmod command.
-type chmodCmdData struct {
-	Mode string `validate:"required"`
-	Path string `validate:"required"`
-}
-
 // chmod changes the permissions of a file or directory.
 // It takes mode (e.g., "755", "u+x") and path as arguments.
 func (cr *CommandRunner) chmod(mode string, path string) (exitCode int, result string) {
@@ -696,20 +690,10 @@ func (cr *CommandRunner) chmod(mode string, path string) (exitCode int, result s
 			}
 			return 1, fmt.Sprintf("chmod: Invalid arguments. %s", strings.Join(fieldErrors, "; "))
 		}
-		return 1, fmt.Sprintf("chmod: Invalid arguments. %s", err.Error())
+		return 1, fmt.Sprintf("chmod: Invalid arguments. %v", err)
 	}
 
-	var cmdArgs []string
-
-	if utils.PlatformLike == "debian" || utils.PlatformLike == "rhel" || utils.PlatformLike == "darwin" {
-		cmdArgs = []string{"/bin/chmod", data.Mode, data.Path}
-	} else { 
-		// For other OS like Windows, we would add specific implementations here
-		// Even though the command might be the same for some platforms,
-		// we use if-else statements to allow for future OS-specific implementations
-		return 1, fmt.Sprintf("chmod: Platform '%s' is not currently supported for the chmod operation.", utils.PlatformLike)
-	}
-
+	cmdArgs := []string{"/bin/chmod", data.Mode, data.Path}
 	exitCode, cmdResult := runCmdWithOutput(cmdArgs, "root", "", nil, 60)
 	if exitCode != 0 {
 		return exitCode, fmt.Sprintf("chmod: Failed to change permissions for '%s' to '%s' on platform '%s'. Exit code: %d, Output: %s", data.Path, data.Mode, utils.PlatformLike, exitCode, cmdResult)

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -125,6 +125,13 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		return cr.delGroup()
 	case "ping":
 		return 0, time.Now().Format(time.RFC3339)
+	case "chmod":
+		if len(args) < 3 {
+			return 1, "chmod: Insufficient arguments. Usage: chmod <mode> <path/file>"
+		}
+		mode := args[1]
+		path := args[2]
+		return cr.chmod(mode, path)
 	//case "debug":
 	//	TODO : getReporterStats()
 	case "download":
@@ -240,6 +247,7 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 	case "help":
 		helpMessage := `
 		Available commands:
+		chmod <mode> <path>: change file/directory permissions
 		package install <package name>: install a system package
 		package uninstall <package name>: remove a system package
 		upgrade: upgrade alpamon
@@ -663,6 +671,52 @@ func (cr *CommandRunner) openFtp(data openFtpData) error {
 	}
 
 	return nil
+}
+
+// chmodCmdData holds the validated arguments for the chmod command.
+type chmodCmdData struct {
+	Mode string `validate:"required"`
+	Path string `validate:"required"`
+}
+
+// chmod changes the permissions of a file or directory.
+// It takes mode (e.g., "755", "u+x") and path as arguments.
+func (cr *CommandRunner) chmod(mode string, path string) (exitCode int, result string) {
+	data := chmodCmdData{
+		Mode: mode,
+		Path: path,
+	}
+
+	err := cr.validateData(data)
+	if err != nil {
+		var validationErrors validator.ValidationErrors
+		if errors.As(err, &validationErrors) {
+			var fieldErrors []string
+			for _, fe := range validationErrors {
+				fieldErrors = append(fieldErrors, fmt.Sprintf("field '%s' failed on the '%s' tag (value: '%v')", fe.Field(), fe.Tag(), fe.Value()))
+			}
+			return 1, fmt.Sprintf("chmod: Invalid arguments. %s", strings.Join(fieldErrors, "; "))
+		}
+		return 1, fmt.Sprintf("chmod: Invalid arguments. %s", err.Error())
+	}
+
+	var cmdArgs []string
+
+	if utils.PlatformLike == "debian" || utils.PlatformLike == "rhel" || utils.PlatformLike == "darwin" {
+		cmdArgs = []string{"/bin/chmod", data.Mode, data.Path}
+	} else { 
+		// For other OS like Windows, we would add specific implementations here
+		// Even though the command might be the same for some platforms,
+		// we use if-else statements to allow for future OS-specific implementations
+		return 1, fmt.Sprintf("chmod: Platform '%s' is not currently supported for the chmod operation.", utils.PlatformLike)
+	}
+
+	exitCode, cmdResult := runCmdWithOutput(cmdArgs, "root", "", nil, 60)
+	if exitCode != 0 {
+		return exitCode, fmt.Sprintf("chmod: Failed to change permissions for '%s' to '%s' on platform '%s'. Exit code: %d, Output: %s", data.Path, data.Mode, utils.PlatformLike, exitCode, cmdResult)
+	}
+
+	return 0, fmt.Sprintf("Successfully changed permissions for '%s' to '%s' on platform '%s'.", data.Path, data.Mode, utils.PlatformLike)
 }
 
 func getFileData(data CommandData) ([]byte, error) {

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -247,7 +247,6 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 	case "help":
 		helpMessage := `
 		Available commands:
-		chmod <mode> <path>: change file/directory permissions
 		package install <package name>: install a system package
 		package uninstall <package name>: remove a system package
 		upgrade: upgrade alpamon

--- a/pkg/runner/command_types.go
+++ b/pkg/runner/command_types.go
@@ -143,3 +143,9 @@ var nonZipExt = map[string]bool{
 	".nupkg": true,
 	".kmz":   true,
 }
+
+// chmodCmdData holds the validated arguments for the chmod command.
+type chmodCmdData struct {
+	Mode string `validate:"required"`
+	Path string `validate:"required"`
+}


### PR DESCRIPTION
**Description:**

This PR introduces a new internal command `chmod` to allow changing file and directory permissions.

**Key Changes:**

*   **New Internal Command:** Added `chmod <mode> <path>` to the list of available internal commands.
    *   Handles argument parsing and validation for `mode` and `path`.
*   **`chmod` Functionality:**
    *   Implemented the `chmod(mode string, path string)` function in `pkg/runner/command.go`.
    *   This function validates the provided mode and path.
    *   Executes the `/bin/chmod` command as the `root` user.
    *   Currently supports Debian, RHEL, and Darwin platforms by using the standard `/bin/chmod`. The structure allows for future expansion to other operating systems.

**How to Use:**

The command can be invoked via the agent's command execution mechanism:
`chmod <numeric_mode_or_symbolic_mode> <target_filepath_or_directorypath>`

Examples:
*   `chmod 755 /tmp/testfile.txt`
*   `chmod u+x /opt/myscript.sh`

This addition enhances the agent's capabilities by providing a direct way to manage file system permissions.