### PR TITLE
Fix .goreleaser.yaml & install_atlas.sh

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,65 +57,6 @@ nfpms:
         dst: "/etc/alpamon/{{ .ProjectName }}.config.tmpl"
 
       - src: "configs/{{ .ProjectName }}.service"
-version: 2
-
-project_name: alpamon
-
-before:
-  hooks:
-    - go run -mod=mod entgo.io/ent/cmd/ent@v0.14.0 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
-    - go mod tidy
-    - chmod +x ./scripts/install_atlas.sh
-
-builds:
-  - main: ./cmd/alpamon
-    binary: alpamon
-    ldflags:
-      - -s -w -X github.com/alpacanetworks/alpamon/pkg/version.Version={{.Version}}
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - arm64
-    hooks:
-      post:
-        - ./scripts/install_atlas.sh {{ .Arch }}
-
-checksum:
-  name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.sha256"
-
-archives:
-  - id: alpamon
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
-    files:
-      - src: bin/atlas-{{ .Arch }}
-        dst: usr/local/bin/atlas
-
-nfpms:
-  - package_name: alpamon
-    maintainer: Younghwan Kim <yh.kim@alpacax.com>
-    description: Alpamon
-    homepage: https://github.com/alpacanetworks/alpamon
-    license: MIT
-    vendor: AlpacaX
-    formats:
-      - deb
-      - rpm
-    dependencies:
-      - zip
-      - sqlite3
-    bindir: /usr/local/bin/
-
-    contents:
-      - src: "configs/tmpfile.conf"
-        dst: "/usr/lib/tmpfiles.d/{{ .ProjectName }}.conf"
-
-      - src: "configs/{{ .ProjectName }}.conf"
-        dst: "/etc/alpamon/{{ .ProjectName }}.config.tmpl"
-
-      - src: "configs/{{ .ProjectName }}.service"
         dst: "/lib/systemd/system/{{ .ProjectName }}.service"
 
       - src: "configs/{{ .ProjectName }}-restart.service"
@@ -123,7 +64,7 @@ nfpms:
 
       - src: "configs/{{ .ProjectName }}-restart.timer"
         dst: "/lib/systemd/system/{{ .ProjectName }}-restart.timer"
-
+      
       - src: "bin/atlas-{{ .Arch }}"
         dst: "/usr/local/bin/atlas"
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,9 +20,32 @@ builds:
     goarch:
       - amd64
       - arm64
+"~/Downloads/.goreleaser.yaml" 81L, 2015B
+version: 2
+
+project_name: alpamon
+
+before:
+  hooks:
+    - go run -mod=mod entgo.io/ent/cmd/ent@v0.14.0 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
+    - go mod tidy
+    - chmod +x ./scripts/install_atlas.sh
+
+builds:
+  - main: ./cmd/alpamon
+    binary: alpamon
+    ldflags:
+      - -s -w -X github.com/alpacanetworks/alpamon/pkg/version.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
     hooks:
-      pre: 
-        - ./scripts/install_atlas.sh
+      post:
+        - ./scripts/install_atlas.sh {{ .Arch }}
 
 checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.sha256"
@@ -31,7 +54,66 @@ archives:
   - id: alpamon
     name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     files:
-      - src: bin/atlas
+      - src: bin/atlas-{{ .Arch }}
+        dst: usr/local/bin/atlas
+
+nfpms:
+  - package_name: alpamon
+    maintainer: Younghwan Kim <yh.kim@alpacax.com>
+    description: Alpamon
+    homepage: https://github.com/alpacanetworks/alpamon
+    license: MIT
+    vendor: AlpacaX
+    formats:
+      - deb
+      - rpm
+    dependencies:
+      - zip
+      - sqlite3
+    bindir: /usr/local/bin/
+
+    contents:
+      - src: "configs/tmpfile.conf"
+        dst: "/usr/lib/tmpfiles.d/{{ .ProjectName }}.conf"
+
+      - src: "configs/{{ .ProjectName }}.conf"
+        dst: "/etc/alpamon/{{ .ProjectName }}.config.tmpl"
+
+      - src: "configs/{{ .ProjectName }}.service"
+version: 2
+
+project_name: alpamon
+
+before:
+  hooks:
+    - go run -mod=mod entgo.io/ent/cmd/ent@v0.14.0 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
+    - go mod tidy
+    - chmod +x ./scripts/install_atlas.sh
+
+builds:
+  - main: ./cmd/alpamon
+    binary: alpamon
+    ldflags:
+      - -s -w -X github.com/alpacanetworks/alpamon/pkg/version.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    hooks:
+      post:
+        - ./scripts/install_atlas.sh {{ .Arch }}
+
+checksum:
+  name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.sha256"
+
+archives:
+  - id: alpamon
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    files:
+      - src: bin/atlas-{{ .Arch }}
         dst: usr/local/bin/atlas
 
 nfpms:
@@ -64,8 +146,8 @@ nfpms:
 
       - src: "configs/{{ .ProjectName }}-restart.timer"
         dst: "/lib/systemd/system/{{ .ProjectName }}-restart.timer"
-      
-      - src: "bin/atlas"
+
+      - src: "bin/atlas-{{ .Arch }}"
         dst: "/usr/local/bin/atlas"
 
     scripts:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,29 +20,6 @@ builds:
     goarch:
       - amd64
       - arm64
-"~/Downloads/.goreleaser.yaml" 81L, 2015B
-version: 2
-
-project_name: alpamon
-
-before:
-  hooks:
-    - go run -mod=mod entgo.io/ent/cmd/ent@v0.14.0 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
-    - go mod tidy
-    - chmod +x ./scripts/install_atlas.sh
-
-builds:
-  - main: ./cmd/alpamon
-    binary: alpamon
-    ldflags:
-      - -s -w -X github.com/alpacanetworks/alpamon/pkg/version.Version={{.Version}}
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - arm64
     hooks:
       post:
         - ./scripts/install_atlas.sh {{ .Arch }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,6 @@ before:
     - go run -mod=mod entgo.io/ent/cmd/ent@v0.14.0 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
     - go mod tidy
     - chmod +x ./scripts/install_atlas.sh
-    - ./scripts/install_atlas.sh
 
 builds:
   - main: ./cmd/alpamon
@@ -21,6 +20,9 @@ builds:
     goarch:
       - amd64
       - arm64
+    hooks:
+      pre: 
+        - ./scripts/install_atlas.sh
 
 checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.sha256"

--- a/scripts/install_atlas.sh
+++ b/scripts/install_atlas.sh
@@ -2,12 +2,12 @@
 
 mkdir -p bin
 
-ARCH=${GOARCH}
+ARCH=$1
 
 if [ "$ARCH" = "amd64" ]; then
-  curl -L -o bin/atlas https://release.ariga.io/atlas/atlas-community-linux-amd64-latest
+  curl -L -o "bin/atlas-$ARCH" https://release.ariga.io/atlas/atlas-linux-amd64-latest
 elif [ "$ARCH" = "arm64" ]; then
-  curl -L -o bin/atlas https://release.ariga.io/atlas/atlas-community-linux-arm64-latest
+  curl -L -o "bin/atlas-$ARCH" https://release.ariga.io/atlas/atlas-linux-arm64-latest
 fi
 
-chmod +x bin/atlas
+chmod +x "bin/atlas-$ARCH"

--- a/scripts/install_atlas.sh
+++ b/scripts/install_atlas.sh
@@ -2,11 +2,11 @@
 
 mkdir -p bin
 
-ARCH=$(uname -m)
+ARCH=${GOARCH}
 
-if [ "$ARCH" = "x86_64" ]; then
+if [ "$ARCH" = "amd64" ]; then
   curl -L -o bin/atlas https://release.ariga.io/atlas/atlas-community-linux-amd64-latest
-elif [ "$ARCH" = "aarch64" ]; then
+elif [ "$ARCH" = "arm64" ]; then
   curl -L -o bin/atlas https://release.ariga.io/atlas/atlas-community-linux-arm64-latest
 fi
 


### PR DESCRIPTION
There was an issue with the existing `.goreleaser.yaml` and `install_atlas.sh` where Linux packages were built based on the CPU architecture of the host building the Linux package, rather than being packaged according to the target `GOARCH`.

To resolve this, fix `.goreleaser.yaml` and `install_atlas.sh` so that Atlas CLI corresponding to the built `GOARCH` is installed.