### PR TITLE
Modify URL pattern in pty client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ alpamon.log
 alpamon.db
 alpamon
 .DS_Store
+.idea

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -59,10 +59,22 @@ func NewPtyClient(data CommandData, apiSession *scheduler.Session) *PtyClient {
 		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, config.GlobalSettings.ID, config.GlobalSettings.Key)},
 		"Origin":        {config.GlobalSettings.ServerURL},
 	}
+
+	// For local development
+	wsURL := strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1)
+	wsURL = strings.Replace(wsURL, ":8000", ":8080", 1)
+
+	var finalURL string
+	if strings.HasPrefix(data.URL, "ws:") || strings.HasPrefix(data.URL, "wss:") {
+		finalURL = data.URL
+	} else {
+		finalURL = wsURL + data.URL
+	}
+
 	return &PtyClient{
 		apiSession:    apiSession,
 		requestHeader: headers,
-		url:           data.URL,
+		url:           finalURL,
 		rows:          data.Rows,
 		cols:          data.Cols,
 		username:      data.Username,

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -62,7 +62,7 @@ func NewPtyClient(data CommandData, apiSession *scheduler.Session) *PtyClient {
 	return &PtyClient{
 		apiSession:    apiSession,
 		requestHeader: headers,
-		url:           strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1) + data.URL,
+		url:           data.URL,
 		rows:          data.Rows,
 		cols:          data.Cols,
 		username:      data.Username,

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -60,14 +60,14 @@ func NewPtyClient(data CommandData, apiSession *scheduler.Session) *PtyClient {
 		"Origin":        {config.GlobalSettings.ServerURL},
 	}
 
-	// For local development
-	wsURL := strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1)
-	wsURL = strings.Replace(wsURL, ":8000", ":8080", 1)
-
 	var finalURL string
 	if strings.HasPrefix(data.URL, "ws:") || strings.HasPrefix(data.URL, "wss:") {
 		finalURL = data.URL
 	} else {
+		// For local development
+		wsURL := strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1)
+		wsURL = strings.Replace(wsURL, ":8000", ":8080", 1)
+
 		finalURL = wsURL + data.URL
 	}
 

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -60,21 +60,10 @@ func NewPtyClient(data CommandData, apiSession *scheduler.Session) *PtyClient {
 		"Origin":        {config.GlobalSettings.ServerURL},
 	}
 
-	var finalURL string
-	if strings.HasPrefix(data.URL, "ws:") || strings.HasPrefix(data.URL, "wss:") {
-		finalURL = data.URL
-	} else {
-		// For local development
-		wsURL := strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1)
-		wsURL = strings.Replace(wsURL, ":8000", ":8080", 1)
-
-		finalURL = wsURL + data.URL
-	}
-
 	return &PtyClient{
 		apiSession:    apiSession,
 		requestHeader: headers,
-		url:           finalURL,
+		url:           data.URL,
 		rows:          data.Rows,
 		cols:          data.Cols,
 		username:      data.Username,


### PR DESCRIPTION
Since the URL provided by the `alpacon-server` will change, we need to update the `alpamon` code accordingly.