### PR TITLE
Hotfix to resolve the overflow issue occurring during disk I/O metric collection

### DIFF
--- a/pkg/collector/check/realtime/disk/io/io_collect.go
+++ b/pkg/collector/check/realtime/disk/io/io_collect.go
@@ -53,19 +53,19 @@ func (c *CollectCheck) parseDiskIO(ioCounters map[string]disk.IOCountersStat) []
 		}
 
 		baseName := utils.GetDiskBaseName(name)
-		if seen[baseName] {
+		if seen[baseName] && baseName != name {
 			continue
 		}
 		seen[baseName] = true
 
-		if lastCounter, exist := c.lastMetric[baseName]; exist {
+		if lastCounter, exist := c.lastMetric[name]; exist {
 			readBps, writeBps = utils.CalculateDiskIOBps(ioCounter, lastCounter, c.GetInterval())
 		} else {
 			readBps = 0
 			writeBps = 0
 		}
 
-		c.lastMetric[baseName] = ioCounter
+		c.lastMetric[name] = ioCounter
 		data = append(data, base.CheckResult{
 			Timestamp: time.Now(),
 			Device:    baseName,


### PR DESCRIPTION
# Description
To fix an overflow issue with disk I/O metric calculation in [v1.1.8](https://github.com/alpacax/alpamon/releases/tag/v1.1.8),
we've rolled back a recent change and added a new condition.

[A recent pull request](https://www.google.com/search?q=https://github.com/alpacax/alpamon/pull/108) changed the disk I/O calculation to use `baseName`. 
However, since disk I/O metrics are collected on a per-partition basis, this change was causing overflows and resulting in incorrect values.

To resolve this, we've reverted the calculation to manage disk I/O on a per-partition basis again. 
Additionally, we've updated the logic to only collect disk I/O metrics for the entire disk, not individual partitions.

Closes #107 