### PR TITLE
feat: make HomeDirectoryPermission optional for addUser 

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -393,9 +393,14 @@ func (cr *CommandRunner) addUser() (exitCode int, result string) {
 		return 1, "Not implemented 'adduser' command for this platform."
 	}
 
+	// Set default permission for home directory if not provided
+	if data.HomeDirectoryPermission == "" {
+		data.HomeDirectoryPermission = "700"
+	}
+
 	exitCode, result = runCmdWithOutput(
 		[]string{
-			"chmod", cr.data.HomeDirectoryPermission, cr.data.HomeDirectory,
+			"chmod", data.HomeDirectoryPermission, data.HomeDirectory,
 		},
 		"root", "", nil, 60,
 	)

--- a/pkg/runner/command_types.go
+++ b/pkg/runner/command_types.go
@@ -74,7 +74,7 @@ type addUserData struct {
 	GID                     uint64 `validate:"required"`
 	Comment                 string `validate:"required"`
 	HomeDirectory           string `validate:"required"`
-	HomeDirectoryPermission string `validate:"required"`
+	HomeDirectoryPermission string `validate:"omitempty"` // Use omitempty for backward compatibility
 	Shell                   string `validate:"required"`
 	Groupname               string `validate:"required"`
 }


### PR DESCRIPTION
## Make HomeDirectoryPermission Optional for addUser (Backward Compatible)

### Description

This PR updates the user creation logic to make the `HomeDirectoryPermission` field optional, ensuring backward compatibility with existing clients and API calls.

### Changes

- **HomeDirectoryPermission is now optional:**
  - Updated the `CommandData` and `addUserData` structs to use `omitempty` for the `HomeDirectoryPermission` field.
  - Validation will skip this field if it is not provided.
- **Default permission applied:**
  - In the `addUser` function, if `HomeDirectoryPermission` is empty, it now defaults to `"700"` when setting the home directory permissions.
- **Backward compatibility:**
  - Existing clients or API calls that do not provide this field will continue to work as before, with the default permission applied automatically.

### Why

- Ensures that older clients or integrations that do not send the `HomeDirectoryPermission` field do not break.
- Provides a secure default (`700`) for home directories when no explicit permission is set.