### PR TITLE
Add moduser command to handle updates in user and membership

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -563,19 +563,6 @@ func (cr *CommandRunner) modUser() (exitCode int, result string) {
 		if exitCode != 0 {
 			return exitCode, result
 		}
-	} else if utils.PlatformLike == "rhel" {
-		exitCode, result = runCmdWithOutput(
-			[]string{
-				"/usr/sbin/usermod",
-				"--comment", data.Comment,
-				"-G", utils.JoinUint64s(cr.data.Groups),
-				data.Username,
-			},
-			"root", "", nil, 60,
-		)
-		if exitCode != 0 {
-			return exitCode, result
-		}
 	} else {
 		return 1, "Not implemented 'moduser' command for this platform."
 	}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -547,13 +547,13 @@ func (cr *CommandRunner) modUser() (exitCode int, result string) {
 
 	err := cr.validateData(data)
 	if err != nil {
-		return 1, fmt.Sprintf("adduser: Not enough information. %s", err)
+		return 1, fmt.Sprintf("moduser: Not enough information. %s", err)
 	}
 
 	if utils.PlatformLike == "debian" {
 		exitCode, result = runCmdWithOutput(
 			[]string{
-				"usr/sbin/usermod",
+				"/usr/sbin/usermod",
 				"--comment", data.Comment,
 				"-G", utils.JoinUint64s(cr.data.Groups),
 				data.Username,

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -555,6 +555,7 @@ func (cr *CommandRunner) modUser() (exitCode int, result string) {
 			[]string{
 				"usr/sbin/usermod",
 				"--comment", data.Comment,
+				"-G", utils.JoinUint64s(cr.data.Groups),
 				data.Username,
 			},
 			"root", "", nil, 60,
@@ -567,6 +568,7 @@ func (cr *CommandRunner) modUser() (exitCode int, result string) {
 			[]string{
 				"/usr/sbin/usermod",
 				"--comment", data.Comment,
+				"-G", utils.JoinUint64s(cr.data.Groups),
 				data.Username,
 			},
 			"root", "", nil, 60,

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -550,7 +550,7 @@ func (cr *CommandRunner) modUser() (exitCode int, result string) {
 		return 1, fmt.Sprintf("moduser: Not enough information. %s", err)
 	}
 
-	if utils.PlatformLike == "debian" {
+	if utils.PlatformLike == "debian" || utils.PlatformLike == "rhel" {
 		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/usermod",

--- a/pkg/runner/command_types.go
+++ b/pkg/runner/command_types.go
@@ -92,6 +92,11 @@ type deleteGroupData struct {
 	Groupname string `validate:"required"`
 }
 
+type modUserData struct {
+	Username string `validate:"required"`
+	Comment  string `validate:"required"`
+}
+
 type openPtyData struct {
 	SessionID     string `validate:"required"`
 	URL           string `validate:"required"`


### PR DESCRIPTION
Description:
Add a new command in alpamon to handle system synchronization triggered by modifications to user information and membership updates:

`moduser`: Handles system-level updates when a user information is modified, or user-group membership is changed.
The server is synced after the server side update to reflect the latest configuration.