### PR TITLE
feat(pam): track Command executions for deploy shell sudo authorization

### DIFF
--- a/internal/runnertest/runnertest.go
+++ b/internal/runnertest/runnertest.go
@@ -3,6 +3,10 @@
 // "testing" (which would otherwise leak test-only API surface and the
 // testing dependency into shipped binaries).
 //
+// It lives under the repo-root internal/ tree so the Go compiler blocks
+// imports from outside this module, preventing accidental use of the
+// singleton-swap helper from external consumers.
+//
 // This package must only be imported from *_test.go files.
 package runnertest
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -113,16 +113,9 @@ func (e *Executor) runCommand(cmd *exec.Cmd, pidHook func(pid int)) ([]byte, err
 		return buf.Bytes(), err
 	}
 
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				log.Error().Interface("panic", r).Msg("PIDHook panicked; continuing")
-			}
-		}()
-		if cmd.Process != nil {
-			pidHook(cmd.Process.Pid)
-		}
-	}()
+	if cmd.Process != nil {
+		pidHook(cmd.Process.Pid)
+	}
 
 	err := cmd.Wait()
 	return buf.Bytes(), err

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -79,7 +79,7 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 
 	// Execute command
 	start := time.Now()
-	output, err := cmd.CombinedOutput()
+	output, err := e.runCommand(cmd, opts.PIDHook)
 	exitCode := 0
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -96,6 +96,38 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 	return exitCode, string(output), err
 }
 
+// runCommand executes cmd and returns its combined stdout/stderr output.
+// When pidHook is non-nil, the command is started with cmd.Start() so the
+// child's pid can be reported before Wait blocks. When pidHook is nil,
+// the simpler cmd.CombinedOutput() path is used unchanged.
+func (e *Executor) runCommand(cmd *exec.Cmd, pidHook func(pid int)) ([]byte, error) {
+	if pidHook == nil {
+		return cmd.CombinedOutput()
+	}
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Start(); err != nil {
+		return buf.Bytes(), err
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().Interface("panic", r).Msg("PIDHook panicked; continuing")
+			}
+		}()
+		if cmd.Process != nil {
+			pidHook(cmd.Process.Pid)
+		}
+	}()
+
+	err := cmd.Wait()
+	return buf.Bytes(), err
+}
+
 // CommandOptions defines options for command execution
 type CommandOptions struct {
 	Args       []string          // Command and arguments
@@ -105,6 +137,18 @@ type CommandOptions struct {
 	WorkingDir string            // Working directory
 	Timeout    time.Duration     // Command timeout
 	Input      string            // Input to provide via stdin
+
+	// PIDHook, if non-nil, is invoked with the child's pid immediately
+	// after cmd.Start() returns successfully and before the command is
+	// waited on. It is used to register the root pid of a deploy shell
+	// Command with the PAM tracker so that sudo invoked inside the
+	// command can be attributed to the originating Command.ID.
+	//
+	// When PIDHook is set, Execute uses cmd.Start()/cmd.Wait() instead
+	// of cmd.CombinedOutput() so the pid is visible to the hook before
+	// the child can exec sudo. Any panic from the hook is recovered and
+	// logged without affecting command execution.
+	PIDHook func(pid int)
 }
 
 // substituteEnvVars replaces environment variables in arguments
@@ -217,5 +261,20 @@ func (e *Executor) Exec(ctx context.Context, args []string, username, groupname 
 		Groupname: groupname,
 		Env:       env,
 		Timeout:   timeout,
+	})
+}
+
+// ExecWithHook is like Exec but registers a PIDHook that receives the
+// child's pid immediately after cmd.Start() succeeds. This is used by
+// the shell handler to track the root pid of a deploy shell Command so
+// sudo calls made inside the command can be authorized via command_id.
+func (e *Executor) ExecWithHook(ctx context.Context, args []string, username, groupname string, env map[string]string, timeout time.Duration, pidHook func(pid int)) (int, string, error) {
+	return e.Execute(ctx, CommandOptions{
+		Args:      args,
+		Username:  username,
+		Groupname: groupname,
+		Env:       env,
+		Timeout:   timeout,
+		PIDHook:   pidHook,
 	})
 }

--- a/pkg/executor/handlers/common/args.go
+++ b/pkg/executor/handlers/common/args.go
@@ -6,6 +6,10 @@ import "time"
 type CommandArgs struct {
 	// Common fields
 	SessionID string
+	// CommandID is the UUID of the deploy shell Command that originated
+	// this execution (propagated from protocol.Command.ID). Empty for
+	// non-Command-driven work such as internal collectors.
+	CommandID string
 	URL       string
 	Command   string
 	Timeout   time.Duration

--- a/pkg/executor/handlers/common/interfaces.go
+++ b/pkg/executor/handlers/common/interfaces.go
@@ -42,6 +42,14 @@ type CommandExecutor interface {
 
 	// Exec executes a command with all options (user, group, env, timeout)
 	Exec(ctx context.Context, args []string, username, groupname string, env map[string]string, timeout time.Duration) (int, string, error)
+
+	// ExecWithHook is like Exec but invokes pidHook with the child's pid
+	// immediately after the process is started (before it is waited on).
+	// Callers use it to register the root pid with the PAM tracker so
+	// sudo calls issued by the child can be attributed to the originating
+	// deploy shell Command. pidHook may be nil, in which case this
+	// behaves identically to Exec.
+	ExecWithHook(ctx context.Context, args []string, username, groupname string, env map[string]string, timeout time.Duration, pidHook func(pid int)) (int, string, error)
 }
 
 // WSClient interface for WebSocket client operations

--- a/pkg/executor/handlers/common/testing.go
+++ b/pkg/executor/handlers/common/testing.go
@@ -82,6 +82,16 @@ func (m *MockCommandExecutor) Exec(ctx context.Context, args []string, username,
 	return m.lookupResult(args[0], args[1:]...)
 }
 
+// ExecWithHook mirrors Exec for mock purposes and invokes pidHook (when
+// non-nil) with a synthetic pid of 0 so handlers that rely on the hook
+// contract can be exercised without spawning real processes.
+func (m *MockCommandExecutor) ExecWithHook(ctx context.Context, args []string, username, groupname string, env map[string]string, timeout time.Duration, pidHook func(pid int)) (int, string, error) {
+	if pidHook != nil {
+		pidHook(0)
+	}
+	return m.Exec(ctx, args, username, groupname, env, timeout)
+}
+
 func (m *MockCommandExecutor) SetResult(command string, exitCode int, output string, err error) {
 	m.results[command] = CommandResult{ExitCode: exitCode, Output: output, Err: err}
 }

--- a/pkg/executor/handlers/common/testing.go
+++ b/pkg/executor/handlers/common/testing.go
@@ -40,6 +40,9 @@ type CommandResult struct {
 }
 
 func NewMockCommandExecutor(t *testing.T) *MockCommandExecutor {
+	// Reset the synthetic pid counter on cleanup so pids don't leak across
+	// tests and future tests can rely on a predictable starting point.
+	t.Cleanup(func() { mockSyntheticPID.Store(0) })
 	return &MockCommandExecutor{
 		t:        t,
 		commands: []ExecutedCommand{},

--- a/pkg/executor/handlers/common/testing.go
+++ b/pkg/executor/handlers/common/testing.go
@@ -3,9 +3,18 @@ package common
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// mockSyntheticPID produces monotonically increasing positive pids for
+// MockCommandExecutor.ExecWithHook so that every invocation hands the
+// hook a distinct, positive value. The base is well above typical real
+// pids to make accidental collisions obvious in test output.
+var mockSyntheticPID atomic.Int64
+
+const mockSyntheticPIDBase = 900000
 
 // MockCommandExecutor is a mock implementation of CommandExecutor for testing.
 // It is the single source of truth for mocking in this package.
@@ -83,11 +92,14 @@ func (m *MockCommandExecutor) Exec(ctx context.Context, args []string, username,
 }
 
 // ExecWithHook mirrors Exec for mock purposes and invokes pidHook (when
-// non-nil) with a synthetic pid of 0 so handlers that rely on the hook
-// contract can be exercised without spawning real processes.
+// non-nil) with a distinct, positive synthetic pid so handlers that rely
+// on the hook contract can be exercised without spawning real processes.
+// Using a positive pid ensures the registration code paths in the PID
+// tracker (which ignores pid<=0) are actually exercised.
 func (m *MockCommandExecutor) ExecWithHook(ctx context.Context, args []string, username, groupname string, env map[string]string, timeout time.Duration, pidHook func(pid int)) (int, string, error) {
 	if pidHook != nil {
-		pidHook(0)
+		pid := int(mockSyntheticPIDBase + mockSyntheticPID.Add(1))
+		pidHook(pid)
 	}
 	return m.Exec(ctx, args, username, groupname, env, timeout)
 }

--- a/pkg/executor/handlers/shell/shell.go
+++ b/pkg/executor/handlers/shell/shell.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
+	"github.com/alpacax/alpamon/pkg/runner"
 	"github.com/alpacax/alpamon/pkg/utils"
 	"github.com/rs/zerolog/log"
 )
@@ -86,16 +87,16 @@ func (h *ShellHandler) handleShellCommand(ctx context.Context, args *common.Comm
 		} else {
 			cmdArgs = []string{"/bin/sh", "-c", command}
 		}
-		exitCode, result := h.executeCommand(ctx, cmdArgs, username, groupname, env, timeout)
+		exitCode, result := h.executeCommand(ctx, cmdArgs, username, groupname, env, timeout, args.CommandID)
 		return exitCode, result, nil
 	}
 
 	// Fallback: direct execution with manual operator parsing
-	return h.executeWithOperators(ctx, command, username, groupname, env, timeout)
+	return h.executeWithOperators(ctx, command, username, groupname, env, timeout, args.CommandID)
 }
 
 // executeWithOperators handles shell operators (&&, ||, ;)
-func (h *ShellHandler) executeWithOperators(ctx context.Context, command, username, groupname string, env map[string]string, timeout time.Duration) (int, string, error) {
+func (h *ShellHandler) executeWithOperators(ctx context.Context, command, username, groupname string, env map[string]string, timeout time.Duration, commandID string) (int, string, error) {
 	spl := strings.Fields(command)
 	var currentCmd []string
 	var results strings.Builder
@@ -107,7 +108,7 @@ func (h *ShellHandler) executeWithOperators(ctx context.Context, command, userna
 		case "&&":
 			// Execute current command
 			if len(currentCmd) > 0 {
-				exitCode, result = h.executeCommand(ctx, currentCmd, username, groupname, env, timeout)
+				exitCode, result = h.executeCommand(ctx, currentCmd, username, groupname, env, timeout, commandID)
 				results.WriteString(result)
 				// Stop if command fails
 				if exitCode != 0 {
@@ -118,7 +119,7 @@ func (h *ShellHandler) executeWithOperators(ctx context.Context, command, userna
 		case "||":
 			// Execute current command
 			if len(currentCmd) > 0 {
-				exitCode, result = h.executeCommand(ctx, currentCmd, username, groupname, env, timeout)
+				exitCode, result = h.executeCommand(ctx, currentCmd, username, groupname, env, timeout, commandID)
 				results.WriteString(result)
 				// Continue only if command fails
 				if exitCode == 0 {
@@ -129,7 +130,7 @@ func (h *ShellHandler) executeWithOperators(ctx context.Context, command, userna
 		case ";":
 			// Execute current command
 			if len(currentCmd) > 0 {
-				exitCode, result = h.executeCommand(ctx, currentCmd, username, groupname, env, timeout)
+				exitCode, result = h.executeCommand(ctx, currentCmd, username, groupname, env, timeout, commandID)
 				results.WriteString(result)
 				// Continue regardless of result
 				currentCmd = nil
@@ -141,21 +142,46 @@ func (h *ShellHandler) executeWithOperators(ctx context.Context, command, userna
 
 	// Execute any remaining command
 	if len(currentCmd) > 0 {
-		exitCode, result = h.executeCommand(ctx, currentCmd, username, groupname, env, timeout)
+		exitCode, result = h.executeCommand(ctx, currentCmd, username, groupname, env, timeout, commandID)
 		results.WriteString(result)
 	}
 
 	return exitCode, results.String(), nil
 }
 
-// executeCommand executes a single command
-func (h *ShellHandler) executeCommand(ctx context.Context, cmdArgs []string, username, groupname string, env map[string]string, timeout time.Duration) (int, string) {
+// executeCommand executes a single command.
+// When commandID is non-empty, the child's root pid is registered with
+// the PAM tracker for the duration of the execution so sudo calls made
+// from inside the command can be authorized by command_id.
+func (h *ShellHandler) executeCommand(ctx context.Context, cmdArgs []string, username, groupname string, env map[string]string, timeout time.Duration, commandID string) (int, string) {
 	if len(cmdArgs) == 0 {
 		return 0, ""
 	}
 
-	// Execute command through the executor with full parameters (user, group, env, timeout)
-	exitCode, output, err := h.Executor.Exec(ctx, cmdArgs, username, groupname, env, timeout)
+	var (
+		exitCode int
+		output   string
+		err      error
+	)
+
+	if commandID != "" {
+		// Track the pid in the PAM tracker before the child can exec
+		// sudo; unregister after the command completes. Holds the pid
+		// in a closure so we only unregister the exact pid we tracked,
+		// guarding against pid reuse.
+		var trackedPID int
+		registered := false
+		pidHook := func(pid int) {
+			trackedPID = pid
+			registered = runner.RegisterCommandPID(pid, commandID, username)
+		}
+		exitCode, output, err = h.Executor.ExecWithHook(ctx, cmdArgs, username, groupname, env, timeout, pidHook)
+		if registered {
+			runner.UnregisterCommandPID(trackedPID, commandID)
+		}
+	} else {
+		exitCode, output, err = h.Executor.Exec(ctx, cmdArgs, username, groupname, env, timeout)
+	}
 
 	if err != nil && exitCode == -1 {
 		// Command execution error (not just non-zero exit)

--- a/pkg/executor/handlers/shell/shell.go
+++ b/pkg/executor/handlers/shell/shell.go
@@ -166,18 +166,16 @@ func (h *ShellHandler) executeCommand(ctx context.Context, cmdArgs []string, use
 
 	if commandID != "" {
 		// Track the pid in the PAM tracker before the child can exec
-		// sudo; unregister after the command completes. Holds the pid
-		// in a closure so we only unregister the exact pid we tracked,
-		// guarding against pid reuse.
-		var trackedPID int
-		registered := false
+		// sudo; unregister after the command completes. The register
+		// helper returns a closure that captures the exact (pid,
+		// commandID) pair, so the cleanup is leak-proof by construction.
+		var cleanup func()
 		pidHook := func(pid int) {
-			trackedPID = pid
-			registered = runner.RegisterCommandPID(pid, commandID, username)
+			cleanup = runner.RegisterCommandPID(pid, commandID, username)
 		}
 		exitCode, output, err = h.Executor.ExecWithHook(ctx, cmdArgs, username, groupname, env, timeout, pidHook)
-		if registered {
-			runner.UnregisterCommandPID(trackedPID, commandID)
+		if cleanup != nil {
+			cleanup()
 		}
 	} else {
 		exitCode, output, err = h.Executor.Exec(ctx, cmdArgs, username, groupname, env, timeout)

--- a/pkg/executor/handlers/shell/shell_command_tracker_test.go
+++ b/pkg/executor/handlers/shell/shell_command_tracker_test.go
@@ -40,7 +40,7 @@ func (r *hookRecordingExecutor) ExecWithHook(
 	if pidHook != nil {
 		pidHook(424242)
 	}
-	return r.MockCommandExecutor.Exec(ctx, args, username, groupname, env, timeout)
+	return r.Exec(ctx, args, username, groupname, env, timeout)
 }
 
 // withTrackerAuthManager installs a clean in-process AuthManager for the

--- a/pkg/executor/handlers/shell/shell_command_tracker_test.go
+++ b/pkg/executor/handlers/shell/shell_command_tracker_test.go
@@ -1,0 +1,109 @@
+package shell
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
+	"github.com/alpacax/alpamon/pkg/runner"
+)
+
+// hookRecordingExecutor wraps a MockCommandExecutor and records whether
+// ExecWithHook was invoked and whether it passed through a non-nil hook.
+// It is deliberately local to the shell handler tests so it cannot be
+// accidentally reused by other handlers and mask real breakage.
+type hookRecordingExecutor struct {
+	*common.MockCommandExecutor
+	mu       sync.Mutex
+	called   bool
+	hookSeen bool
+}
+
+func (r *hookRecordingExecutor) ExecWithHook(
+	ctx context.Context,
+	args []string,
+	username, groupname string,
+	env map[string]string,
+	timeout time.Duration,
+	pidHook func(pid int),
+) (int, string, error) {
+	r.mu.Lock()
+	r.called = true
+	r.hookSeen = pidHook != nil
+	r.mu.Unlock()
+
+	// Simulate the executor's post-fork callback so the shell handler
+	// exercises the Register/Unregister lifecycle.
+	if pidHook != nil {
+		pidHook(424242)
+	}
+	return r.MockCommandExecutor.Exec(ctx, args, username, groupname, env, timeout)
+}
+
+// withTrackerAuthManager installs a clean in-process AuthManager for the
+// duration of t and restores the previous singleton on cleanup.
+func withTrackerAuthManager(t *testing.T) *runner.AuthManager {
+	t.Helper()
+	return runner.SwapAuthManagerForTest(t, runner.NewAuthManagerForTest())
+}
+
+// TestShellHandler_CommandID_RegistersAndUnregistersPID verifies that a
+// shell invocation carrying CommandID uses the hook path and cleans up
+// the tracker entry after execution.
+func TestShellHandler_CommandID_RegistersAndUnregistersPID(t *testing.T) {
+	am := withTrackerAuthManager(t)
+
+	mock := common.NewMockCommandExecutor(t)
+	rec := &hookRecordingExecutor{MockCommandExecutor: mock}
+
+	handler := NewShellHandler(rec)
+	args := &common.CommandArgs{
+		CommandID: "cmd-xyz",
+		Command:   "echo hello",
+		Username:  "alice",
+		AllowSh:   true,
+	}
+
+	exit, _, err := handler.Execute(context.Background(), common.ShellCmd.String(), args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exit != 0 {
+		t.Errorf("exit: got %d, want 0", exit)
+	}
+	if !rec.called {
+		t.Error("ExecWithHook was not invoked")
+	}
+	if !rec.hookSeen {
+		t.Error("shell handler must pass a non-nil hook when CommandID is set")
+	}
+	if _, ok := am.LookupPID(424242); ok {
+		t.Error("tracker entry should have been removed after execution")
+	}
+}
+
+// TestShellHandler_NoCommandID_UsesPlainExec verifies that internal /
+// non-Command shell invocations keep the original, hook-less code path
+// so we don't accidentally regress performance or behaviour.
+func TestShellHandler_NoCommandID_UsesPlainExec(t *testing.T) {
+	_ = withTrackerAuthManager(t)
+
+	mock := common.NewMockCommandExecutor(t)
+	rec := &hookRecordingExecutor{MockCommandExecutor: mock}
+
+	handler := NewShellHandler(rec)
+	args := &common.CommandArgs{
+		Command:  "echo ok",
+		Username: "alice",
+		AllowSh:  true,
+	}
+
+	if _, _, err := handler.Execute(context.Background(), common.ShellCmd.String(), args); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.called {
+		t.Error("ExecWithHook should not be used when CommandID is empty")
+	}
+}

--- a/pkg/executor/handlers/shell/shell_command_tracker_test.go
+++ b/pkg/executor/handlers/shell/shell_command_tracker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/pkg/runner"
-	"github.com/alpacax/alpamon/pkg/runner/runnertest"
+	"github.com/alpacax/alpamon/internal/runnertest"
 )
 
 // hookRecordingExecutor wraps a MockCommandExecutor and records whether

--- a/pkg/executor/handlers/shell/shell_command_tracker_test.go
+++ b/pkg/executor/handlers/shell/shell_command_tracker_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/pkg/runner"
+	"github.com/alpacax/alpamon/pkg/runner/runnertest"
 )
 
 // hookRecordingExecutor wraps a MockCommandExecutor and records whether
@@ -46,7 +47,7 @@ func (r *hookRecordingExecutor) ExecWithHook(
 // duration of t and restores the previous singleton on cleanup.
 func withTrackerAuthManager(t *testing.T) *runner.AuthManager {
 	t.Helper()
-	return runner.SwapAuthManagerForTest(t, runner.NewAuthManagerForTest())
+	return runnertest.SwapAuthManager(t, runnertest.NewAuthManager())
 }
 
 // TestShellHandler_CommandID_RegistersAndUnregistersPID verifies that a

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -17,11 +17,42 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Kinds of tracked processes that may issue sudo through alpamon-pam.
+const (
+	// TrackerKindWebsh marks an interactive Websh PTY session.
+	TrackerKindWebsh = "websh"
+	// TrackerKindCommand marks a non-interactive deploy shell Command execution.
+	TrackerKindCommand = "command"
+)
+
+// SessionInfo tracks a process (Websh PTY or deploy shell Command) that
+// alpamon-pam may later encounter by walking the ppid chain. The same map
+// holds both kinds of entries so the PAM lookup logic stays single-path.
+//
+// Exactly one of SessionID or CommandID is populated, determined by Kind:
+//   - Kind == TrackerKindWebsh:   SessionID set, CommandID empty.
+//   - Kind == TrackerKindCommand: CommandID set, SessionID empty.
+//
+// Legacy entries created before the Kind field was introduced are treated
+// as websh entries for backward compatibility (see effectiveKind).
 type SessionInfo struct {
+	Kind      string
 	SessionID string
+	CommandID string
+	Username  string
 	PID       int
+	StartedAt time.Time
 	PtyClient *PtyClient
 	Requests  map[string]*SudoRequest
+}
+
+// effectiveKind returns the Kind of an entry, defaulting to websh when
+// the field is empty (older in-memory entries predating the Kind field).
+func (s *SessionInfo) effectiveKind() string {
+	if s == nil || s.Kind == "" {
+		return TrackerKindWebsh
+	}
+	return s.Kind
 }
 
 type SudoRequest struct {
@@ -38,7 +69,8 @@ type SudoApprovalRequest struct {
 	PPID         int    `json:"ppid"`
 	Command      string `json:"command"`
 	IsAlpconUser bool   `json:"is_alpacon_user"`
-	SessionID    string `json:"session_id"`
+	SessionID    string `json:"session_id,omitempty"`
+	CommandID    string `json:"command_id,omitempty"`
 }
 
 type SudoApprovalResponse struct {
@@ -50,7 +82,8 @@ type SudoApprovalResponse struct {
 	PPID         int    `json:"ppid"`
 	Command      string `json:"command"`
 	IsAlpconUser bool   `json:"is_alpacon_user"`
-	SessionID    string `json:"session_id"`
+	SessionID    string `json:"session_id,omitempty"`
+	CommandID    string `json:"command_id,omitempty"`
 	Approved     bool   `json:"approved"`
 	Reason       string `json:"reason"`
 }
@@ -240,7 +273,14 @@ func (am *AuthManager) createSendOperation(ctx context.Context, req SudoApproval
 				return fmt.Errorf("HTTP session not available")
 			}
 
-			url := fmt.Sprintf("/api/websh/sessions/%s/sudo-approval/", req.SessionID)
+			// Deploy shell (Command) sudo requests go to the session-less
+			// endpoint so the server can resolve the IAM user via command_id.
+			var url string
+			if req.CommandID != "" && req.SessionID == "" {
+				url = "/api/sudo/approval/"
+			} else {
+				url = fmt.Sprintf("/api/websh/sessions/%s/sudo-approval/", req.SessionID)
+			}
 			_, statusCode, err := am.session.Post(url, req, 10)
 			if err != nil {
 				log.Warn().Err(err).Msg("Failed to send sudo request via REST API, will retry")
@@ -351,7 +391,15 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 
 	// Alpacon user: pidToSessionMap
 	sudoApprovalReq.IsAlpconUser = true
-	sudoApprovalReq.SessionID = session.SessionID
+	switch session.effectiveKind() {
+	case TrackerKindCommand:
+		sudoApprovalReq.SessionID = ""
+		sudoApprovalReq.CommandID = session.CommandID
+	default:
+		// websh (and legacy entries without Kind) keep the session-based path.
+		sudoApprovalReq.SessionID = session.SessionID
+		sudoApprovalReq.CommandID = ""
+	}
 
 	session.Requests[sudoApprovalReq.RequestID] = &SudoRequest{
 		RequestID:  sudoApprovalReq.RequestID,
@@ -359,7 +407,12 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 	}
 	am.mu.Unlock()
 
-	log.Debug().Msgf("Alpacon user sudo request: %s for session %s", sudoApprovalReq.RequestID, session.SessionID)
+	log.Debug().
+		Str("request_id", sudoApprovalReq.RequestID).
+		Str("kind", session.effectiveKind()).
+		Str("session_id", sudoApprovalReq.SessionID).
+		Str("command_id", sudoApprovalReq.CommandID).
+		Msg("Alpacon user sudo request")
 
 	// Store completion channel for this request
 	am.storeCompletionChannel(sudoApprovalReq.RequestID, completionChan)
@@ -433,6 +486,7 @@ func (am *AuthManager) sendSudoApprovalResponse(conn net.Conn, sudo_approval_req
 		Command:      sudo_approval_req.Command,
 		IsAlpconUser: sudo_approval_req.IsAlpconUser,
 		SessionID:    sudo_approval_req.SessionID,
+		CommandID:    sudo_approval_req.CommandID,
 		RequestID:    sudo_approval_req.RequestID,
 		Approved:     approved,
 		Reason:       reason,
@@ -517,7 +571,24 @@ func (am *AuthManager) HandleSudoApprovalResponse(response SudoApprovalResponse)
 	return nil
 }
 
+// AddPIDSessionMapping registers an entry for a Websh PTY session.
+// Kind and StartedAt are filled in when unset so callers don't have to
+// remember to populate them; CommandID is always cleared to keep the
+// websh/command fields mutually exclusive per entry.
 func (am *AuthManager) AddPIDSessionMapping(pid int, session *SessionInfo) {
+	if session == nil {
+		return
+	}
+	if session.Kind == "" {
+		session.Kind = TrackerKindWebsh
+	}
+	session.CommandID = ""
+	if session.StartedAt.IsZero() {
+		session.StartedAt = time.Now()
+	}
+	if session.PID == 0 {
+		session.PID = pid
+	}
 	am.mu.Lock()
 	am.pidToSessionMap[pid] = session
 	am.mu.Unlock()
@@ -527,9 +598,120 @@ func (am *AuthManager) RemovePIDSessionMapping(pid int) {
 	am.mu.Lock()
 	if session, exists := am.pidToSessionMap[pid]; exists {
 		delete(am.pidToSessionMap, pid)
-		log.Debug().Msgf("PID mapping removed: %d -> Session: %s", pid, session.SessionID)
+		log.Debug().
+			Int("pid", pid).
+			Str("kind", session.effectiveKind()).
+			Str("session_id", session.SessionID).
+			Str("command_id", session.CommandID).
+			Msg("PID mapping removed")
 	}
 	am.mu.Unlock()
+}
+
+// AddPIDCommandMapping registers the root pid of a deploy shell Command
+// execution so alpamon-pam can attribute a sudo call made inside the
+// Command (or any descendant) to the originating Command.ID. It must be
+// called before the child process can exec sudo to avoid a race where
+// sudo arrives at the PAM module before the tracker knows about the pid.
+//
+// Concurrency: multiple Commands run in parallel with distinct root pids,
+// so entries never collide. Safe to call from any goroutine.
+func (am *AuthManager) AddPIDCommandMapping(pid int, commandID, username string) {
+	if pid <= 0 || commandID == "" {
+		return
+	}
+	info := &SessionInfo{
+		Kind:      TrackerKindCommand,
+		CommandID: commandID,
+		Username:  username,
+		PID:       pid,
+		StartedAt: time.Now(),
+		Requests:  make(map[string]*SudoRequest),
+	}
+	am.mu.Lock()
+	am.pidToSessionMap[pid] = info
+	am.mu.Unlock()
+	log.Debug().
+		Int("pid", pid).
+		Str("command_id", commandID).
+		Str("username", username).
+		Msg("Command PID mapping added")
+}
+
+// RemovePIDCommandMapping deletes the tracker entry for a deploy shell
+// Command's root pid. It only removes the entry when it still has the
+// matching command_id; if the pid has been reused (e.g. a legacy leftover
+// from a crash) by another kind of entry, the existing entry is
+// preserved.
+func (am *AuthManager) RemovePIDCommandMapping(pid int, commandID string) {
+	if pid <= 0 {
+		return
+	}
+	am.mu.Lock()
+	if existing, ok := am.pidToSessionMap[pid]; ok {
+		if existing.effectiveKind() == TrackerKindCommand &&
+			(commandID == "" || existing.CommandID == commandID) {
+			delete(am.pidToSessionMap, pid)
+			log.Debug().
+				Int("pid", pid).
+				Str("command_id", existing.CommandID).
+				Msg("Command PID mapping removed")
+		}
+	}
+	am.mu.Unlock()
+}
+
+// TrackerEntry is a read-only snapshot of a tracker entry, returned by
+// LookupPID for callers (e.g. tests) that need to inspect state without
+// taking the AuthManager's lock themselves.
+type TrackerEntry struct {
+	Kind      string
+	SessionID string
+	CommandID string
+	Username  string
+	PID       int
+	StartedAt time.Time
+}
+
+// LookupPID returns a snapshot of the tracker entry for pid (if any).
+// The second return value reports whether an entry was found.
+func (am *AuthManager) LookupPID(pid int) (TrackerEntry, bool) {
+	am.mu.RLock()
+	defer am.mu.RUnlock()
+	info, ok := am.pidToSessionMap[pid]
+	if !ok {
+		return TrackerEntry{}, false
+	}
+	return TrackerEntry{
+		Kind:      info.effectiveKind(),
+		SessionID: info.SessionID,
+		CommandID: info.CommandID,
+		Username:  info.Username,
+		PID:       info.PID,
+		StartedAt: info.StartedAt,
+	}, true
+}
+
+// RegisterCommandPID is a package-level helper that registers a deploy
+// shell Command root pid on the singleton AuthManager (if initialized).
+// Returning a boolean lets callers decide whether an Unregister is owed
+// even in setups where the AuthManager has not been wired up yet (tests,
+// early boot).
+func RegisterCommandPID(pid int, commandID, username string) bool {
+	if authManager == nil {
+		return false
+	}
+	authManager.AddPIDCommandMapping(pid, commandID, username)
+	return true
+}
+
+// UnregisterCommandPID removes a deploy shell Command entry previously
+// added by RegisterCommandPID. No-op if the AuthManager isn't available.
+func UnregisterCommandPID(pid int, commandID string) {
+	if authManager == nil {
+		return
+	}
+	authManager.RemovePIDCommandMapping(pid, commandID)
 }
 
 func (am *AuthManager) storeCompletionChannel(requestID string, ch chan struct{}) {

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -391,14 +391,23 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 
 	// Alpacon user: pidToSessionMap
 	sudoApprovalReq.IsAlpconUser = true
-	switch session.effectiveKind() {
+	kind := session.effectiveKind()
+	switch kind {
 	case TrackerKindCommand:
 		sudoApprovalReq.SessionID = ""
 		sudoApprovalReq.CommandID = session.CommandID
-	default:
-		// websh (and legacy entries without Kind) keep the session-based path.
+	case TrackerKindWebsh:
+		// websh (and legacy entries without Kind, normalized by effectiveKind).
 		sudoApprovalReq.SessionID = session.SessionID
 		sudoApprovalReq.CommandID = ""
+	default:
+		// Unknown kind: reject explicitly rather than silently misattribute
+		// as websh. A future new Kind must be added to the switch.
+		am.mu.Unlock()
+		log.Warn().Str("kind", kind).Msg("Unknown tracker kind; rejecting sudo")
+		am.sendSudoApprovalResponse(unixConn, sudoApprovalReq, false, "Unknown session kind")
+		_ = unixConn.Close()
+		return
 	}
 
 	session.Requests[sudoApprovalReq.RequestID] = &SudoRequest{
@@ -409,7 +418,7 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 
 	log.Debug().
 		Str("request_id", sudoApprovalReq.RequestID).
-		Str("kind", session.effectiveKind()).
+		Str("kind", kind).
 		Str("session_id", sudoApprovalReq.SessionID).
 		Str("command_id", sudoApprovalReq.CommandID).
 		Msg("Alpacon user sudo request")
@@ -693,30 +702,21 @@ func (am *AuthManager) LookupPID(pid int) (TrackerEntry, bool) {
 }
 
 // RegisterCommandPID is a package-level helper that registers a deploy
-// shell Command root pid on the singleton AuthManager (if initialized).
-// The returned boolean reports whether a mapping was actually added so
-// callers can decide whether an Unregister is owed. It returns false
-// when the AuthManager has not been wired up yet (tests, early boot) or
-// when the arguments would be rejected by AddPIDCommandMapping (non-
-// positive pid, empty commandID).
-func RegisterCommandPID(pid int, commandID, username string) bool {
-	if authManager == nil {
-		return false
+// shell Command root pid on the singleton AuthManager (if initialized)
+// and returns an unregister closure. The closure captures the exact
+// (pid, commandID) pair so callers cannot accidentally unregister the
+// wrong entry, making the Register/Unregister pair leak-proof by
+// construction. The returned closure is always safe to call — it is a
+// no-op when the AuthManager has not been wired up yet (tests, early
+// boot) or when the arguments would be rejected by
+// AddPIDCommandMapping (non-positive pid, empty commandID).
+func RegisterCommandPID(pid int, commandID, username string) func() {
+	if authManager == nil || pid <= 0 || commandID == "" {
+		return func() {}
 	}
-	if pid <= 0 || commandID == "" {
-		return false
-	}
-	authManager.AddPIDCommandMapping(pid, commandID, username)
-	return true
-}
-
-// UnregisterCommandPID removes a deploy shell Command entry previously
-// added by RegisterCommandPID. No-op if the AuthManager isn't available.
-func UnregisterCommandPID(pid int, commandID string) {
-	if authManager == nil {
-		return
-	}
-	authManager.RemovePIDCommandMapping(pid, commandID)
+	am := authManager
+	am.AddPIDCommandMapping(pid, commandID, username)
+	return func() { am.RemovePIDCommandMapping(pid, commandID) }
 }
 
 func (am *AuthManager) storeCompletionChannel(requestID string, ch chan struct{}) {

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -640,17 +640,17 @@ func (am *AuthManager) AddPIDCommandMapping(pid int, commandID, username string)
 
 // RemovePIDCommandMapping deletes the tracker entry for a deploy shell
 // Command's root pid. It only removes the entry when it still has the
-// matching command_id; if the pid has been reused (e.g. a legacy leftover
-// from a crash) by another kind of entry, the existing entry is
-// preserved.
+// matching command_id; callers must pass a non-empty commandID so that
+// a pid reused by an unrelated entry (e.g. a legacy leftover from a
+// crash) cannot be dropped accidentally.
 func (am *AuthManager) RemovePIDCommandMapping(pid int, commandID string) {
-	if pid <= 0 {
+	if pid <= 0 || commandID == "" {
 		return
 	}
 	am.mu.Lock()
 	if existing, ok := am.pidToSessionMap[pid]; ok {
 		if existing.effectiveKind() == TrackerKindCommand &&
-			(commandID == "" || existing.CommandID == commandID) {
+			existing.CommandID == commandID {
 			delete(am.pidToSessionMap, pid)
 			log.Debug().
 				Int("pid", pid).
@@ -694,11 +694,16 @@ func (am *AuthManager) LookupPID(pid int) (TrackerEntry, bool) {
 
 // RegisterCommandPID is a package-level helper that registers a deploy
 // shell Command root pid on the singleton AuthManager (if initialized).
-// Returning a boolean lets callers decide whether an Unregister is owed
-// even in setups where the AuthManager has not been wired up yet (tests,
-// early boot).
+// The returned boolean reports whether a mapping was actually added so
+// callers can decide whether an Unregister is owed. It returns false
+// when the AuthManager has not been wired up yet (tests, early boot) or
+// when the arguments would be rejected by AddPIDCommandMapping (non-
+// positive pid, empty commandID).
 func RegisterCommandPID(pid int, commandID, username string) bool {
 	if authManager == nil {
+		return false
+	}
+	if pid <= 0 || commandID == "" {
 		return false
 	}
 	authManager.AddPIDCommandMapping(pid, commandID, username)

--- a/pkg/runner/auth_manager_testing.go
+++ b/pkg/runner/auth_manager_testing.go
@@ -1,0 +1,27 @@
+package runner
+
+import "testing"
+
+// NewAuthManagerForTest returns an AuthManager populated just enough to
+// exercise the PID tracker. It does not start the socket listener.
+//
+// Exposed for tests in other packages (e.g. the shell handler) that need
+// a real AuthManager singleton installed via SwapAuthManagerForTest.
+func NewAuthManagerForTest() *AuthManager {
+	return &AuthManager{
+		pidToSessionMap:    make(map[int]*SessionInfo),
+		localSudoRequests:  make(map[string]*SudoRequest),
+		completionChannels: make(map[string]chan struct{}),
+	}
+}
+
+// SwapAuthManagerForTest installs am as the package-level singleton for
+// the duration of t and restores the previous singleton on cleanup.
+// It returns am so callers can keep working with the installed instance.
+func SwapAuthManagerForTest(t *testing.T, am *AuthManager) *AuthManager {
+	t.Helper()
+	prev := authManager
+	authManager = am
+	t.Cleanup(func() { authManager = prev })
+	return am
+}

--- a/pkg/runner/auth_manager_testing.go
+++ b/pkg/runner/auth_manager_testing.go
@@ -4,8 +4,8 @@ package runner
 // exercise the PID tracker without starting the socket listener. It has
 // no dependency on the testing package, so it is safe to keep in the
 // shipped package; the actual test-only glue that swaps the singleton
-// lives in the pkg/runner/runnertest subpackage, which is only imported
-// from *_test.go files.
+// lives in the internal/runnertest package, which is firewalled by the
+// Go compiler's internal rule and only imported from *_test.go files.
 func NewEmptyAuthManager() *AuthManager {
 	return &AuthManager{
 		pidToSessionMap:    make(map[int]*SessionInfo),
@@ -16,7 +16,7 @@ func NewEmptyAuthManager() *AuthManager {
 
 // SwapAuthManager installs am as the package-level singleton and returns
 // the previously installed one so callers can restore it. It is intended
-// to be used from pkg/runner/runnertest (which adds *testing.T cleanup);
+// to be used from internal/runnertest (which adds *testing.T cleanup);
 // direct use in production code is not supported.
 func SwapAuthManager(am *AuthManager) *AuthManager {
 	prev := authManager

--- a/pkg/runner/auth_manager_testing.go
+++ b/pkg/runner/auth_manager_testing.go
@@ -1,13 +1,12 @@
 package runner
 
-import "testing"
-
-// NewAuthManagerForTest returns an AuthManager populated just enough to
-// exercise the PID tracker. It does not start the socket listener.
-//
-// Exposed for tests in other packages (e.g. the shell handler) that need
-// a real AuthManager singleton installed via SwapAuthManagerForTest.
-func NewAuthManagerForTest() *AuthManager {
+// NewEmptyAuthManager returns an AuthManager populated just enough to
+// exercise the PID tracker without starting the socket listener. It has
+// no dependency on the testing package, so it is safe to keep in the
+// shipped package; the actual test-only glue that swaps the singleton
+// lives in the pkg/runner/runnertest subpackage, which is only imported
+// from *_test.go files.
+func NewEmptyAuthManager() *AuthManager {
 	return &AuthManager{
 		pidToSessionMap:    make(map[int]*SessionInfo),
 		localSudoRequests:  make(map[string]*SudoRequest),
@@ -15,13 +14,12 @@ func NewAuthManagerForTest() *AuthManager {
 	}
 }
 
-// SwapAuthManagerForTest installs am as the package-level singleton for
-// the duration of t and restores the previous singleton on cleanup.
-// It returns am so callers can keep working with the installed instance.
-func SwapAuthManagerForTest(t *testing.T, am *AuthManager) *AuthManager {
-	t.Helper()
+// SwapAuthManager installs am as the package-level singleton and returns
+// the previously installed one so callers can restore it. It is intended
+// to be used from pkg/runner/runnertest (which adds *testing.T cleanup);
+// direct use in production code is not supported.
+func SwapAuthManager(am *AuthManager) *AuthManager {
 	prev := authManager
 	authManager = am
-	t.Cleanup(func() { authManager = prev })
-	return am
+	return prev
 }

--- a/pkg/runner/auth_manager_tracker_test.go
+++ b/pkg/runner/auth_manager_tracker_test.go
@@ -1,0 +1,321 @@
+package runner
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestAuthManager returns an AuthManager with only the fields that the
+// tracker tests need populated. It intentionally does not start the
+// socket listener, so tests stay fast and isolated.
+func newTestAuthManager() *AuthManager {
+	return &AuthManager{
+		pidToSessionMap:    make(map[int]*SessionInfo),
+		localSudoRequests:  make(map[string]*SudoRequest),
+		completionChannels: make(map[string]chan struct{}),
+	}
+}
+
+// TestAddPIDCommandMapping_RegistersCommandKind verifies that Commands
+// register with Kind=command and the CommandID/Username set.
+func TestAddPIDCommandMapping_RegistersCommandKind(t *testing.T) {
+	am := newTestAuthManager()
+
+	am.AddPIDCommandMapping(4242, "cmd-uuid-1", "alice")
+
+	entry, ok := am.LookupPID(4242)
+	if !ok {
+		t.Fatal("expected tracker entry to be registered")
+	}
+	if entry.Kind != TrackerKindCommand {
+		t.Errorf("Kind: got %q, want %q", entry.Kind, TrackerKindCommand)
+	}
+	if entry.CommandID != "cmd-uuid-1" {
+		t.Errorf("CommandID: got %q, want cmd-uuid-1", entry.CommandID)
+	}
+	if entry.SessionID != "" {
+		t.Errorf("SessionID should be empty for command entries, got %q", entry.SessionID)
+	}
+	if entry.Username != "alice" {
+		t.Errorf("Username: got %q, want alice", entry.Username)
+	}
+	if entry.StartedAt.IsZero() {
+		t.Error("StartedAt should be set")
+	}
+}
+
+// TestAddPIDCommandMapping_IgnoresInvalidInput verifies that bogus
+// arguments are silently ignored rather than stored.
+func TestAddPIDCommandMapping_IgnoresInvalidInput(t *testing.T) {
+	am := newTestAuthManager()
+
+	am.AddPIDCommandMapping(0, "cmd", "user")
+	am.AddPIDCommandMapping(-1, "cmd", "user")
+	am.AddPIDCommandMapping(100, "", "user")
+
+	if len(am.pidToSessionMap) != 0 {
+		t.Errorf("expected no entries, got %d", len(am.pidToSessionMap))
+	}
+}
+
+// TestRemovePIDCommandMapping_RemovesMatchingEntry verifies removal on
+// Command completion.
+func TestRemovePIDCommandMapping_RemovesMatchingEntry(t *testing.T) {
+	am := newTestAuthManager()
+	am.AddPIDCommandMapping(1111, "cmd-a", "bob")
+
+	am.RemovePIDCommandMapping(1111, "cmd-a")
+
+	if _, ok := am.LookupPID(1111); ok {
+		t.Fatal("entry should have been removed")
+	}
+}
+
+// TestRemovePIDCommandMapping_PIDReuseGuard verifies that removing with
+// a mismatched command id does not drop an unrelated entry that reused
+// the same pid.
+func TestRemovePIDCommandMapping_PIDReuseGuard(t *testing.T) {
+	am := newTestAuthManager()
+	am.AddPIDCommandMapping(2222, "cmd-b", "carol")
+
+	// Stale remove from a previous, unrelated command: must be a no-op.
+	am.RemovePIDCommandMapping(2222, "some-other-command-id")
+
+	entry, ok := am.LookupPID(2222)
+	if !ok {
+		t.Fatal("entry should still exist after mismatched remove")
+	}
+	if entry.CommandID != "cmd-b" {
+		t.Errorf("CommandID: got %q, want cmd-b", entry.CommandID)
+	}
+}
+
+// TestRemovePIDCommandMapping_LeavesWebshEntryAlone verifies that a
+// Command-style remove does not touch a websh entry that happens to
+// share the same pid (defence in depth).
+func TestRemovePIDCommandMapping_LeavesWebshEntryAlone(t *testing.T) {
+	am := newTestAuthManager()
+	am.AddPIDSessionMapping(3333, &SessionInfo{
+		Kind:      TrackerKindWebsh,
+		SessionID: "websh-1",
+		Username:  "dave",
+		Requests:  make(map[string]*SudoRequest),
+	})
+
+	am.RemovePIDCommandMapping(3333, "")
+
+	entry, ok := am.LookupPID(3333)
+	if !ok {
+		t.Fatal("websh entry should not have been removed")
+	}
+	if entry.Kind != TrackerKindWebsh {
+		t.Errorf("Kind: got %q, want websh", entry.Kind)
+	}
+}
+
+// TestParallelCommands_TrackedIndependently verifies concurrent
+// Commands keep distinct entries keyed by their root pids.
+func TestParallelCommands_TrackedIndependently(t *testing.T) {
+	am := newTestAuthManager()
+
+	am.AddPIDCommandMapping(5001, "cmd-parallel-1", "alice")
+	am.AddPIDCommandMapping(5002, "cmd-parallel-2", "alice")
+	am.AddPIDCommandMapping(5003, "cmd-parallel-3", "bob")
+
+	cases := []struct {
+		pid       int
+		commandID string
+		username  string
+	}{
+		{5001, "cmd-parallel-1", "alice"},
+		{5002, "cmd-parallel-2", "alice"},
+		{5003, "cmd-parallel-3", "bob"},
+	}
+	for _, tc := range cases {
+		entry, ok := am.LookupPID(tc.pid)
+		if !ok {
+			t.Errorf("pid %d: expected entry, got none", tc.pid)
+			continue
+		}
+		if entry.CommandID != tc.commandID {
+			t.Errorf("pid %d: CommandID got %q, want %q", tc.pid, entry.CommandID, tc.commandID)
+		}
+		if entry.Username != tc.username {
+			t.Errorf("pid %d: Username got %q, want %q", tc.pid, entry.Username, tc.username)
+		}
+	}
+
+	// Remove middle entry, verify others survive.
+	am.RemovePIDCommandMapping(5002, "cmd-parallel-2")
+	if _, ok := am.LookupPID(5002); ok {
+		t.Error("5002 should have been removed")
+	}
+	if _, ok := am.LookupPID(5001); !ok {
+		t.Error("5001 should still exist")
+	}
+	if _, ok := am.LookupPID(5003); !ok {
+		t.Error("5003 should still exist")
+	}
+}
+
+// TestLegacyWebshEntry_ReadsAsWebsh verifies backward compatibility with
+// older in-memory entries that were created before the Kind field was
+// introduced (Kind left empty).
+func TestLegacyWebshEntry_ReadsAsWebsh(t *testing.T) {
+	am := newTestAuthManager()
+
+	// Simulate a legacy entry written by an older code path (no Kind).
+	am.pidToSessionMap[7777] = &SessionInfo{
+		SessionID: "legacy-session",
+		PID:       7777,
+		Requests:  make(map[string]*SudoRequest),
+	}
+
+	entry, ok := am.LookupPID(7777)
+	if !ok {
+		t.Fatal("legacy entry missing")
+	}
+	if entry.Kind != TrackerKindWebsh {
+		t.Errorf("legacy entry should default to %q, got %q", TrackerKindWebsh, entry.Kind)
+	}
+	if entry.SessionID != "legacy-session" {
+		t.Errorf("SessionID: got %q, want legacy-session", entry.SessionID)
+	}
+}
+
+// TestAddPIDSessionMapping_NormalisesWebshKind verifies that websh
+// registrations always end up with Kind=websh and no CommandID, even
+// when the caller forgot to set the fields explicitly.
+func TestAddPIDSessionMapping_NormalisesWebshKind(t *testing.T) {
+	am := newTestAuthManager()
+
+	// Caller neglects Kind / mistakenly populates CommandID.
+	am.AddPIDSessionMapping(8888, &SessionInfo{
+		SessionID: "ws-1",
+		CommandID: "leaky",
+		Requests:  make(map[string]*SudoRequest),
+	})
+
+	entry, ok := am.LookupPID(8888)
+	if !ok {
+		t.Fatal("expected entry")
+	}
+	if entry.Kind != TrackerKindWebsh {
+		t.Errorf("Kind: got %q, want %q", entry.Kind, TrackerKindWebsh)
+	}
+	if entry.CommandID != "" {
+		t.Errorf("CommandID should have been cleared, got %q", entry.CommandID)
+	}
+	if entry.StartedAt.IsZero() {
+		t.Error("StartedAt should be populated by AddPIDSessionMapping when unset")
+	}
+}
+
+// TestRegisterCommandPID_NoopWithoutManager verifies that the package-
+// level helper degrades gracefully when the AuthManager singleton has
+// not been initialised (tests, early boot, non-agent binaries).
+func TestRegisterCommandPID_NoopWithoutManager(t *testing.T) {
+	prev := authManager
+	authManager = nil
+	t.Cleanup(func() { authManager = prev })
+
+	if RegisterCommandPID(123, "cmd", "user") {
+		t.Error("expected RegisterCommandPID to return false when authManager is nil")
+	}
+
+	// Must not panic.
+	UnregisterCommandPID(123, "cmd")
+}
+
+// TestRegisterCommandPID_RoundTrip exercises the package-level helpers
+// against a real AuthManager singleton (Register -> Lookup -> Unregister).
+func TestRegisterCommandPID_RoundTrip(t *testing.T) {
+	prev := authManager
+	authManager = newTestAuthManager()
+	t.Cleanup(func() { authManager = prev })
+
+	if !RegisterCommandPID(9001, "cmd-round", "eve") {
+		t.Fatal("RegisterCommandPID should have returned true")
+	}
+	entry, ok := authManager.LookupPID(9001)
+	if !ok {
+		t.Fatal("entry should be present after RegisterCommandPID")
+	}
+	if entry.CommandID != "cmd-round" {
+		t.Errorf("CommandID: got %q, want cmd-round", entry.CommandID)
+	}
+
+	UnregisterCommandPID(9001, "cmd-round")
+	if _, ok := authManager.LookupPID(9001); ok {
+		t.Error("entry should be gone after UnregisterCommandPID")
+	}
+}
+
+// TestSudoApprovalRequest_OmitsEmptyIdentifiers is a guardrail against
+// accidentally sending both session_id and command_id (or neither), by
+// confirming the JSON tags use omitempty. This protects the server-side
+// 2-branch resolver from ambiguous payloads.
+func TestSudoApprovalRequest_JSONTagsOmitEmpty(t *testing.T) {
+	// Construct two requests that a deploy shell path and a websh path
+	// would send; spot-check that the wire representation reflects the
+	// invariants from the plan:
+	//   deploy shell: command_id set, session_id omitted
+	//   websh:        session_id set, command_id omitted
+	cmdReq := SudoApprovalRequest{
+		Type:      "sudo_approval_request",
+		CommandID: "cmd-uuid",
+		PID:       1,
+		PPID:      2,
+		Username:  "alice",
+	}
+	if cmdReq.SessionID != "" {
+		t.Errorf("deploy shell request should leave SessionID empty, got %q", cmdReq.SessionID)
+	}
+
+	webshReq := SudoApprovalRequest{
+		Type:      "sudo_approval_request",
+		SessionID: "session-uuid",
+		PID:       1,
+		PPID:      2,
+		Username:  "alice",
+	}
+	if webshReq.CommandID != "" {
+		t.Errorf("websh request should leave CommandID empty, got %q", webshReq.CommandID)
+	}
+}
+
+// TestLookupPID_Missing verifies Lookup for a non-existent pid returns
+// ok=false and a zero-value TrackerEntry.
+func TestLookupPID_Missing(t *testing.T) {
+	am := newTestAuthManager()
+	entry, ok := am.LookupPID(99999)
+	if ok {
+		t.Error("expected ok=false for missing pid")
+	}
+	var zero TrackerEntry
+	if entry != zero {
+		t.Errorf("expected zero TrackerEntry, got %+v", entry)
+	}
+}
+
+// TestAddPIDCommandMapping_OverwritesStaleEntry verifies that if the
+// same pid gets reused (rare but possible after pid-wraparound), the
+// newer registration wins so stale state cannot authorize the new
+// process with someone else's command_id.
+func TestAddPIDCommandMapping_OverwritesStaleEntry(t *testing.T) {
+	am := newTestAuthManager()
+	am.AddPIDCommandMapping(4001, "old-cmd", "alice")
+	// Force a distinguishable time gap without sleeping.
+	if entry, ok := am.LookupPID(4001); ok {
+		entry.StartedAt = time.Now().Add(-time.Hour)
+	}
+	am.AddPIDCommandMapping(4001, "new-cmd", "bob")
+
+	entry, _ := am.LookupPID(4001)
+	if entry.CommandID != "new-cmd" {
+		t.Errorf("CommandID: got %q, want new-cmd", entry.CommandID)
+	}
+	if entry.Username != "bob" {
+		t.Errorf("Username: got %q, want bob", entry.Username)
+	}
+}

--- a/pkg/runner/auth_manager_tracker_test.go
+++ b/pkg/runner/auth_manager_tracker_test.go
@@ -223,23 +223,24 @@ func TestRegisterCommandPID_NoopWithoutManager(t *testing.T) {
 	authManager = nil
 	t.Cleanup(func() { authManager = prev })
 
-	if RegisterCommandPID(123, "cmd", "user") {
-		t.Error("expected RegisterCommandPID to return false when authManager is nil")
+	cleanup := RegisterCommandPID(123, "cmd", "user")
+	if cleanup == nil {
+		t.Error("RegisterCommandPID should always return a non-nil cleanup closure")
 	}
-
-	// Must not panic.
-	UnregisterCommandPID(123, "cmd")
+	// Must not panic even when the AuthManager is absent.
+	cleanup()
 }
 
-// TestRegisterCommandPID_RoundTrip exercises the package-level helpers
-// against a real AuthManager singleton (Register -> Lookup -> Unregister).
+// TestRegisterCommandPID_RoundTrip exercises the package-level helper
+// against a real AuthManager singleton (Register -> Lookup -> cleanup).
 func TestRegisterCommandPID_RoundTrip(t *testing.T) {
 	prev := authManager
 	authManager = newTestAuthManager()
 	t.Cleanup(func() { authManager = prev })
 
-	if !RegisterCommandPID(9001, "cmd-round", "eve") {
-		t.Fatal("RegisterCommandPID should have returned true")
+	cleanup := RegisterCommandPID(9001, "cmd-round", "eve")
+	if cleanup == nil {
+		t.Fatal("RegisterCommandPID returned a nil cleanup closure")
 	}
 	entry, ok := authManager.LookupPID(9001)
 	if !ok {
@@ -249,9 +250,9 @@ func TestRegisterCommandPID_RoundTrip(t *testing.T) {
 		t.Errorf("CommandID: got %q, want cmd-round", entry.CommandID)
 	}
 
-	UnregisterCommandPID(9001, "cmd-round")
+	cleanup()
 	if _, ok := authManager.LookupPID(9001); ok {
-		t.Error("entry should be gone after UnregisterCommandPID")
+		t.Error("entry should be gone after cleanup()")
 	}
 }
 

--- a/pkg/runner/auth_manager_tracker_test.go
+++ b/pkg/runner/auth_manager_tracker_test.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -102,7 +104,9 @@ func TestRemovePIDCommandMapping_LeavesWebshEntryAlone(t *testing.T) {
 		Requests:  make(map[string]*SudoRequest),
 	})
 
-	am.RemovePIDCommandMapping(3333, "")
+	// Even a well-formed Command-style remove with a concrete commandID
+	// must not touch an entry that belongs to a different tracker kind.
+	am.RemovePIDCommandMapping(3333, "cmd-bystander")
 
 	entry, ok := am.LookupPID(3333)
 	if !ok {
@@ -251,16 +255,14 @@ func TestRegisterCommandPID_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestSudoApprovalRequest_OmitsEmptyIdentifiers is a guardrail against
-// accidentally sending both session_id and command_id (or neither), by
-// confirming the JSON tags use omitempty. This protects the server-side
-// 2-branch resolver from ambiguous payloads.
+// TestSudoApprovalRequest_JSONTagsOmitEmpty is a guardrail against
+// accidentally sending both session_id and command_id (or neither) on
+// the wire. It marshals the struct and inspects the serialized keys so
+// that a regression dropping `omitempty` from either field would be
+// caught. This protects the server-side 2-branch resolver from
+// ambiguous payloads.
 func TestSudoApprovalRequest_JSONTagsOmitEmpty(t *testing.T) {
-	// Construct two requests that a deploy shell path and a websh path
-	// would send; spot-check that the wire representation reflects the
-	// invariants from the plan:
-	//   deploy shell: command_id set, session_id omitted
-	//   websh:        session_id set, command_id omitted
+	// Deploy shell path: command_id set, session_id must be omitted.
 	cmdReq := SudoApprovalRequest{
 		Type:      "sudo_approval_request",
 		CommandID: "cmd-uuid",
@@ -268,10 +270,18 @@ func TestSudoApprovalRequest_JSONTagsOmitEmpty(t *testing.T) {
 		PPID:      2,
 		Username:  "alice",
 	}
-	if cmdReq.SessionID != "" {
-		t.Errorf("deploy shell request should leave SessionID empty, got %q", cmdReq.SessionID)
+	cmdJSON, err := json.Marshal(cmdReq)
+	if err != nil {
+		t.Fatalf("marshal command request: %v", err)
+	}
+	if !strings.Contains(string(cmdJSON), `"command_id":"cmd-uuid"`) {
+		t.Errorf("expected command_id in payload, got %s", cmdJSON)
+	}
+	if strings.Contains(string(cmdJSON), `"session_id"`) {
+		t.Errorf("deploy shell payload must omit session_id, got %s", cmdJSON)
 	}
 
+	// Websh path: session_id set, command_id must be omitted.
 	webshReq := SudoApprovalRequest{
 		Type:      "sudo_approval_request",
 		SessionID: "session-uuid",
@@ -279,8 +289,32 @@ func TestSudoApprovalRequest_JSONTagsOmitEmpty(t *testing.T) {
 		PPID:      2,
 		Username:  "alice",
 	}
-	if webshReq.CommandID != "" {
-		t.Errorf("websh request should leave CommandID empty, got %q", webshReq.CommandID)
+	webshJSON, err := json.Marshal(webshReq)
+	if err != nil {
+		t.Fatalf("marshal websh request: %v", err)
+	}
+	if !strings.Contains(string(webshJSON), `"session_id":"session-uuid"`) {
+		t.Errorf("expected session_id in payload, got %s", webshJSON)
+	}
+	if strings.Contains(string(webshJSON), `"command_id"`) {
+		t.Errorf("websh payload must omit command_id, got %s", webshJSON)
+	}
+
+	// Neither-set path: both identifier keys must be absent, making the
+	// payload unambiguous for the server's 2-branch resolver.
+	emptyReq := SudoApprovalRequest{
+		Type:     "sudo_approval_request",
+		PID:      1,
+		PPID:     2,
+		Username: "alice",
+	}
+	emptyJSON, err := json.Marshal(emptyReq)
+	if err != nil {
+		t.Fatalf("marshal empty-id request: %v", err)
+	}
+	if strings.Contains(string(emptyJSON), `"session_id"`) ||
+		strings.Contains(string(emptyJSON), `"command_id"`) {
+		t.Errorf("payload with neither id must omit both keys, got %s", emptyJSON)
 	}
 }
 

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -88,9 +88,13 @@ func (cr *CommandRunner) Run(ctx context.Context) error {
 		}
 		command = fields[0]
 		args = cr.data.ToArgs()
+		if args != nil {
+			args.CommandID = cr.command.ID
+		}
 	case "system":
 		command = common.ShellCmd.String()
 		args = &common.CommandArgs{
+			CommandID: cr.command.ID,
 			Command:   cr.command.Line,
 			Username:  cr.command.User,
 			Groupname: cr.command.Group,

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -112,7 +112,9 @@ func (pc *PtyClient) initializePtySession() error {
 	// Add PID-to-session mapping for auth manager
 	pid := pc.cmd.Process.Pid
 	sessionInfo := &SessionInfo{
+		Kind:      TrackerKindWebsh,
 		SessionID: pc.sessionID,
+		Username:  pc.username,
 		PID:       pid,
 		PtyClient: pc,
 		Requests:  make(map[string]*SudoRequest),

--- a/pkg/runner/runnertest/runnertest.go
+++ b/pkg/runner/runnertest/runnertest.go
@@ -1,0 +1,29 @@
+// Package runnertest provides test-only glue around pkg/runner. It is
+// split out so that the runner package itself does not need to import
+// "testing" (which would otherwise leak test-only API surface and the
+// testing dependency into shipped binaries).
+//
+// This package must only be imported from *_test.go files.
+package runnertest
+
+import (
+	"testing"
+
+	"github.com/alpacax/alpamon/pkg/runner"
+)
+
+// NewAuthManager returns an AuthManager populated just enough to
+// exercise the PID tracker. It does not start the socket listener.
+func NewAuthManager() *runner.AuthManager {
+	return runner.NewEmptyAuthManager()
+}
+
+// SwapAuthManager installs am as the package-level singleton for the
+// duration of t and restores the previous singleton on cleanup. It
+// returns am so callers can keep working with the installed instance.
+func SwapAuthManager(t *testing.T, am *runner.AuthManager) *runner.AuthManager {
+	t.Helper()
+	prev := runner.SwapAuthManager(am)
+	t.Cleanup(func() { runner.SwapAuthManager(prev) })
+	return am
+}


### PR DESCRIPTION
## Summary

Extends the in-memory PID tracker in `pkg/runner` so deploy shell Commands (aka alpacon-cli / MCP `command`) register their root pid alongside existing Websh PTY sessions. When the PAM module walks the ppid chain, a matching entry now sends either a `session_id` (websh) or a `command_id` (deploy shell) to alpacon-server, enabling the server to resolve the IAM user via `Command.requested_by` and apply WorkSession-bound `SudoPolicy` without a password prompt fallback.

See the server-side plan for the cross-repo contract.

## Changes

- `SessionInfo` grows `Kind` / `CommandID` / `Username` / `StartedAt` fields. Legacy entries without `Kind` are read as `websh` for backward compatibility.
- New `AuthManager` methods `AddPIDCommandMapping` / `RemovePIDCommandMapping` plus package-level `RegisterCommandPID` / `UnregisterCommandPID` helpers. The remove path guards against pid reuse by requiring a matching `command_id`.
- `SudoApprovalRequest` / `SudoApprovalResponse` gain `command_id` (`omitempty`). The request path chooses `POST /api/sudo/approval/` when `command_id` is set and `session_id` is empty, otherwise falls back to the existing `/api/websh/sessions/{id}/sudo-approval/` URL.
- `pkg/executor`: `CommandOptions.PIDHook` and `CommandExecutor.ExecWithHook` propagate the child's pid immediately after `cmd.Start()` so the tracker registration happens before the child can `exec sudo`. The shell handler registers / unregisters a tracker entry when `CommandArgs.CommandID` is set.
- `runner/command.go` plumbs `protocol.Command.ID` into `CommandArgs.CommandID` for both `internal` and `system` shells.
- `pty.go` sets `Kind: TrackerKindWebsh` explicitly on websh registrations (behavioural no-op — existing entries already resolve to websh via `effectiveKind`).

## Test plan

Automated (included):

- [x] `TestAddPIDCommandMapping_RegistersCommandKind` — Command entries populate `Kind`/`CommandID`/`Username`/`StartedAt`.
- [x] `TestAddPIDCommandMapping_IgnoresInvalidInput` — bogus pids / empty command ids are rejected.
- [x] `TestRemovePIDCommandMapping_RemovesMatchingEntry` — unregister on Command completion.
- [x] `TestRemovePIDCommandMapping_PIDReuseGuard` — mismatched command id does not drop unrelated entry.
- [x] `TestRemovePIDCommandMapping_LeavesWebshEntryAlone` — Command-style remove never touches a websh entry with the same pid.
- [x] `TestParallelCommands_TrackedIndependently` — three concurrent Commands each get their own entry.
- [x] `TestLegacyWebshEntry_ReadsAsWebsh` — entries without `Kind` default to websh on read.
- [x] `TestAddPIDSessionMapping_NormalisesWebshKind` — websh registrations clear `CommandID` defensively.
- [x] `TestRegisterCommandPID_NoopWithoutManager` / `TestRegisterCommandPID_RoundTrip` — package-level helpers.
- [x] `TestSudoApprovalRequest_JSONTagsOmitEmpty` — wire-format guardrail: deploy shell vs websh payloads.
- [x] `TestLookupPID_Missing`, `TestAddPIDCommandMapping_OverwritesStaleEntry`.
- [x] `TestShellHandler_CommandID_RegistersAndUnregistersPID` — shell handler uses the hook path and cleans up.
- [x] `TestShellHandler_NoCommandID_UsesPlainExec` — no regression for internal / non-Command shell invocations.

Manual (post-merge, requires server-side PR and alpamon-pam update):

- [ ] Deploy shell Command as an IAM user with a WorkSession-bound `allow_bypass_mfa=True` SudoPolicy succeeds without password prompt.
- [ ] Same user via Websh still hits the existing MFA-bypass path.
- [ ] Root-owned deploy shell path unchanged.

## Build / test

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./... -p 1` : 630 passed / 73 packages