### PR TITLE
Resolve "Improve getDpkgPackage scanner robustness for large package blocks"

### DIFF
--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -614,7 +614,7 @@ func getDpkgPackage() ([]SystemPackageData, error) {
 		}
 
 		if pkg.Name == "" || pkg.Version == "" {
-			log.Error().Msgf("Skip malformed package entry: %s", chunk)
+			log.Debug().Msgf("Skip malformed package entry: %s", chunk)
 			continue
 		}
 


### PR DESCRIPTION
As mentioned in https://github.com/alpacanetworks/alpamon/issues/71, improve getDpkgPackage() as follows:

- Avoids panic when parsing large package blocks
   - Explicitly set a larger buffer size using scanner.Buffer()

- Gracefully handles large or malformed entries
   - Add exception handling for packages that are malformed or failed to parse in the dpkg status file

- Add logs if a block is too large or file is malformed

- Exclude system packages from the commit data if it failed to collect

Closes https://github.com/alpacanetworks/alpamon/issues/71