### PR TITLE
Resolve "Allow to set InsecureSkipVerify based on config during file transfer"

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -714,7 +714,7 @@ func getFileData(data CommandData) ([]byte, error) {
 			caCertPool := x509.NewCertPool()
 			caCert, err := os.ReadFile(config.GlobalSettings.CaCert)
 			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to read CA certificate.")
+				log.Error().Err(err).Msg("Failed to read CA certificate.")
 			}
 			caCertPool.AppendCertsFromPEM(caCert)
 			tlsConfig.RootCAs = caCertPool

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -692,7 +692,7 @@ func getFileData(data CommandData) ([]byte, error) {
 			return nil, fmt.Errorf("failed to parse URL '%s': %w", data.Content, err)
 		}
 
-		req, err := http.NewRequest("GET", parsedRequestURL.String(), nil)
+		req, err := http.NewRequest(http.MethodGet, parsedRequestURL.String(), nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}

--- a/pkg/utils/http_client.go
+++ b/pkg/utils/http_client.go
@@ -2,9 +2,15 @@ package utils
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"io"
 	"net/http"
+	"os"
 	"time"
+
+	"github.com/alpacanetworks/alpamon/pkg/config"
+	"github.com/rs/zerolog/log"
 )
 
 func Put(url string, body bytes.Buffer, timeout time.Duration) ([]byte, int, error) {
@@ -14,6 +20,22 @@ func Put(url string, body bytes.Buffer, timeout time.Duration) ([]byte, int, err
 	}
 
 	client := &http.Client{Timeout: timeout}
+
+	tlsConfig := &tls.Config{}
+	if config.GlobalSettings.CaCert != "" {
+		caCertPool := x509.NewCertPool()
+		caCert, err := os.ReadFile(config.GlobalSettings.CaCert)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to read CA certificate.")
+		}
+		caCertPool.AppendCertsFromPEM(caCert)
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	tlsConfig.InsecureSkipVerify = !config.GlobalSettings.SSLVerify
+	client.Transport = &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/utils/http_client.go
+++ b/pkg/utils/http_client.go
@@ -26,7 +26,7 @@ func Put(url string, body bytes.Buffer, timeout time.Duration) ([]byte, int, err
 		caCertPool := x509.NewCertPool()
 		caCert, err := os.ReadFile(config.GlobalSettings.CaCert)
 		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to read CA certificate.")
+			log.Error().Err(err).Msg("Failed to read CA certificate.")
 		}
 		caCertPool.AppendCertsFromPEM(caCert)
 		tlsConfig.RootCAs = caCertPool


### PR DESCRIPTION
Add `tls.Config` to `http.Client` based on the SSLVerify option defined in `alpamon.conf.` during file transfer

Closes https://github.com/alpacanetworks/alpamon/issues/67