### PR TITLE
Add HomeDirectoryPermission to addUser and CommandData structs

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -125,13 +125,6 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		return cr.delGroup()
 	case "ping":
 		return 0, time.Now().Format(time.RFC3339)
-	case "chmod":
-		if len(args) < 3 {
-			return 1, "chmod: Insufficient arguments. Usage: chmod <mode> <path/file>"
-		}
-		mode := args[1]
-		path := args[2]
-		return cr.chmod(mode, path)
 	//case "debug":
 	//	TODO : getReporterStats()
 	case "download":
@@ -323,13 +316,14 @@ func (cr *CommandRunner) sync(keys []string) {
 
 func (cr *CommandRunner) addUser() (exitCode int, result string) {
 	data := addUserData{
-		Username:      cr.data.Username,
-		UID:           cr.data.UID,
-		GID:           cr.data.GID,
-		Comment:       cr.data.Comment,
-		HomeDirectory: cr.data.HomeDirectory,
-		Shell:         cr.data.Shell,
-		Groupname:     cr.data.Groupname,
+		Username:                cr.data.Username,
+		UID:                     cr.data.UID,
+		GID:                     cr.data.GID,
+		Comment:                 cr.data.Comment,
+		HomeDirectory:           cr.data.HomeDirectory,
+		HomeDirectoryPermission: cr.data.HomeDirectoryPermission,
+		Shell:                   cr.data.Shell,
+		Groupname:               cr.data.Groupname,
 	}
 
 	err := cr.validateData(data)
@@ -397,6 +391,16 @@ func (cr *CommandRunner) addUser() (exitCode int, result string) {
 		}
 	} else {
 		return 1, "Not implemented 'adduser' command for this platform."
+	}
+
+	exitCode, result = runCmdWithOutput(
+		[]string{
+			"chmod", cr.data.HomeDirectoryPermission, cr.data.HomeDirectory,
+		},
+		"root", "", nil, 60,
+	)
+	if exitCode != 0 {
+		return exitCode, result
 	}
 
 	cr.sync([]string{"groups", "users"})
@@ -670,36 +674,6 @@ func (cr *CommandRunner) openFtp(data openFtpData) error {
 	}
 
 	return nil
-}
-
-// chmod changes the permissions of a file or directory.
-// It takes mode (e.g., "755", "u+x") and path as arguments.
-func (cr *CommandRunner) chmod(mode string, path string) (exitCode int, result string) {
-	data := chmodCmdData{
-		Mode: mode,
-		Path: path,
-	}
-
-	err := cr.validateData(data)
-	if err != nil {
-		var validationErrors validator.ValidationErrors
-		if errors.As(err, &validationErrors) {
-			var fieldErrors []string
-			for _, fe := range validationErrors {
-				fieldErrors = append(fieldErrors, fmt.Sprintf("field '%s' failed on the '%s' tag (value: '%v')", fe.Field(), fe.Tag(), fe.Value()))
-			}
-			return 1, fmt.Sprintf("chmod: Invalid arguments. %s", strings.Join(fieldErrors, "; "))
-		}
-		return 1, fmt.Sprintf("chmod: Invalid arguments. %v", err)
-	}
-
-	cmdArgs := []string{"/bin/chmod", data.Mode, data.Path}
-	exitCode, cmdResult := runCmdWithOutput(cmdArgs, "root", "", nil, 60)
-	if exitCode != 0 {
-		return exitCode, fmt.Sprintf("chmod: Failed to change permissions for '%s' to '%s' on platform '%s'. Exit code: %d, Output: %s", data.Path, data.Mode, utils.PlatformLike, exitCode, cmdResult)
-	}
-
-	return 0, fmt.Sprintf("Successfully changed permissions for '%s' to '%s' on platform '%s'.", data.Path, data.Mode, utils.PlatformLike)
 }
 
 func getFileData(data CommandData) ([]byte, error) {

--- a/pkg/runner/command_types.go
+++ b/pkg/runner/command_types.go
@@ -33,27 +33,28 @@ type File struct {
 }
 
 type CommandData struct {
-	SessionID      string   `json:"session_id"`
-	URL            string   `json:"url"`
-	Rows           uint16   `json:"rows"`
-	Cols           uint16   `json:"cols"`
-	Username       string   `json:"username"`
-	Groupname      string   `json:"groupname"`
-	HomeDirectory  string   `json:"home_directory"`
-	UID            uint64   `json:"uid"`
-	GID            uint64   `json:"gid"`
-	Comment        string   `json:"comment"`
-	Shell          string   `json:"shell"`
-	Groups         []uint64 `json:"groups"`
-	Type           string   `json:"type"`
-	Content        string   `json:"content"`
-	Path           string   `json:"path"`
-	Paths          []string `json:"paths"`
-	Files          []File   `json:"files,omitempty"`
-	AllowOverwrite bool     `json:"allow_overwrite,omitempty"`
-	AllowUnzip     bool     `json:"allow_unzip,omitempty"`
-	UseBlob        bool     `json:"use_blob,omitempty"`
-	Keys           []string `json:"keys"`
+	SessionID               string   `json:"session_id"`
+	URL                     string   `json:"url"`
+	Rows                    uint16   `json:"rows"`
+	Cols                    uint16   `json:"cols"`
+	Username                string   `json:"username"`
+	Groupname               string   `json:"groupname"`
+	HomeDirectory           string   `json:"home_directory"`
+	HomeDirectoryPermission string   `json:"home_directory_permission"`
+	UID                     uint64   `json:"uid"`
+	GID                     uint64   `json:"gid"`
+	Comment                 string   `json:"comment"`
+	Shell                   string   `json:"shell"`
+	Groups                  []uint64 `json:"groups"`
+	Type                    string   `json:"type"`
+	Content                 string   `json:"content"`
+	Path                    string   `json:"path"`
+	Paths                   []string `json:"paths"`
+	Files                   []File   `json:"files,omitempty"`
+	AllowOverwrite          bool     `json:"allow_overwrite,omitempty"`
+	AllowUnzip              bool     `json:"allow_unzip,omitempty"`
+	UseBlob                 bool     `json:"use_blob,omitempty"`
+	Keys                    []string `json:"keys"`
 }
 
 type CommandRunner struct {
@@ -68,13 +69,14 @@ type CommandRunner struct {
 // Structs defining the required input data for command validation purposes. //
 
 type addUserData struct {
-	Username      string `validate:"required"`
-	UID           uint64 `validate:"required"`
-	GID           uint64 `validate:"required"`
-	Comment       string `validate:"required"`
-	HomeDirectory string `validate:"required"`
-	Shell         string `validate:"required"`
-	Groupname     string `validate:"required"`
+	Username                string `validate:"required"`
+	UID                     uint64 `validate:"required"`
+	GID                     uint64 `validate:"required"`
+	Comment                 string `validate:"required"`
+	HomeDirectory           string `validate:"required"`
+	HomeDirectoryPermission string `validate:"required"`
+	Shell                   string `validate:"required"`
+	Groupname               string `validate:"required"`
 }
 
 type addGroupData struct {
@@ -142,10 +144,4 @@ var nonZipExt = map[string]bool{
 	".ipk":   true,
 	".nupkg": true,
 	".kmz":   true,
-}
-
-// chmodCmdData holds the validated arguments for the chmod command.
-type chmodCmdData struct {
-	Mode string `validate:"required"`
-	Path string `validate:"required"`
 }


### PR DESCRIPTION
## Integrate Home Directory Permissions into addUser Command

### Description
This PR streamlines the file permission workflow by integrating home directory permission setting directly into the user creation process. It removes the standalone `chmod` command in favor of a more integrated approach.

### Changes
- **Added `HomeDirectoryPermission` field**:
  - Added to `CommandData` struct to receive permission setting from API
  - Added to `addUserData` struct for validation and processing
  
- **Enhanced `addUser` function**:
  - Updated to set home directory permissions immediately after user creation
  - Added explicit chmod command execution as root user with proper error handling
  
- **Removed standalone `chmod` command**:
  - Removed the `chmod` case from `handleInternalCmd` function
  - Removed `chmod` function and its supporting `chmodCmdData` struct
  - Removed `chmod` command from help message documentation
