### PR TITLE
Resolve "Fix the issue where disk I/O related metrics were not being collected properly"

### DIFF
--- a/pkg/collector/check/realtime/disk/io/io_collect.go
+++ b/pkg/collector/check/realtime/disk/io/io_collect.go
@@ -58,14 +58,14 @@ func (c *CollectCheck) parseDiskIO(ioCounters map[string]disk.IOCountersStat) []
 		}
 		seen[baseName] = true
 
-		if lastCounter, exist := c.lastMetric[name]; exist {
+		if lastCounter, exist := c.lastMetric[baseName]; exist {
 			readBps, writeBps = utils.CalculateDiskIOBps(ioCounter, lastCounter, c.GetInterval())
 		} else {
 			readBps = 0
 			writeBps = 0
 		}
 
-		c.lastMetric[name] = ioCounter
+		c.lastMetric[baseName] = ioCounter
 		data = append(data, base.CheckResult{
 			Timestamp: time.Now(),
 			Device:    baseName,

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -693,7 +693,7 @@ func getDisks() ([]Disk, error) {
 		seen[baseName] = true
 
 		disks = append(disks, Disk{
-			Name:         name,
+			Name:         baseName,
 			SerialNumber: ioCounter.SerialNumber,
 			Label:        ioCounter.Label,
 		})


### PR DESCRIPTION
Correct the incorrect disk names collected during the commit and sync actions,
which caused disk I/O metrics to appear uncollected due to a mismatch between the names from the actions and the collector.

Closes #107 