### PR TITLE
feat: add Homebrew tap support for macOS installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
       - name: Set TAG_NAME from channel output
         run: echo "TAG_NAME=${{ steps.channel.outputs.tag }}" >> $GITHUB_ENV

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -97,6 +97,22 @@ nfpms:
         suggests:
           - alpamon-pam
       
+brews:
+  - name: alpamon
+    ids:
+      - alpamon
+    repository:
+      owner: alpacax
+      name: homebrew-alpacon
+    commit_author:
+      name: alpacaxbot
+      email: support@alpacax.com
+    directory: Formula
+    homepage: "https://github.com/alpacax/alpamon"
+    description: "Secure server agent for Alpacon"
+    license: MIT
+    skip_upload: auto
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -99,8 +99,6 @@ nfpms:
       
 brews:
   - name: alpamon
-    ids:
-      - alpamon
     repository:
       owner: alpacax
       name: homebrew-alpacon

--- a/cmd/alpamon/command/register/service_darwin.go
+++ b/cmd/alpamon/command/register/service_darwin.go
@@ -10,10 +10,23 @@ import (
 )
 
 const (
-	alpamonBinPath = "/usr/local/bin/alpamon"
-	plistName      = "com.alpacax.alpamon.plist"
-	launchdDir     = "/Library/LaunchDaemons"
+	alpamonBinPathFallback = "/usr/local/bin/alpamon"
+	plistName              = "com.alpacax.alpamon.plist"
+	launchdDir             = "/Library/LaunchDaemons"
 )
+
+// getAlpamonBinPath returns the path of the currently running alpamon binary.
+// This handles Homebrew installations where the binary may be at /opt/homebrew/bin/alpamon
+// (Apple Silicon) instead of the default /usr/local/bin/alpamon (Intel).
+// Note: symlinks are intentionally NOT resolved so that the plist uses the stable
+// symlink path (e.g. /opt/homebrew/bin/alpamon) rather than a version-pinned
+// Cellar path that would break after brew upgrade.
+func getAlpamonBinPath() string {
+	if exe, err := os.Executable(); err == nil {
+		return exe
+	}
+	return alpamonBinPathFallback
+}
 
 func ensureDirectories() error {
 	return utils.EnsureDirectories()
@@ -60,7 +73,7 @@ func writeLaunchdPlist(path string) error {
 	<string>/</string>
 </dict>
 </plist>
-`, alpamonBinPath)
+`, getAlpamonBinPath())
 
 	return os.WriteFile(path, []byte(plist), 0644)
 }

--- a/cmd/alpamon/command/register/service_darwin.go
+++ b/cmd/alpamon/command/register/service_darwin.go
@@ -23,6 +23,9 @@ const (
 // Cellar path that would break after brew upgrade.
 func getAlpamonBinPath() string {
 	if exe, err := os.Executable(); err == nil {
+		if abs, err := filepath.Abs(exe); err == nil {
+			return abs
+		}
 		return exe
 	}
 	return alpamonBinPathFallback


### PR DESCRIPTION
## Summary

- Add `brews` section to `.goreleaser.yaml` to auto-publish `Formula/alpamon.rb` to the existing `alpacax/homebrew-alpacon` tap on stable releases
- Use `GORELEASER_GITHUB_TOKEN` PAT for cross-repo formula push, consistent with the alpacon-cli release workflow
- Resolve launchd plist binary path dynamically to support both Apple Silicon (`/opt/homebrew/bin/`) and Intel (`/usr/local/bin/`) Homebrew installations

## Motivation

macOS support was introduced in v2.1.0-rc.1, but users must manually download binaries from GitHub Releases. This PR enables `brew install alpacax/alpacon/alpamon` by leveraging the same Homebrew tap already used by alpacon-cli.

## Changes

| File | Change |
|------|--------|
| `.goreleaser.yaml` | Add `brews` section targeting `alpacax/homebrew-alpacon` with `skip_upload: auto` |
| `.github/workflows/release.yml` | Use `secrets.GORELEASER_GITHUB_TOKEN` for cross-repo write access |
| `cmd/alpamon/command/register/service_darwin.go` | Replace hardcoded `/usr/local/bin/alpamon` with `os.Executable()` |

## Design decisions

- **Shared tap**: Reuses `alpacax/homebrew-alpacon` instead of creating a new repo. Formula files (`alpacon-cli.rb`, `alpamon.rb`) are independent and managed by their respective goreleaser configs.
- **No `post_install`**: Directory creation and launchd plist setup are handled by `sudo alpamon register`, which already works regardless of install method.
- **No symlink resolution**: `filepath.EvalSymlinks` is intentionally omitted so the plist uses the stable symlink path (`/opt/homebrew/bin/alpamon`) rather than a version-pinned Cellar path that would break after `brew upgrade`.
- **Pre-release skip**: `skip_upload: auto` ensures only stable releases update the Homebrew formula.

## Prerequisites (manual)

- [ ] Verify `GORELEASER_GITHUB_TOKEN` secret exists in `alpacax/alpamon` repo (may already be available as an org-level secret)
- [ ] Update `homebrew-alpacon` README to include alpamon install instructions

## Test plan

- [ ] Run `goreleaser release --snapshot --clean --skip=publish` and verify `dist/homebrew/Formula/alpamon.rb` is generated correctly
- [ ] Verify formula contains only darwin (amd64/arm64) archives, not linux
- [ ] Tag an rc release and confirm homebrew-alpacon repo is NOT updated
- [ ] Tag a stable release and confirm `Formula/alpamon.rb` appears in homebrew-alpacon
- [ ] Run `brew install alpacax/alpacon/alpamon && alpamon --help` on Apple Silicon Mac
- [ ] Run `sudo alpamon register` and verify launchd plist contains correct binary path
- [ ] Run `brew upgrade alpamon` and verify service still works (symlink path survives upgrade)
- [ ] Confirm existing `alpacon-cli.rb` formula is unaffected

## References

- [alpacax/homebrew-alpacon](https://github.com/alpacax/homebrew-alpacon)
- [GoReleaser Homebrew docs](https://goreleaser.com/customization/homebrew/)
