### PR TITLE
Modify websocket url for proxy-server WebFTP

### DIFF
--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -34,7 +34,7 @@ func NewFtpClient(data FtpConfigData) *FtpClient {
 
 	return &FtpClient{
 		requestHeader:    headers,
-		url:              strings.Replace(data.ServerURL, "http", "ws", 1) + data.URL,
+		url:              data.URL,
 		homeDirectory:    data.HomeDirectory,
 		workingDirectory: data.HomeDirectory,
 		log:              data.Logger,


### PR DESCRIPTION
To handle URL generation on the Alpacon server, i need to know whether the next alpamon release will be `1.2.0` or `1.1.10`.