### PR TITLE
Add a timer to ensure atomicity

### DIFF
--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -59,7 +59,10 @@ var syncMutex sync.Mutex
 
 func CommitAsync(session *scheduler.Session, commissioned bool) {
 	if commissioned {
-		go syncSystemInfo(session, nil)
+		go func() {
+			time.Sleep(5 * time.Second)
+			syncSystemInfo(session, nil)
+		}()
 	} else {
 		go commitSystemInfo()
 	}


### PR DESCRIPTION
When alpamon restarts, atomicity isn't guaranteed between the data sent for sync and the data sent by the collector, causing errors on the server side.
To resolve this, add a timer to sync after a 5-second delay upon restart.