### PR TITLE
Upgrade Go version to 1.23 in all Dockerfiles

### DIFF
--- a/Dockerfiles/centos/7/Dockerfile
+++ b/Dockerfiles/centos/7/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Set golang env
 ENV GO111MODULE=on \

--- a/Dockerfiles/debian/10/Dockerfile
+++ b/Dockerfiles/debian/10/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Set golang env
 ENV GO111MODULE=on \

--- a/Dockerfiles/debian/11/Dockerfile
+++ b/Dockerfiles/debian/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Set golang env
 ENV GO111MODULE=on \

--- a/Dockerfiles/redhat/8/Dockerfile
+++ b/Dockerfiles/redhat/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Set golang env
 ENV GO111MODULE=on \

--- a/Dockerfiles/redhat/9/Dockerfile
+++ b/Dockerfiles/redhat/9/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Set golang env
 ENV GO111MODULE=on \

--- a/Dockerfiles/ubuntu/18.04/Dockerfile
+++ b/Dockerfiles/ubuntu/18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Set golang env
 ENV GO111MODULE=on \

--- a/Dockerfiles/ubuntu/20.04/Dockerfile
+++ b/Dockerfiles/ubuntu/20.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Set golang env
 ENV GO111MODULE=on \

--- a/Dockerfiles/ubuntu/22.04/Dockerfile
+++ b/Dockerfiles/ubuntu/22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Set golang env
 ENV GO111MODULE=on \


### PR DESCRIPTION
# Description
Related issue: #88 

- Updated Go version in all Dockerfiles with the upgraded project version (1.23).

Confirmed that images were successfully built and the server connected properly for all targets except redhat-9 when running build.sh.