### PR TITLE
feat: integrate Ed25519 signature verification into command flow

### DIFF
--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -260,8 +261,18 @@ func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
 
 		// Verify signature before ACK
 		if err := wc.verifyCommandSignature(msg.Command); err != nil {
-			log.Error().Err(err).Str("command_id", msg.Command.ID).
-				Msg("Command signature verification failed.")
+			// Log the full error chain locally; err.Error() returns only
+			// the fixed rejection reason, Unwrap() has the detailed cause.
+			var rejection *rejectionError
+			if errors.As(err, &rejection) {
+				log.Error().Err(rejection.Unwrap()).
+					Str("command_id", msg.Command.ID).
+					Str("reason", rejection.reason).
+					Msg("Command signature verification failed.")
+			} else {
+				log.Error().Err(err).Str("command_id", msg.Command.ID).
+					Msg("Command signature verification failed.")
+			}
 			wc.rejectCommand(msg.Command.ID, err.Error())
 			return
 		}

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -44,6 +44,7 @@ type WebsocketClient struct {
 	dispatcher           CommandDispatcher
 	keyManager           *signing.KeyManager
 	signingMode          string
+	serverID             string
 }
 
 func NewWebsocketClient(session *scheduler.Session, ctxManager *agent.ContextManager, workerPool *pool.Pool) *WebsocketClient {
@@ -62,13 +63,14 @@ func NewWebsocketClient(session *scheduler.Session, ctxManager *agent.ContextMan
 		pool:                 workerPool,
 		ctxManager:           ctxManager,
 		signingMode:          config.GlobalSettings.SigningMode,
+		serverID:             config.GlobalSettings.ID,
 	}
 
 	if config.GlobalSettings.AIServerURL != "" {
 		wc.keyManager = signing.NewKeyManager(
 			config.GlobalSettings.AIServerURL,
 			config.GlobalSettings.KeyRefreshSecs,
-			nil,
+			utils.NewHTTPClient(),
 		)
 		log.Info().Str("mode", wc.signingMode).Msg("Command signature verification enabled.")
 	}

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alpacax/alpamon/pkg/config"
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/pkg/scheduler"
+	"github.com/alpacax/alpamon/pkg/signing"
 	"github.com/alpacax/alpamon/pkg/utils"
 	"github.com/cenkalti/backoff"
 	"github.com/gorilla/websocket"
@@ -26,8 +27,9 @@ const (
 	ConnectionReadTimeout = 35 * time.Minute
 	maxRetryTimeout       = 3 * 24 * time.Hour
 
-	eventCommandAckURL = "/api/events/commands/%s/ack/"
-	eventCommandFinURL = "/api/events/commands/%s/fin/"
+	eventCommandAckURL    = "/api/events/commands/%s/ack/"
+	eventCommandFinURL    = "/api/events/commands/%s/fin/"
+	eventCommandRejectURL = "/api/events/commands/%s/reject/"
 )
 
 type WebsocketClient struct {
@@ -40,6 +42,8 @@ type WebsocketClient struct {
 	pool                 *pool.Pool
 	ctxManager           *agent.ContextManager
 	dispatcher           CommandDispatcher
+	keyManager           *signing.KeyManager
+	signingMode          string
 }
 
 func NewWebsocketClient(session *scheduler.Session, ctxManager *agent.ContextManager, workerPool *pool.Pool) *WebsocketClient {
@@ -49,7 +53,7 @@ func NewWebsocketClient(session *scheduler.Session, ctxManager *agent.ContextMan
 		"User-Agent":    {utils.GetUserAgent("alpamon")},
 	}
 
-	return &WebsocketClient{
+	wc := &WebsocketClient{
 		requestHeader:        headers,
 		apiSession:           session,
 		RestartChan:          make(chan struct{}),
@@ -57,7 +61,19 @@ func NewWebsocketClient(session *scheduler.Session, ctxManager *agent.ContextMan
 		CollectorRestartChan: make(chan struct{}, 1),
 		pool:                 workerPool,
 		ctxManager:           ctxManager,
+		signingMode:          config.GlobalSettings.SigningMode,
 	}
+
+	if config.GlobalSettings.AIServerURL != "" {
+		wc.keyManager = signing.NewKeyManager(
+			config.GlobalSettings.AIServerURL,
+			config.GlobalSettings.KeyRefreshSecs,
+			nil,
+		)
+		log.Info().Str("mode", wc.signingMode).Msg("Command signature verification enabled.")
+	}
+
+	return wc
 }
 
 // SetDispatcher sets the dispatcher for handling commands with dispatcher
@@ -237,6 +253,14 @@ func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
 	case protocol.MessageTypeCommand:
 		if msg.Command == nil {
 			log.Warn().Msg("Command message without command data")
+			return
+		}
+
+		// Verify signature before ACK
+		if err := wc.verifyCommandSignature(msg.Command); err != nil {
+			log.Error().Err(err).Str("command_id", msg.Command.ID).
+				Msg("Command signature verification failed.")
+			wc.rejectCommand(msg.Command.ID, err.Error())
 			return
 		}
 

--- a/pkg/runner/signing.go
+++ b/pkg/runner/signing.go
@@ -11,6 +11,31 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Rejection reasons sent to the server via the reject endpoint.
+// These are fixed strings to avoid leaking internal details (AI server URLs,
+// status codes, key IDs) into server-side records visible to console users.
+const (
+	rejectReasonUnsigned          = "unsigned_command"
+	rejectReasonKeyUnavailable    = "key_unavailable"
+	rejectReasonInvalidSignature  = "invalid_signature"
+	rejectReasonSignatureMismatch = "signature_mismatch"
+)
+
+// rejectionError pairs a user-facing reason (sent to server) with an internal
+// error (logged locally). This avoids leaking implementation details into the
+// reject payload while preserving full diagnostics in logs.
+type rejectionError struct {
+	reason string // fixed string for the server
+	err    error  // detailed error for local logging
+}
+
+func (r *rejectionError) Error() string { return r.reason }
+func (r *rejectionError) Unwrap() error { return r.err }
+
+func newRejection(reason string, err error) *rejectionError {
+	return &rejectionError{reason: reason, err: err}
+}
+
 // verifyCommandSignature checks the Ed25519 signature on a command.
 // Internal commands bypass verification. In monitor mode, unsigned or
 // invalid signatures log a warning but allow execution. In enforce mode,
@@ -29,7 +54,8 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 	// No signature: unsigned command
 	if cmd.Signature == "" {
 		if wc.signingMode == "enforce" {
-			return errors.New("missing signature in enforce mode")
+			return newRejection(rejectReasonUnsigned,
+				errors.New("missing signature in enforce mode"))
 		}
 		log.Warn().Str("command_id", cmd.ID).Msg("Command has no signature (unsigned).")
 		return nil
@@ -47,7 +73,8 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 
 	if err != nil {
 		if wc.signingMode == "enforce" {
-			return fmt.Errorf("public key unavailable: %w", err)
+			return newRejection(rejectReasonKeyUnavailable,
+				fmt.Errorf("public key unavailable: %w", err))
 		}
 		log.Warn().Err(err).Str("command_id", cmd.ID).
 			Msg("Public key unavailable, executing without verification.")
@@ -78,7 +105,11 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 	}
 
 	if wc.signingMode == "enforce" {
-		return err
+		reason := rejectReasonInvalidSignature
+		if errors.Is(err, signing.ErrSignatureMismatch) {
+			reason = rejectReasonSignatureMismatch
+		}
+		return newRejection(reason, err)
 	}
 	log.Warn().Err(err).Str("command_id", cmd.ID).
 		Msg("Signature verification failed, executing in monitor mode.")
@@ -104,7 +135,7 @@ func (wc *WebsocketClient) retryVerificationAfterRefresh(cmd *protocol.Command, 
 		pubKey, err = wc.keyManager.GetPublicKey()
 	}
 	if err != nil {
-		return fmt.Errorf("public key unavailable after refresh: %w", err)
+		return fmt.Errorf("signing key rotated, command was signed with a decommissioned key: %w", err)
 	}
 
 	if retryErr := signing.VerifyCommand(cmd, wc.serverID, pubKey); retryErr != nil {

--- a/pkg/runner/signing.go
+++ b/pkg/runner/signing.go
@@ -1,0 +1,119 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/alpacax/alpamon/internal/protocol"
+	"github.com/alpacax/alpamon/pkg/config"
+	"github.com/alpacax/alpamon/pkg/scheduler"
+	"github.com/alpacax/alpamon/pkg/signing"
+	"github.com/rs/zerolog/log"
+)
+
+// verifyCommandSignature checks the Ed25519 signature on a command.
+// Internal commands bypass verification. In monitor mode, unsigned or
+// invalid signatures log a warning but allow execution. In enforce mode,
+// they return an error which prevents ACK and execution.
+func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
+	// Internal commands bypass verification (no signature expected)
+	if cmd.Shell == "internal" {
+		return nil
+	}
+
+	// Signing not configured: skip verification
+	if wc.keyManager == nil {
+		return nil
+	}
+
+	// No signature: unsigned command
+	if cmd.Signature == "" {
+		if wc.signingMode == "enforce" {
+			return errors.New("missing signature in enforce mode")
+		}
+		log.Warn().Str("command_id", cmd.ID).Msg("Command has no signature (unsigned).")
+		return nil
+	}
+
+	// Resolve public key using key_id from the command
+	var pubKey []byte
+	var err error
+
+	if cmd.KeyID != "" {
+		pubKey, err = wc.keyManager.GetPublicKeyForKID(cmd.KeyID)
+	} else {
+		pubKey, err = wc.keyManager.GetPublicKey()
+	}
+
+	if err != nil {
+		if wc.signingMode == "enforce" {
+			return fmt.Errorf("public key unavailable: %w", err)
+		}
+		log.Warn().Err(err).Str("command_id", cmd.ID).
+			Msg("Public key unavailable, executing without verification.")
+		return nil
+	}
+
+	// Verify signature
+	err = signing.VerifyCommand(cmd, config.GlobalSettings.ID, pubKey)
+	if err == nil {
+		log.Debug().Str("command_id", cmd.ID).Msg("Command signature verified.")
+		return nil
+	}
+
+	// Verification failed: try key refresh once (handles key rotation)
+	log.Debug().Err(err).Str("command_id", cmd.ID).
+		Msg("Signature verification failed, refreshing key.")
+
+	retryErr := wc.retryVerificationAfterRefresh(cmd, err)
+	if retryErr == nil {
+		log.Debug().Str("command_id", cmd.ID).Msg("Command signature verified after key refresh.")
+		return nil
+	}
+
+	if wc.signingMode == "enforce" {
+		return retryErr
+	}
+	log.Warn().Err(retryErr).Str("command_id", cmd.ID).
+		Msg("Signature verification failed, executing in monitor mode.")
+	return nil
+}
+
+// retryVerificationAfterRefresh refreshes the public key and retries signature verification.
+func (wc *WebsocketClient) retryVerificationAfterRefresh(cmd *protocol.Command, originalErr error) error {
+	if refreshErr := wc.keyManager.Refresh(); refreshErr != nil {
+		log.Warn().Err(refreshErr).Msg("Key refresh failed.")
+		return fmt.Errorf("signature verification failed: %w", originalErr)
+	}
+
+	var pubKey []byte
+	var err error
+	if cmd.KeyID != "" {
+		pubKey, err = wc.keyManager.GetPublicKeyForKID(cmd.KeyID)
+	} else {
+		pubKey, err = wc.keyManager.GetPublicKey()
+	}
+	if err != nil {
+		return fmt.Errorf("public key unavailable after refresh: %w", err)
+	}
+
+	if retryErr := signing.VerifyCommand(cmd, config.GlobalSettings.ID, pubKey); retryErr != nil {
+		return fmt.Errorf("signature verification failed after key refresh: %w", retryErr)
+	}
+
+	return nil
+}
+
+// rejectCommand reports a rejected command to alpacon-server.
+func (wc *WebsocketClient) rejectCommand(commandID string, reason string) {
+	payload := map[string]string{
+		"reason": reason,
+	}
+	scheduler.Rqueue.Post(
+		fmt.Sprintf(eventCommandRejectURL, commandID),
+		payload,
+		10,
+		time.Time{},
+	)
+}

--- a/pkg/runner/signing.go
+++ b/pkg/runner/signing.go
@@ -61,20 +61,26 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 		return nil
 	}
 
-	// Verification failed: try key refresh once (handles key rotation)
-	log.Debug().Err(err).Str("command_id", cmd.ID).
-		Msg("Signature verification failed, refreshing key.")
+	// Only retry with key refresh on actual signature mismatch (possible key
+	// rotation). Malformed input errors (bad base64, wrong size) cannot be
+	// fixed by fetching a new key, so skip the refresh to avoid unnecessary
+	// AI server load.
+	if errors.Is(err, signing.ErrSignatureMismatch) {
+		log.Debug().Str("command_id", cmd.ID).
+			Msg("Signature mismatch, refreshing key for possible rotation.")
 
-	retryErr := wc.retryVerificationAfterRefresh(cmd, err)
-	if retryErr == nil {
-		log.Debug().Str("command_id", cmd.ID).Msg("Command signature verified after key refresh.")
-		return nil
+		retryErr := wc.retryVerificationAfterRefresh(cmd, err)
+		if retryErr == nil {
+			log.Debug().Str("command_id", cmd.ID).Msg("Command signature verified after key refresh.")
+			return nil
+		}
+		err = retryErr
 	}
 
 	if wc.signingMode == "enforce" {
-		return retryErr
+		return err
 	}
-	log.Warn().Err(retryErr).Str("command_id", cmd.ID).
+	log.Warn().Err(err).Str("command_id", cmd.ID).
 		Msg("Signature verification failed, executing in monitor mode.")
 	return nil
 }

--- a/pkg/runner/signing.go
+++ b/pkg/runner/signing.go
@@ -127,15 +127,12 @@ func (wc *WebsocketClient) retryVerificationAfterRefresh(cmd *protocol.Command, 
 			errors.Join(originalErr, refreshErr))
 	}
 
-	var pubKey []byte
-	var err error
-	if cmd.KeyID != "" {
-		pubKey, err = wc.keyManager.GetPublicKeyForKID(cmd.KeyID)
-	} else {
-		pubKey, err = wc.keyManager.GetPublicKey()
-	}
+	// Use GetPublicKey (not GetPublicKeyForKID) since ForceRefresh just
+	// populated the cache. Calling GetPublicKeyForKID here would trigger a
+	// second fetch if the AI server rotated to a different KID.
+	pubKey, err := wc.keyManager.GetPublicKey()
 	if err != nil {
-		return fmt.Errorf("signing key rotated, command was signed with a decommissioned key: %w", err)
+		return fmt.Errorf("public key unavailable after refresh: %w", err)
 	}
 
 	if retryErr := signing.VerifyCommand(cmd, wc.serverID, pubKey); retryErr != nil {

--- a/pkg/runner/signing.go
+++ b/pkg/runner/signing.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/alpacax/alpamon/internal/protocol"
-	"github.com/alpacax/alpamon/pkg/config"
 	"github.com/alpacax/alpamon/pkg/scheduler"
 	"github.com/alpacax/alpamon/pkg/signing"
 	"github.com/rs/zerolog/log"
@@ -56,7 +55,7 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 	}
 
 	// Verify signature
-	err = signing.VerifyCommand(cmd, config.GlobalSettings.ID, pubKey)
+	err = signing.VerifyCommand(cmd, wc.serverID, pubKey)
 	if err == nil {
 		log.Debug().Str("command_id", cmd.ID).Msg("Command signature verified.")
 		return nil
@@ -80,11 +79,15 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 	return nil
 }
 
-// retryVerificationAfterRefresh refreshes the public key and retries signature verification.
+// retryVerificationAfterRefresh force-refreshes the public key and retries
+// signature verification. ForceRefresh fetches unconditionally (unlike Refresh
+// which is a no-op when the cached key hasn't expired), ensuring a rotated key
+// is actually fetched.
 func (wc *WebsocketClient) retryVerificationAfterRefresh(cmd *protocol.Command, originalErr error) error {
-	if refreshErr := wc.keyManager.Refresh(); refreshErr != nil {
+	if refreshErr := wc.keyManager.ForceRefresh(); refreshErr != nil {
 		log.Warn().Err(refreshErr).Msg("Key refresh failed.")
-		return fmt.Errorf("signature verification failed: %w", originalErr)
+		return fmt.Errorf("signature verification failed and key refresh failed: %w",
+			errors.Join(originalErr, refreshErr))
 	}
 
 	var pubKey []byte
@@ -98,7 +101,7 @@ func (wc *WebsocketClient) retryVerificationAfterRefresh(cmd *protocol.Command, 
 		return fmt.Errorf("public key unavailable after refresh: %w", err)
 	}
 
-	if retryErr := signing.VerifyCommand(cmd, config.GlobalSettings.ID, pubKey); retryErr != nil {
+	if retryErr := signing.VerifyCommand(cmd, wc.serverID, pubKey); retryErr != nil {
 		return fmt.Errorf("signature verification failed after key refresh: %w", retryErr)
 	}
 

--- a/pkg/runner/signing_test.go
+++ b/pkg/runner/signing_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 
 	"github.com/alpacax/alpamon/internal/protocol"
-	"github.com/alpacax/alpamon/pkg/config"
 	"github.com/alpacax/alpamon/pkg/signing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testServerID = "server-456"
 
 // newTestKeyServer creates a test HTTP server that serves a public key.
 func newTestKeyServer(t *testing.T, pub ed25519.PublicKey, keyID string) *httptest.Server {
@@ -112,13 +113,9 @@ func TestVerifyCommandSignature_ValidSignature(t *testing.T) {
 	server := newTestKeyServer(t, pub, keyID)
 	defer server.Close()
 
-	serverID := "server-456"
-	origID := config.GlobalSettings.ID
-	config.GlobalSettings.ID = serverID
-	defer func() { config.GlobalSettings.ID = origID }()
-
 	wc := &WebsocketClient{
 		signingMode: "enforce",
+		serverID:    testServerID,
 		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
 	}
 
@@ -131,7 +128,7 @@ func TestVerifyCommandSignature_ValidSignature(t *testing.T) {
 		AnalyzedAt: "2026-03-01T12:00:00+00:00",
 		KeyID:      keyID,
 	}
-	signCommand(t, cmd, serverID, priv)
+	signCommand(t, cmd, testServerID, priv)
 
 	err = wc.verifyCommandSignature(cmd)
 	assert.NoError(t, err, "valid signature should pass")
@@ -149,13 +146,9 @@ func TestVerifyCommandSignature_InvalidSignature(t *testing.T) {
 	server := newTestKeyServer(t, pub, keyID)
 	defer server.Close()
 
-	serverID := "server-456"
-	origID := config.GlobalSettings.ID
-	config.GlobalSettings.ID = serverID
-	defer func() { config.GlobalSettings.ID = origID }()
-
 	wc := &WebsocketClient{
 		signingMode: "enforce",
+		serverID:    testServerID,
 		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
 	}
 
@@ -168,7 +161,7 @@ func TestVerifyCommandSignature_InvalidSignature(t *testing.T) {
 		AnalyzedAt: "2026-03-01T12:00:00+00:00",
 		KeyID:      keyID,
 	}
-	signCommand(t, cmd, serverID, differentPriv)
+	signCommand(t, cmd, testServerID, differentPriv)
 
 	err = wc.verifyCommandSignature(cmd)
 	assert.Error(t, err, "invalid signature should fail")
@@ -197,13 +190,9 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 	}))
 	defer server.Close()
 
-	serverID := "server-456"
-	origID := config.GlobalSettings.ID
-	config.GlobalSettings.ID = serverID
-	defer func() { config.GlobalSettings.ID = origID }()
-
 	wc := &WebsocketClient{
 		signingMode: "enforce",
+		serverID:    testServerID,
 		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
 	}
 
@@ -217,7 +206,7 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 		AnalyzedAt: "2026-03-01T12:00:00+00:00",
 		KeyID:      keyID,
 	}
-	signCommand(t, cmdOld, serverID, oldPriv)
+	signCommand(t, cmdOld, testServerID, oldPriv)
 
 	// This will fail with old key, trigger refresh, fetch new key, but still fail
 	// because the command was signed with old key
@@ -234,7 +223,7 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 		AnalyzedAt: "2026-03-01T12:00:00+00:00",
 		KeyID:      keyID,
 	}
-	signCommand(t, cmdNew, serverID, newPriv)
+	signCommand(t, cmdNew, testServerID, newPriv)
 
 	err = wc.verifyCommandSignature(cmdNew)
 	assert.NoError(t, err, "command signed with new key should succeed after rotation")
@@ -298,13 +287,9 @@ func TestVerifyCommandSignature_InvalidSignatureMonitorMode(t *testing.T) {
 	server := newTestKeyServer(t, pub, keyID)
 	defer server.Close()
 
-	serverID := "server-456"
-	origID := config.GlobalSettings.ID
-	config.GlobalSettings.ID = serverID
-	defer func() { config.GlobalSettings.ID = origID }()
-
 	wc := &WebsocketClient{
 		signingMode: "monitor",
+		serverID:    testServerID,
 		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
 	}
 
@@ -317,7 +302,7 @@ func TestVerifyCommandSignature_InvalidSignatureMonitorMode(t *testing.T) {
 		AnalyzedAt: "2026-03-01T12:00:00+00:00",
 		KeyID:      keyID,
 	}
-	signCommand(t, cmd, serverID, differentPriv)
+	signCommand(t, cmd, testServerID, differentPriv)
 
 	err = wc.verifyCommandSignature(cmd)
 	assert.NoError(t, err, "monitor mode should allow execution even with invalid signature")
@@ -330,13 +315,9 @@ func TestVerifyCommandSignature_WithoutKeyID(t *testing.T) {
 	server := newTestKeyServer(t, pub, "default-key")
 	defer server.Close()
 
-	serverID := "server-456"
-	origID := config.GlobalSettings.ID
-	config.GlobalSettings.ID = serverID
-	defer func() { config.GlobalSettings.ID = origID }()
-
 	wc := &WebsocketClient{
 		signingMode: "enforce",
+		serverID:    testServerID,
 		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
 	}
 
@@ -349,7 +330,7 @@ func TestVerifyCommandSignature_WithoutKeyID(t *testing.T) {
 		AnalyzedAt: "2026-03-01T12:00:00+00:00",
 		// No KeyID: uses GetPublicKey() instead of GetPublicKeyForKID()
 	}
-	signCommand(t, cmd, serverID, priv)
+	signCommand(t, cmd, testServerID, priv)
 
 	err = wc.verifyCommandSignature(cmd)
 	assert.NoError(t, err, "should work without key_id using default key")

--- a/pkg/runner/signing_test.go
+++ b/pkg/runner/signing_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -103,7 +104,7 @@ func TestVerifyCommandSignature_UnsignedEnforceMode(t *testing.T) {
 
 	err := wc.verifyCommandSignature(cmd)
 	assert.Error(t, err, "enforce mode should reject unsigned commands")
-	assert.Contains(t, err.Error(), "missing signature")
+	assert.Equal(t, rejectReasonUnsigned, err.Error())
 }
 
 func TestVerifyCommandSignature_ValidSignature(t *testing.T) {
@@ -166,7 +167,7 @@ func TestVerifyCommandSignature_InvalidSignature(t *testing.T) {
 
 	err = wc.verifyCommandSignature(cmd)
 	assert.Error(t, err, "invalid signature should fail")
-	assert.Contains(t, err.Error(), "signature verification failed")
+	assert.Equal(t, rejectReasonSignatureMismatch, err.Error())
 }
 
 func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
@@ -283,7 +284,7 @@ func TestVerifyCommandSignature_KeyUnavailableEnforceMode(t *testing.T) {
 
 	err := wc.verifyCommandSignature(cmd)
 	assert.Error(t, err, "enforce mode should reject when key unavailable")
-	assert.Contains(t, err.Error(), "public key unavailable")
+	assert.Equal(t, rejectReasonKeyUnavailable, err.Error())
 }
 
 func TestVerifyCommandSignature_InvalidSignatureMonitorMode(t *testing.T) {
@@ -345,6 +346,18 @@ func TestVerifyCommandSignature_WithoutKeyID(t *testing.T) {
 
 	err = wc.verifyCommandSignature(cmd)
 	assert.NoError(t, err, "should work without key_id using default key")
+}
+
+func TestRejectionError_ReasonAndUnwrap(t *testing.T) {
+	inner := errors.New("detailed internal error")
+	re := newRejection(rejectReasonInvalidSignature, inner)
+
+	// Error() returns only the fixed reason string (sent to server)
+	assert.Equal(t, rejectReasonInvalidSignature, re.Error())
+
+	// Unwrap() returns the detailed error (for local logging)
+	assert.Equal(t, inner, errors.Unwrap(re))
+	assert.ErrorIs(t, re, inner)
 }
 
 func TestRejectCommandURL(t *testing.T) {

--- a/pkg/runner/signing_test.go
+++ b/pkg/runner/signing_test.go
@@ -1,0 +1,362 @@
+package runner
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpacax/alpamon/internal/protocol"
+	"github.com/alpacax/alpamon/pkg/config"
+	"github.com/alpacax/alpamon/pkg/signing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestKeyServer creates a test HTTP server that serves a public key.
+func newTestKeyServer(t *testing.T, pub ed25519.PublicKey, keyID string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]string{
+			"algorithm":  "Ed25519",
+			"public_key": base64.StdEncoding.EncodeToString(pub),
+			"key_id":     keyID,
+			"valid_from": "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// signCommand signs a command with the given private key and server ID.
+func signCommand(t *testing.T, cmd *protocol.Command, serverID string, priv ed25519.PrivateKey) {
+	t.Helper()
+	payload := signing.BuildCanonicalPayload(cmd, serverID)
+	sig := ed25519.Sign(priv, payload)
+	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
+}
+
+func TestVerifyCommandSignature_InternalBypass(t *testing.T) {
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:    "cmd-1",
+		Shell: "internal",
+		Line:  "ping",
+	}
+
+	err := wc.verifyCommandSignature(cmd)
+	assert.NoError(t, err, "internal commands should bypass verification")
+}
+
+func TestVerifyCommandSignature_NoKeyManager(t *testing.T) {
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		keyManager:  nil,
+	}
+
+	cmd := &protocol.Command{
+		ID:    "cmd-1",
+		Shell: "system",
+		Line:  "whoami",
+	}
+
+	err := wc.verifyCommandSignature(cmd)
+	assert.NoError(t, err, "should skip when key manager is nil")
+}
+
+func TestVerifyCommandSignature_UnsignedMonitorMode(t *testing.T) {
+	wc := &WebsocketClient{
+		signingMode: "monitor",
+		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:    "cmd-1",
+		Shell: "system",
+		Line:  "whoami",
+	}
+
+	err := wc.verifyCommandSignature(cmd)
+	assert.NoError(t, err, "monitor mode should allow unsigned commands")
+}
+
+func TestVerifyCommandSignature_UnsignedEnforceMode(t *testing.T) {
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:    "cmd-1",
+		Shell: "system",
+		Line:  "whoami",
+	}
+
+	err := wc.verifyCommandSignature(cmd)
+	assert.Error(t, err, "enforce mode should reject unsigned commands")
+	assert.Contains(t, err.Error(), "missing signature")
+}
+
+func TestVerifyCommandSignature_ValidSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	keyID := "test-key-1"
+	server := newTestKeyServer(t, pub, keyID)
+	defer server.Close()
+
+	serverID := "server-456"
+	origID := config.GlobalSettings.ID
+	config.GlobalSettings.ID = serverID
+	defer func() { config.GlobalSettings.ID = origID }()
+
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "echo hello",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		KeyID:      keyID,
+	}
+	signCommand(t, cmd, serverID, priv)
+
+	err = wc.verifyCommandSignature(cmd)
+	assert.NoError(t, err, "valid signature should pass")
+}
+
+func TestVerifyCommandSignature_InvalidSignature(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	// Sign with a different key
+	_, differentPriv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	keyID := "test-key-1"
+	server := newTestKeyServer(t, pub, keyID)
+	defer server.Close()
+
+	serverID := "server-456"
+	origID := config.GlobalSettings.ID
+	config.GlobalSettings.ID = serverID
+	defer func() { config.GlobalSettings.ID = origID }()
+
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "echo hello",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		KeyID:      keyID,
+	}
+	signCommand(t, cmd, serverID, differentPriv)
+
+	err = wc.verifyCommandSignature(cmd)
+	assert.Error(t, err, "invalid signature should fail")
+	assert.Contains(t, err.Error(), "signature verification failed")
+}
+
+func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
+	// Start with old key, then rotate to new key
+	_, oldPriv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	newPub, newPriv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	keyID := "new-key-1"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always serve the new key (simulating key rotation)
+		resp := map[string]string{
+			"algorithm":  "Ed25519",
+			"public_key": base64.StdEncoding.EncodeToString(newPub),
+			"key_id":     keyID,
+			"valid_from": "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	serverID := "server-456"
+	origID := config.GlobalSettings.ID
+	config.GlobalSettings.ID = serverID
+	defer func() { config.GlobalSettings.ID = origID }()
+
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+	}
+
+	// First, sign with old key and pre-load old key into cache
+	cmdOld := &protocol.Command{
+		ID:         "cmd-old",
+		Shell:      "system",
+		Line:       "whoami",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		KeyID:      keyID,
+	}
+	signCommand(t, cmdOld, serverID, oldPriv)
+
+	// This will fail with old key, trigger refresh, fetch new key, but still fail
+	// because the command was signed with old key
+	err = wc.verifyCommandSignature(cmdOld)
+	assert.Error(t, err, "command signed with old key should fail after rotation")
+
+	// Now sign with new key: should succeed (new key already cached from refresh)
+	cmdNew := &protocol.Command{
+		ID:         "cmd-new",
+		Shell:      "system",
+		Line:       "whoami",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		KeyID:      keyID,
+	}
+	signCommand(t, cmdNew, serverID, newPriv)
+
+	err = wc.verifyCommandSignature(cmdNew)
+	assert.NoError(t, err, "command signed with new key should succeed after rotation")
+}
+
+func TestVerifyCommandSignature_KeyUnavailableMonitorMode(t *testing.T) {
+	// AI server returns 500
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	wc := &WebsocketClient{
+		signingMode: "monitor",
+		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:        "cmd-1",
+		Shell:     "system",
+		Line:      "whoami",
+		Signature: "some-signature",
+	}
+
+	err := wc.verifyCommandSignature(cmd)
+	assert.NoError(t, err, "monitor mode should allow when key unavailable")
+}
+
+func TestVerifyCommandSignature_KeyUnavailableEnforceMode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:        "cmd-1",
+		Shell:     "system",
+		Line:      "whoami",
+		Signature: "some-signature",
+	}
+
+	err := wc.verifyCommandSignature(cmd)
+	assert.Error(t, err, "enforce mode should reject when key unavailable")
+	assert.Contains(t, err.Error(), "public key unavailable")
+}
+
+func TestVerifyCommandSignature_InvalidSignatureMonitorMode(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	// Sign with a different key
+	_, differentPriv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	keyID := "test-key-1"
+	server := newTestKeyServer(t, pub, keyID)
+	defer server.Close()
+
+	serverID := "server-456"
+	origID := config.GlobalSettings.ID
+	config.GlobalSettings.ID = serverID
+	defer func() { config.GlobalSettings.ID = origID }()
+
+	wc := &WebsocketClient{
+		signingMode: "monitor",
+		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "echo hello",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		KeyID:      keyID,
+	}
+	signCommand(t, cmd, serverID, differentPriv)
+
+	err = wc.verifyCommandSignature(cmd)
+	assert.NoError(t, err, "monitor mode should allow execution even with invalid signature")
+}
+
+func TestVerifyCommandSignature_WithoutKeyID(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	server := newTestKeyServer(t, pub, "default-key")
+	defer server.Close()
+
+	serverID := "server-456"
+	origID := config.GlobalSettings.ID
+	config.GlobalSettings.ID = serverID
+	defer func() { config.GlobalSettings.ID = origID }()
+
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "echo hello",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		// No KeyID: uses GetPublicKey() instead of GetPublicKeyForKID()
+	}
+	signCommand(t, cmd, serverID, priv)
+
+	err = wc.verifyCommandSignature(cmd)
+	assert.NoError(t, err, "should work without key_id using default key")
+}
+
+func TestRejectCommandURL(t *testing.T) {
+	// Verify the reject URL format is correct
+	assert.Equal(t, "/api/events/commands/cmd-123/reject/",
+		fmt.Sprintf(eventCommandRejectURL, "cmd-123"))
+}

--- a/pkg/runner/signing_test.go
+++ b/pkg/runner/signing_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/alpacax/alpamon/internal/protocol"
@@ -169,19 +170,27 @@ func TestVerifyCommandSignature_InvalidSignature(t *testing.T) {
 }
 
 func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
-	// Start with old key, then rotate to new key
-	_, oldPriv, err := ed25519.GenerateKey(nil)
+	oldPub, oldPriv, err := ed25519.GenerateKey(nil)
 	require.NoError(t, err)
 
 	newPub, newPriv, err := ed25519.GenerateKey(nil)
 	require.NoError(t, err)
 
-	keyID := "new-key-1"
+	keyID := "rotated-key-1"
+	var fetchCount atomic.Int32
+
+	// Serve old key on first request, new key on subsequent requests
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Always serve the new key (simulating key rotation)
+		n := fetchCount.Add(1)
+		var pub ed25519.PublicKey
+		if n == 1 {
+			pub = oldPub
+		} else {
+			pub = newPub
+		}
 		resp := map[string]string{
 			"algorithm":  "Ed25519",
-			"public_key": base64.StdEncoding.EncodeToString(newPub),
+			"public_key": base64.StdEncoding.EncodeToString(pub),
 			"key_id":     keyID,
 			"valid_from": "2026-01-01T00:00:00Z",
 		}
@@ -196,7 +205,7 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
 	}
 
-	// First, sign with old key and pre-load old key into cache
+	// Pre-populate cache with old key by verifying a command signed with it
 	cmdOld := &protocol.Command{
 		ID:         "cmd-old",
 		Shell:      "system",
@@ -207,13 +216,13 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 		KeyID:      keyID,
 	}
 	signCommand(t, cmdOld, testServerID, oldPriv)
-
-	// This will fail with old key, trigger refresh, fetch new key, but still fail
-	// because the command was signed with old key
 	err = wc.verifyCommandSignature(cmdOld)
-	assert.Error(t, err, "command signed with old key should fail after rotation")
+	require.NoError(t, err, "command signed with old key should pass initially")
+	require.Equal(t, int32(1), fetchCount.Load(), "should have fetched key once")
 
-	// Now sign with new key: should succeed (new key already cached from refresh)
+	// Now sign a command with the new key. First verification attempt uses
+	// the cached old key and fails, triggering ForceRefresh which fetches the
+	// new key, and the retry succeeds.
 	cmdNew := &protocol.Command{
 		ID:         "cmd-new",
 		Shell:      "system",
@@ -226,7 +235,9 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 	signCommand(t, cmdNew, testServerID, newPriv)
 
 	err = wc.verifyCommandSignature(cmdNew)
-	assert.NoError(t, err, "command signed with new key should succeed after rotation")
+	assert.NoError(t, err, "command signed with new key should succeed after key rotation")
+	assert.Equal(t, int32(2), fetchCount.Load(),
+		"should have fetched key twice: initial + ForceRefresh for rotation")
 }
 
 func TestVerifyCommandSignature_KeyUnavailableMonitorMode(t *testing.T) {

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -151,6 +151,13 @@ func (m *KeyManager) Refresh() error {
 	return m.fetchKeyLocked()
 }
 
+// ForceRefresh fetches the public key from the AI server unconditionally,
+// regardless of whether the cached key is still valid. Use this when
+// signature verification fails and a key rotation may have occurred.
+func (m *KeyManager) ForceRefresh() error {
+	return m.fetchKey()
+}
+
 // fetchKey acquires the refresh lock and fetches unconditionally.
 // Used by GetPublicKeyForKID when kid doesn't match (key may not be expired).
 func (m *KeyManager) fetchKey() error {

--- a/pkg/signing/verifier.go
+++ b/pkg/signing/verifier.go
@@ -11,6 +11,12 @@ import (
 	"github.com/alpacax/alpamon/internal/protocol"
 )
 
+// ErrSignatureMismatch is returned when the Ed25519 signature does not match
+// the payload. This is the only VerifyCommand error worth retrying after a
+// key refresh (key rotation scenario). Other errors (malformed input, wrong
+// sizes) cannot be fixed by fetching a new key.
+var ErrSignatureMismatch = errors.New("signature verification failed")
+
 // signingPayload defines the canonical payload that the AI server signs.
 // Struct fields are ordered alphabetically by JSON tag to match Python's
 // json.dumps(sort_keys=True, separators=(',', ':')).
@@ -118,7 +124,7 @@ func VerifyCommand(cmd *protocol.Command, serverID string, publicKey ed25519.Pub
 	payload := BuildCanonicalPayload(cmd, serverID)
 
 	if !ed25519.Verify(publicKey, payload, sig) {
-		return errors.New("signature verification failed")
+		return ErrSignatureMismatch
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Wire `pkg/signing` into `CommandRequestHandler()` to verify Ed25519 signatures before ACK
- Monitor mode: log warnings on unsigned/invalid commands, always execute
- Enforce mode: reject unsigned/invalid commands, report via `POST /api/events/commands/{id}/reject/`
- Key rotation support: retry verification once after forced key refresh on failure

This is **PR 3 of 3** for the command signing feature (#262).

## Changes

- `pkg/runner/client.go`: Add `keyManager`/`signingMode` fields, initialize `KeyManager` from config, insert verification before ACK in `CommandRequestHandler`
- `pkg/runner/signing.go` (new): `verifyCommandSignature()` with internal bypass, mode-aware handling, and key rotation retry; `rejectCommand()` for server-side rejection reporting
- `pkg/runner/signing_test.go` (new): 12 tests covering internal bypass, unsigned in both modes, valid/invalid signatures in both modes, key rotation, key unavailability, and no-KID fallback

## Pipeline results

- Tests: PASS (93 tests across `pkg/runner` and `pkg/signing`, 0 failures)
- Review: APPROVED after fix (1 critical issue found and fixed — monitor mode was rejecting invalid signatures instead of warning)

## Testing

- [x] All existing runner tests pass (68 tests)
- [x] All signing package tests pass (25 tests)
- [x] New integration tests pass (12 tests)
- [x] Build passes (`go build ./cmd/alpamon`)

## Dependencies

- [x] PR 1: Protocol fields + config (#263) — merged
- [x] PR 2: Signing package (#264) — merged
- [ ] alpacon-server #1816 (view integration) — open, blocks end-to-end testing

Closes #262