### PR TITLE
Resolve "Enhance WebFTP cp command and defined error codes"

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -738,11 +738,14 @@ func (cr *CommandRunner) openFtp(data openFtpData) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	if err = cmd.Start(); err != nil {
+	err = cmd.Start()
+	if err != nil {
 		log.Debug().Err(err).Msg("Failed to start ftp worker process")
 
 		return fmt.Errorf("openftp: Failed to start ftp worker process. %w", err)
 	}
+
+	go func() { _ = cmd.Wait() }()
 
 	return nil
 }

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -720,7 +720,7 @@ func getPartitions() ([]Partition, error) {
 			continue
 		}
 		disk := utils.ParseDiskName(partition.Device)
-		seen[disk] = Partition{
+		seen[partition.Device] = Partition{
 			Name:        partition.Device,
 			MountPoints: []string{partition.Mountpoint},
 			DiskName:    disk,

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -417,6 +417,12 @@ func (fc *FtpClient) cp(src, dst string, allowOverwrite bool) (CommandResult, er
 		dst = utils.GetCopyPath(src, dst)
 	}
 
+	if !allowOverwrite {
+		if _, err := os.Stat(dst); err == nil {
+			dst = utils.GetCopyPath(src, dst)
+		}
+	}
+
 	info, err := os.Stat(src)
 	if err != nil {
 		return CommandResult{

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -157,7 +157,7 @@ func (fc *FtpClient) handleFtpCommand(command FtpCommand, data FtpData) (Command
 	case Mv:
 		return fc.mv(data.Src, data.Dst)
 	case Cp:
-		return fc.cp(data.Src, data.Dst)
+		return fc.cp(data.Src, data.Dst, data.AllowOverwrite)
 	case Chmod:
 		return fc.chmod(data.Path, data.Mode, data.Recursive)
 	case Chown:
@@ -172,13 +172,16 @@ func (fc *FtpClient) parsePath(path string) string {
 		path = strings.Replace(path, "~", fc.workingDirectory, 1)
 	}
 
-	absPath := path
 	if !filepath.IsAbs(path) {
-		absPath = filepath.Join(fc.workingDirectory, path)
+		path = filepath.Join(fc.workingDirectory, path)
 	}
 
-	parsedPath := filepath.Clean(absPath)
-	return parsedPath
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+
+	return absPath
 }
 
 func (fc *FtpClient) list(rootDir string, depth int, showHidden bool) (CommandResult, error) {
@@ -406,9 +409,13 @@ func (fc *FtpClient) mv(src, dst string) (CommandResult, error) {
 	}, nil
 }
 
-func (fc *FtpClient) cp(src, dst string) (CommandResult, error) {
+func (fc *FtpClient) cp(src, dst string, allowOverwrite bool) (CommandResult, error) {
 	src = fc.parsePath(src)
-	dst = filepath.Join(fc.parsePath(dst), filepath.Base(src))
+	dst = fc.parsePath(dst)
+
+	if src == dst {
+		dst = utils.GetCopyPath(src, dst)
+	}
 
 	info, err := os.Stat(src)
 	if err != nil {
@@ -418,13 +425,14 @@ func (fc *FtpClient) cp(src, dst string) (CommandResult, error) {
 	}
 
 	if info.IsDir() {
-		return fc.cpDir(src, dst)
+		return fc.cpDir(src, dst, allowOverwrite)
 	}
-	return fc.cpFile(src, dst)
+
+	return fc.cpFile(src, dst, allowOverwrite)
 }
 
-func (fc *FtpClient) cpDir(src, dst string) (CommandResult, error) {
-	err := utils.CopyDir(src, dst)
+func (fc *FtpClient) cpDir(src, dst string, allowOverwrite bool) (CommandResult, error) {
+	err := utils.CopyDir(src, dst, allowOverwrite)
 	if err != nil {
 		return CommandResult{
 			Message: err.Error(),
@@ -437,8 +445,8 @@ func (fc *FtpClient) cpDir(src, dst string) (CommandResult, error) {
 	}, nil
 }
 
-func (fc *FtpClient) cpFile(src, dst string) (CommandResult, error) {
-	err := utils.CopyFile(src, dst)
+func (fc *FtpClient) cpFile(src, dst string, allowOverwrite bool) (CommandResult, error) {
+	err := utils.CopyFile(src, dst, allowOverwrite)
 	if err != nil {
 		return CommandResult{
 			Message: err.Error(),

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -30,6 +30,7 @@ const (
 	ErrNoSuchFileOrDirectory = "no such file or directory"
 	ErrFileExists            = "file exists"
 	ErrDirectoryNotEmpty     = "directory not empty"
+	ErrInfiniteRecursion     = "causing infinite recursion"
 )
 
 type FtpConfigData struct {
@@ -158,6 +159,7 @@ var returnCodes = map[FtpCommand]returnCode{
 			ErrInvalidArgument:       452,
 			ErrNoSuchFileOrDirectory: 550,
 			ErrFileExists:            552,
+			ErrInfiniteRecursion:     553,
 		},
 	},
 	Chmod: {

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -40,15 +40,16 @@ type FtpConfigData struct {
 }
 
 type FtpData struct {
-	Path       string `json:"path,omitempty"`
-	Depth      int    `json:"depth,omitempty"`
-	Recursive  bool   `json:"recursive,omitempty"`
-	ShowHidden bool   `json:"show_hidden,omitempty"`
-	Src        string `json:"src,omitempty"`
-	Dst        string `json:"dst,omitempty"`
-	Mode       string `json:"mode,omitempty"`
-	Username   string `json:"username,omitempty"`
-	Groupname  string `json:"groupname,omitempty"`
+	Path           string `json:"path,omitempty"`
+	Depth          int    `json:"depth,omitempty"`
+	Recursive      bool   `json:"recursive,omitempty"`
+	ShowHidden     bool   `json:"show_hidden,omitempty"`
+	AllowOverwrite bool   `json:"allow_overwrite,omitempty"`
+	Src            string `json:"src,omitempty"`
+	Dst            string `json:"dst,omitempty"`
+	Mode           string `json:"mode,omitempty"`
+	Username       string `json:"username,omitempty"`
+	Groupname      string `json:"groupname,omitempty"`
 }
 
 type FtpContent struct {

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -187,7 +187,7 @@ func GetFtpErrorCode(command FtpCommand, result CommandResult) (CommandResult, i
 		for message, code := range codes.Error {
 			if strings.Contains(result.Message, message) {
 				return CommandResult{
-					Message: message,
+					Message: result.Message,
 				}, code
 			}
 		}

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -177,7 +177,7 @@ func GetCopyPath(src, dst string) string {
 	parent := filepath.Dir(dst)
 
 	for i := 1; ; i++ {
-		candidate := filepath.Join(parent, fmt.Sprintf("%s(%d)%s", name, i, ext))
+		candidate := filepath.Join(parent, fmt.Sprintf("%s (%d)%s", name, i, ext))
 		_, err := os.Stat(candidate)
 		if os.IsNotExist(err) {
 			return candidate

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -12,12 +12,6 @@ import (
 )
 
 func CopyFile(src, dst string, allowOverwrite bool) error {
-	if !allowOverwrite {
-		if _, err := os.Stat(dst); err == nil {
-			dst = GetCopyPath(src, dst)
-		}
-	}
-
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return err
@@ -56,12 +50,6 @@ func CopyDir(src, dst string, allowOverwrite bool) error {
 
 	if rel != "." && !strings.HasPrefix(rel, "..") {
 		return fmt.Errorf("%s is inside %s, causing infinite recursion", dst, src)
-	}
-
-	if !allowOverwrite {
-		if _, err := os.Stat(dst); err == nil {
-			dst = GetCopyPath(src, dst)
-		}
 	}
 
 	srcInfo, err := os.Stat(src)


### PR DESCRIPTION
As mentioned in https://github.com/alpacax/alpamon/issues/96, 
enhance WebFTP cp command as follows:

- Support overwrite option
    - Update WebFTP cp command to support an overwrite option, allowing users to choose whether to overwrite existing files.
    - If the overwrite option is false and an object with the same file/folder name already exists in the destination path, 
      a new object name will be assigned, as shown in the example below.
        - example -> example(1)
        - example.txt -> example(1).txt
- Add ErrInfiniteRecursion to returnCodes
    - Add an error code for infinite recursion to provide users with more granular error messages.

Additionally,  we've also implemented and modified the following:

- Resolve issue where the webftp process became defunct
    - We found and fixed an issue where the webftp process became defunct instead of being properly reaped upon termination. 
- Support overwrite option in WebFTP mv command
    - Update WebFTP mv command to support an overwrite option, allowing users to choose whether to overwrite existing files. 