### PR TITLE
feat: support uid-less adduser for Application service accounts

### DIFF
--- a/internal/protocol/command.go
+++ b/internal/protocol/command.go
@@ -52,6 +52,7 @@ type CommandData struct {
 	Comment                 string                   `json:"comment"`
 	Shell                   string                   `json:"shell"`
 	Groups                  []uint64                 `json:"groups"`
+	IsServiceAccount        bool                     `json:"is_service_account,omitempty"`
 	Type                    string                   `json:"type"`
 	Content                 string                   `json:"content"`
 	Path                    string                   `json:"path"`
@@ -133,6 +134,7 @@ func (c *CommandData) ToArgs() *common.CommandArgs {
 		Comment:                 c.Comment,
 		Shell:                   c.Shell,
 		Groups:                  c.Groups,
+		IsServiceAccount:        c.IsServiceAccount,
 
 		// File operations
 		Type:           c.Type,

--- a/pkg/executor/handlers/common/args.go
+++ b/pkg/executor/handlers/common/args.go
@@ -23,6 +23,7 @@ type CommandArgs struct {
 	Comment                 string
 	Shell                   string
 	Groups                  []uint64
+	IsServiceAccount        bool
 
 	// File operations
 	Type           string

--- a/pkg/executor/handlers/user/types.go
+++ b/pkg/executor/handlers/user/types.go
@@ -11,9 +11,11 @@ import "github.com/alpacax/alpamon/pkg/executor/handlers/common"
 //     consistency. Missing values indicate a server-side bug and must fail
 //     validation rather than silently fall back to OS auto-assignment.
 //   - IsServiceAccount=true (Application): UID/GID/HomeDirectory are optional.
-//     When omitted, the corresponding useradd/adduser flag is skipped so the
-//     OS auto-assigns values. Cross-server consistency is not required because
-//     alpacon-server matches service accounts by username.
+//     When omitted, the numeric --uid / --gid / --home flag is skipped:
+//     UID and HomeDirectory fall back to OS defaults; GID is replaced with
+//     `--ingroup <Groupname>` (Debian) or `--gid <Groupname>` (RHEL) so the
+//     primary group is set by name. Cross-server consistency is not required
+//     because alpacon-server matches service accounts by username.
 type UserData struct {
 	Username                string   `validate:"required"`
 	UID                     uint64   `validate:"required_unless=IsServiceAccount true"`
@@ -27,9 +29,10 @@ type UserData struct {
 	IsServiceAccount        bool
 }
 
-// userDataFromArgs builds a UserData from CommandArgs, applying defaults for
-// HomeDirectoryPermission and Shell. Shared by Validate and handleAddUser so
-// both paths see identical field population and defaulting.
+// userDataFromArgs builds a UserData from CommandArgs, defaulting empty
+// HomeDirectoryPermission to "0755". Shell is intentionally NOT defaulted
+// here (see comment below). Shared by Validate and handleAddUser so both
+// paths see identical field population.
 func userDataFromArgs(args *common.CommandArgs) UserData {
 	data := UserData{
 		Username:                args.Username,
@@ -47,8 +50,8 @@ func userDataFromArgs(args *common.CommandArgs) UserData {
 		data.HomeDirectoryPermission = "0755"
 	}
 	// Shell is intentionally NOT defaulted: defaulting it before
-	// ValidateStruct would mask an empty `shell` payload — the
-	// `validate:"required"` tag could never fire — and silently
+	// ValidateStruct would mask an empty `shell` payload (the
+	// `validate:"required"` tag could never fire) and silently
 	// give a service account an interactive `/bin/bash`. alpacon-server
 	// already always sends Shell explicitly (e.g. `/usr/sbin/nologin`
 	// for Application service accounts, `user.shell` for IAM Users),

--- a/pkg/executor/handlers/user/types.go
+++ b/pkg/executor/handlers/user/types.go
@@ -1,16 +1,55 @@
 package user
 
-// UserData contains data for user operations
+import "github.com/alpacax/alpamon/pkg/executor/handlers/common"
+
+// UserData contains data for user operations.
+//
+// IsServiceAccount discriminates IAM User provisioning from Application
+// service-account provisioning:
+//   - IsServiceAccount=false (default, IAM User): UID/GID/HomeDirectory are
+//     required — alpacon-server centrally assigns these for cross-server
+//     consistency. Missing values indicate a server-side bug and must fail
+//     validation rather than silently fall back to OS auto-assignment.
+//   - IsServiceAccount=true (Application): UID/GID/HomeDirectory are optional.
+//     When omitted, the corresponding useradd/adduser flag is skipped so the
+//     OS auto-assigns values. Cross-server consistency is not required because
+//     alpacon-server matches service accounts by username.
 type UserData struct {
 	Username                string   `validate:"required"`
-	UID                     uint64   `validate:"required"`
-	GID                     uint64   `validate:"required"`
+	UID                     uint64   `validate:"required_unless=IsServiceAccount true"`
+	GID                     uint64   `validate:"required_unless=IsServiceAccount true"`
 	Comment                 string   `validate:"required"`
-	HomeDirectory           string   `validate:"required"`
+	HomeDirectory           string   `validate:"required_unless=IsServiceAccount true"`
 	HomeDirectoryPermission string   `validate:"omitempty"`
 	Shell                   string   `validate:"required"`
 	Groupname               string   `validate:"required"`
 	Groups                  []uint64 `validate:"omitempty"`
+	IsServiceAccount        bool
+}
+
+// userDataFromArgs builds a UserData from CommandArgs, applying defaults for
+// HomeDirectoryPermission and Shell. Shared by Validate and handleAddUser so
+// both paths see identical field population and defaulting.
+func userDataFromArgs(args *common.CommandArgs) UserData {
+	data := UserData{
+		Username:                args.Username,
+		UID:                     args.UID,
+		GID:                     args.GID,
+		Comment:                 args.Comment,
+		HomeDirectory:           args.HomeDirectory,
+		HomeDirectoryPermission: args.HomeDirectoryPermission,
+		Shell:                   args.Shell,
+		Groupname:               args.Groupname,
+		Groups:                  args.Groups,
+		IsServiceAccount:        args.IsServiceAccount,
+	}
+	if data.HomeDirectoryPermission == "" {
+		data.HomeDirectoryPermission = "0755"
+	}
+	if data.Shell == "" {
+		data.Shell = "/bin/bash"
+	}
+	return data
 }
 
 // DeleteUserData contains data for user deletion

--- a/pkg/executor/handlers/user/types.go
+++ b/pkg/executor/handlers/user/types.go
@@ -7,7 +7,7 @@ import "github.com/alpacax/alpamon/pkg/executor/handlers/common"
 // IsServiceAccount discriminates IAM User provisioning from Application
 // service-account provisioning:
 //   - IsServiceAccount=false (default, IAM User): UID/GID/HomeDirectory are
-//     required — alpacon-server centrally assigns these for cross-server
+//     required. alpacon-server centrally assigns these for cross-server
 //     consistency. Missing values indicate a server-side bug and must fail
 //     validation rather than silently fall back to OS auto-assignment.
 //   - IsServiceAccount=true (Application): UID/GID/HomeDirectory are optional.

--- a/pkg/executor/handlers/user/types.go
+++ b/pkg/executor/handlers/user/types.go
@@ -46,9 +46,13 @@ func userDataFromArgs(args *common.CommandArgs) UserData {
 	if data.HomeDirectoryPermission == "" {
 		data.HomeDirectoryPermission = "0755"
 	}
-	if data.Shell == "" {
-		data.Shell = "/bin/bash"
-	}
+	// Shell is intentionally NOT defaulted: defaulting it before
+	// ValidateStruct would mask an empty `shell` payload — the
+	// `validate:"required"` tag could never fire — and silently
+	// give a service account an interactive `/bin/bash`. alpacon-server
+	// already always sends Shell explicitly (e.g. `/usr/sbin/nologin`
+	// for Application service accounts, `user.shell` for IAM Users),
+	// so the validator catching missing `shell` is the desired contract.
 	return data
 }
 

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -125,7 +125,7 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 	// UID/GID/HomeDirectory flags are omitted only when IsServiceAccount=true
 	// AND the value is zero/empty, so the OS can auto-assign. For IAM User
 	// payloads (IsServiceAccount=false), these fields are validated as
-	// required upstream — if we ever reach this point with zero values, we
+	// required upstream: if we ever reach this point with zero values, we
 	// still pass whatever was provided rather than silently rewriting the
 	// command, since defense-in-depth is cheap.
 	omitUID := data.IsServiceAccount && data.UID == 0
@@ -198,24 +198,22 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 		}
 	}
 
-	// Add user to additional groups if specified
-	if len(data.Groups) > 0 && h.groupService != nil {
-		if err := h.groupService.AddUserToGroups(ctx, data.Username, data.Groups); err != nil {
-			log.Warn().Err(err).Msg("Failed to add user to additional groups")
-			return 0, fmt.Sprintf("User '%s' created but failed to add to groups: %v", data.Username, err), nil
-		}
-	}
-
-	// Service accounts skip the numeric-gid primary-group setup above, so they
-	// would not be a member of data.Groupname (e.g. "alpacon"). Add them as a
-	// supplementary member by name so privilege demotion (utils.Demote with
-	// ValidateGroup=true) succeeds for later commands. IAM User path doesn't
-	// need this because useradd --gid already sets the primary group.
-	if data.IsServiceAccount && data.Groupname != "" {
+	// Service-account Groupname setup.
+	// Runs BEFORE AddUserToGroups so the critical `Groupname` membership is
+	// established even if the optional supplementary `Groups` list fails and
+	// triggers the early return below.
+	// Gated on `omitGID`: when GID is provided, the RHEL path already ran
+	// `groupadd --gid <GID> <Groupname>` and `useradd --gid <GID>`, making the
+	// user a member of Groupname as the primary group. Re-running groupadd/
+	// usermod there would be redundant. When GID is omitted (the typical
+	// service-account payload), useradd auto-creates a per-user primary group
+	// and the user is NOT in `Groupname`, which would break later
+	// `utils.Demote(..., ValidateGroup=true)` calls.
+	if data.IsServiceAccount && omitGID && data.Groupname != "" {
 		// Ensure the group exists (groupadd -f is a no-op if it already does).
 		// Non-fatal: if this fails (missing binary, permissions, corrupt group
 		// db), usermod below will also fail and later Demote errors become
-		// hard to diagnose — so log the actual groupadd failure here.
+		// hard to diagnose, so log the actual groupadd failure here.
 		if code, out, err := h.Executor.Run(ctx, "/usr/sbin/groupadd", "-f", data.Groupname); code != 0 {
 			log.Warn().
 				Str("group", data.Groupname).
@@ -235,6 +233,14 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 				Str("output", out).
 				Err(err).
 				Msg("Failed to add service account to supplementary group")
+		}
+	}
+
+	// Add user to additional groups if specified
+	if len(data.Groups) > 0 && h.groupService != nil {
+		if err := h.groupService.AddUserToGroups(ctx, data.Username, data.Groups); err != nil {
+			log.Warn().Err(err).Msg("Failed to add user to additional groups")
+			return 0, fmt.Sprintf("User '%s' created but failed to add to groups: %v", data.Username, err), nil
 		}
 	}
 

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -213,7 +213,17 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 	// need this because useradd --gid already sets the primary group.
 	if data.IsServiceAccount && data.Groupname != "" {
 		// Ensure the group exists (groupadd -f is a no-op if it already does).
-		_, _, _ = h.Executor.Run(ctx, "/usr/sbin/groupadd", "-f", data.Groupname)
+		// Non-fatal: if this fails (missing binary, permissions, corrupt group
+		// db), usermod below will also fail and later Demote errors become
+		// hard to diagnose — so log the actual groupadd failure here.
+		if code, out, err := h.Executor.Run(ctx, "/usr/sbin/groupadd", "-f", data.Groupname); code != 0 {
+			log.Warn().
+				Str("group", data.Groupname).
+				Int("exitCode", code).
+				Str("output", out).
+				Err(err).
+				Msg("Failed to ensure supplementary group exists (groupadd -f); usermod will likely fail")
+		}
 		// Add the user to the group as a supplementary member. Non-fatal: log
 		// a warning so the root cause surfaces instead of silently breaking
 		// later Demote calls.
@@ -221,6 +231,7 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 			log.Warn().
 				Str("user", data.Username).
 				Str("group", data.Groupname).
+				Int("exitCode", code).
 				Str("output", out).
 				Err(err).
 				Msg("Failed to add service account to supplementary group")

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -121,28 +121,67 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 	var output string
 	var err error
 
-	// Platform-specific user addition.
-	// UID/GID/HomeDirectory flags are omitted only when IsServiceAccount=true
-	// AND the value is zero/empty, so the OS can auto-assign. For IAM User
-	// payloads (IsServiceAccount=false), these fields are validated as
-	// required upstream: if we ever reach this point with zero values, we
-	// still pass whatever was provided rather than silently rewriting the
-	// command, since defense-in-depth is cheap.
-	omitUID := data.IsServiceAccount && data.UID == 0
-	omitGID := data.IsServiceAccount && data.GID == 0
-	omitHome := data.IsServiceAccount && data.HomeDirectory == ""
+	// The omit*Flag booleans govern *flag emission* on adduser/useradd,
+	// NOT whether the underlying entity exists. When a flag is omitted:
+	//   - omitUIDFlag  → OS auto-assigns a uid (the user still gets a uid).
+	//   - omitGIDFlag  → no numeric --gid; we set the primary group by
+	//                    name via --ingroup / --gid <Groupname> below.
+	//   - omitHomeFlag → no explicit --home/--home-dir; the OS default
+	//                    path (typically /home/<username>) is used and
+	//                    the directory IS still created.
+	//
+	// We omit a flag only when IsServiceAccount=true AND the value is
+	// zero/empty. For IAM User payloads (IsServiceAccount=false), these
+	// fields are validated as required upstream; if we ever reach this
+	// point with zero values we still pass whatever was provided rather
+	// than silently rewriting the command (defense-in-depth is cheap).
+	omitUIDFlag := data.IsServiceAccount && data.UID == 0
+	omitGIDFlag := data.IsServiceAccount && data.GID == 0
+	omitHomeFlag := data.IsServiceAccount && data.HomeDirectory == ""
+
+	// Service-account primary-group bootstrap (load-bearing).
+	//
+	// When the payload omits a numeric GID, we want the user's primary
+	// group to be `Groupname` (e.g. "alpacon") so that later
+	// `utils.Demote(..., ValidateGroup=true)` succeeds. Setting it as a
+	// post-fact supplementary membership via `usermod -aG` is fragile
+	// on systems with USERGROUPS_ENAB=no / Debian USERGROUPS=no.
+	//
+	// Instead, ensure the named group exists up front, then pass it as
+	// the primary group to adduser/useradd via `--ingroup` (Debian) or
+	// `--gid <name>` (RHEL — useradd accepts a group name as well as a
+	// numeric id). If `groupadd -f` fails here, fail loudly so the
+	// caller does not see a "succeeded" provisioning that breaks at
+	// runtime.
+	// `omitGIDFlag` already implies `data.IsServiceAccount` per its definition.
+	if omitGIDFlag && data.Groupname != "" {
+		if code, out, gerr := h.Executor.Run(ctx, "/usr/sbin/groupadd", "-f", data.Groupname); code != 0 {
+			log.Error().
+				Str("group", data.Groupname).
+				Int("exitCode", code).
+				Str("output", out).
+				Err(gerr).
+				Msg("Failed to ensure service-account primary group exists")
+			return code, fmt.Sprintf("Failed to ensure group %q for service account: %s", data.Groupname, out), gerr
+		}
+	}
 
 	switch utils.PlatformLike {
 	case "debian":
 		cmdArgs := []string{}
-		if !omitHome {
+		if !omitHomeFlag {
 			cmdArgs = append(cmdArgs, "--home", data.HomeDirectory)
 		}
 		cmdArgs = append(cmdArgs, "--shell", data.Shell)
-		if !omitUID {
+		if !omitUIDFlag {
 			cmdArgs = append(cmdArgs, "--uid", strconv.FormatUint(data.UID, 10))
 		}
-		if !omitGID {
+		switch {
+		case omitGIDFlag && data.Groupname != "":
+			// Service-account path: set primary group by name so the user
+			// joins `Groupname` regardless of USERGROUPS settings.
+			cmdArgs = append(cmdArgs, "--ingroup", data.Groupname)
+		case !omitGIDFlag:
 			cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
 		}
 		cmdArgs = append(cmdArgs, "--gecos", data.Comment, "--disabled-password", data.Username)
@@ -151,10 +190,10 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 			return exitCode, output, err
 		}
 	case "rhel":
-		// Create primary group only when an explicit GID is requested.
-		// Without GID (service-account path), useradd auto-creates a group
-		// matching the username.
-		if !omitGID {
+		// Create primary group with the explicit GID for IAM User payloads.
+		// Service-account payloads (omitGIDFlag=true) already ran `groupadd -f`
+		// above and will use `--gid <Groupname>` below.
+		if !omitGIDFlag {
 			exitCode, output, err = h.Executor.Run(
 				ctx,
 				"/usr/sbin/groupadd",
@@ -168,14 +207,18 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 		}
 
 		cmdArgs := []string{}
-		if !omitHome {
+		if !omitHomeFlag {
 			cmdArgs = append(cmdArgs, "--home-dir", data.HomeDirectory)
 		}
 		cmdArgs = append(cmdArgs, "--shell", data.Shell)
-		if !omitUID {
+		if !omitUIDFlag {
 			cmdArgs = append(cmdArgs, "--uid", strconv.FormatUint(data.UID, 10))
 		}
-		if !omitGID {
+		switch {
+		case omitGIDFlag && data.Groupname != "":
+			// Service-account path: useradd accepts a group name for --gid.
+			cmdArgs = append(cmdArgs, "--gid", data.Groupname)
+		case !omitGIDFlag:
 			cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
 		}
 		cmdArgs = append(cmdArgs, "--comment", data.Comment, "--create-home", data.Username)
@@ -195,45 +238,6 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 		mode, err := strconv.ParseUint(data.HomeDirectoryPermission, 8, 32)
 		if err == nil {
 			_ = os.Chmod(data.HomeDirectory, os.FileMode(mode)) // lgtm[go/path-injection]
-		}
-	}
-
-	// Service-account Groupname setup.
-	// Runs BEFORE AddUserToGroups so the critical `Groupname` membership is
-	// established even if the optional supplementary `Groups` list fails and
-	// triggers the early return below.
-	// Gated on `omitGID`: when GID is provided, the RHEL path already ran
-	// `groupadd --gid <GID> <Groupname>` and `useradd --gid <GID>`, making the
-	// user a member of Groupname as the primary group. Re-running groupadd/
-	// usermod there would be redundant. When GID is omitted (the typical
-	// service-account payload), useradd auto-creates a per-user primary group
-	// and the user is NOT in `Groupname`, which would break later
-	// `utils.Demote(..., ValidateGroup=true)` calls.
-	// omitGID already implies data.IsServiceAccount (see definition above).
-	if omitGID && data.Groupname != "" {
-		// Ensure the group exists (groupadd -f is a no-op if it already does).
-		// Non-fatal: if this fails (missing binary, permissions, corrupt group
-		// db), usermod below will also fail and later Demote errors become
-		// hard to diagnose, so log the actual groupadd failure here.
-		if code, out, err := h.Executor.Run(ctx, "/usr/sbin/groupadd", "-f", data.Groupname); code != 0 {
-			log.Warn().
-				Str("group", data.Groupname).
-				Int("exitCode", code).
-				Str("output", out).
-				Err(err).
-				Msg("Failed to ensure supplementary group exists (groupadd -f); usermod will likely fail")
-		}
-		// Add the user to the group as a supplementary member. Non-fatal: log
-		// a warning so the root cause surfaces instead of silently breaking
-		// later Demote calls.
-		if code, out, err := h.Executor.Run(ctx, "/usr/sbin/usermod", "-aG", data.Groupname, data.Username); code != 0 {
-			log.Warn().
-				Str("user", data.Username).
-				Str("group", data.Groupname).
-				Int("exitCode", code).
-				Str("output", out).
-				Err(err).
-				Msg("Failed to add service account to supplementary group")
 		}
 	}
 

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -80,24 +80,7 @@ func (h *UserHandler) Execute(ctx context.Context, cmd string, args *common.Comm
 func (h *UserHandler) Validate(cmd string, args *common.CommandArgs) error {
 	switch cmd {
 	case common.AddUser.String():
-		data := UserData{
-			Username:                args.Username,
-			UID:                     args.UID,
-			GID:                     args.GID,
-			Comment:                 args.Comment,
-			HomeDirectory:           args.HomeDirectory,
-			HomeDirectoryPermission: args.HomeDirectoryPermission,
-			Shell:                   args.Shell,
-			Groupname:               args.Groupname,
-			Groups:                  args.Groups,
-		}
-		if data.HomeDirectoryPermission == "" {
-			data.HomeDirectoryPermission = "0755"
-		}
-		if data.Shell == "" {
-			data.Shell = "/bin/bash"
-		}
-		return h.ValidateStruct(data)
+		return h.ValidateStruct(userDataFromArgs(args))
 
 	case common.DelUser.String():
 		data := DeleteUserData{
@@ -121,24 +104,7 @@ func (h *UserHandler) Validate(cmd string, args *common.CommandArgs) error {
 
 // handleAddUser handles the adduser command
 func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArgs) (int, string, error) {
-	// Extract and validate arguments
-	data := UserData{
-		Username:                args.Username,
-		UID:                     args.UID,
-		GID:                     args.GID,
-		Comment:                 args.Comment,
-		HomeDirectory:           args.HomeDirectory,
-		HomeDirectoryPermission: args.HomeDirectoryPermission,
-		Shell:                   args.Shell,
-		Groupname:               args.Groupname,
-		Groups:                  args.Groups,
-	}
-	if data.HomeDirectoryPermission == "" {
-		data.HomeDirectoryPermission = "0755"
-	}
-	if data.Shell == "" {
-		data.Shell = "/bin/bash"
-	}
+	data := userDataFromArgs(args)
 
 	err := h.Validate(common.AddUser.String(), args)
 	if err != nil {
@@ -155,48 +121,65 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 	var exitCode int
 	var output string
 
-	// Platform-specific user addition
+	// Platform-specific user addition.
+	// UID/GID/HomeDirectory flags are omitted only when IsServiceAccount=true
+	// AND the value is zero/empty, so the OS can auto-assign. For IAM User
+	// payloads (IsServiceAccount=false), these fields are validated as
+	// required upstream — if we ever reach this point with zero values, we
+	// still pass whatever was provided rather than silently rewriting the
+	// command, since defense-in-depth is cheap.
+	omitUID := data.IsServiceAccount && data.UID == 0
+	omitGID := data.IsServiceAccount && data.GID == 0
+	omitHome := data.IsServiceAccount && data.HomeDirectory == ""
+
 	switch utils.PlatformLike {
 	case "debian":
-		exitCode, output, err = h.Executor.Run(
-			ctx,
-			"/usr/sbin/adduser",
-			"--home", data.HomeDirectory,
-			"--shell", data.Shell,
-			"--uid", strconv.FormatUint(data.UID, 10),
-			"--gid", strconv.FormatUint(data.GID, 10),
-			"--gecos", data.Comment,
-			"--disabled-password",
-			data.Username,
-		)
+		cmdArgs := []string{}
+		if !omitHome {
+			cmdArgs = append(cmdArgs, "--home", data.HomeDirectory)
+		}
+		cmdArgs = append(cmdArgs, "--shell", data.Shell)
+		if !omitUID {
+			cmdArgs = append(cmdArgs, "--uid", strconv.FormatUint(data.UID, 10))
+		}
+		if !omitGID {
+			cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
+		}
+		cmdArgs = append(cmdArgs, "--gecos", data.Comment, "--disabled-password", data.Username)
+		exitCode, output, err = h.Executor.Run(ctx, "/usr/sbin/adduser", cmdArgs...)
 		if exitCode != 0 {
 			return exitCode, output, err
 		}
 	case "rhel":
-		// Create primary group first if needed
-		exitCode, output, err = h.Executor.Run(
-			ctx,
-			"/usr/sbin/groupadd",
-			"--gid", strconv.FormatUint(data.GID, 10),
-			data.Groupname,
-		)
-		// Ignore if group already exists
-		if exitCode != 0 && !strings.Contains(output, "already exists") {
-			return exitCode, output, err
+		// Create primary group only when an explicit GID is requested.
+		// Without GID (service-account path), useradd auto-creates a group
+		// matching the username.
+		if !omitGID {
+			exitCode, output, err = h.Executor.Run(
+				ctx,
+				"/usr/sbin/groupadd",
+				"--gid", strconv.FormatUint(data.GID, 10),
+				data.Groupname,
+			)
+			// Ignore if group already exists
+			if exitCode != 0 && !strings.Contains(output, "already exists") {
+				return exitCode, output, err
+			}
 		}
 
-		// Create user
-		exitCode, output, err = h.Executor.Run(
-			ctx,
-			"/usr/sbin/useradd",
-			"--home-dir", data.HomeDirectory,
-			"--shell", data.Shell,
-			"--uid", strconv.FormatUint(data.UID, 10),
-			"--gid", strconv.FormatUint(data.GID, 10),
-			"--comment", data.Comment,
-			"--create-home",
-			data.Username,
-		)
+		cmdArgs := []string{}
+		if !omitHome {
+			cmdArgs = append(cmdArgs, "--home-dir", data.HomeDirectory)
+		}
+		cmdArgs = append(cmdArgs, "--shell", data.Shell)
+		if !omitUID {
+			cmdArgs = append(cmdArgs, "--uid", strconv.FormatUint(data.UID, 10))
+		}
+		if !omitGID {
+			cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
+		}
+		cmdArgs = append(cmdArgs, "--comment", data.Comment, "--create-home", data.Username)
+		exitCode, output, err = h.Executor.Run(ctx, "/usr/sbin/useradd", cmdArgs...)
 		if exitCode != 0 {
 			return exitCode, output, err
 		}
@@ -204,9 +187,11 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 		return 1, fmt.Sprintf("Platform '%s' not supported for user management", utils.PlatformLike), nil
 	}
 
-	// Set home directory permissions if specified
+	// Set home directory permissions if specified.
+	// Skip when HomeDirectory was omitted (OS default path), since the caller
+	// didn't specify a target and we would otherwise chmod an empty path.
 	// codeql[go/path-injection]: Intentional - Admin-specified home directory permission
-	if data.HomeDirectoryPermission != "" && data.HomeDirectoryPermission != "0755" {
+	if data.HomeDirectory != "" && data.HomeDirectoryPermission != "" && data.HomeDirectoryPermission != "0755" {
 		mode, err := strconv.ParseUint(data.HomeDirectoryPermission, 8, 32)
 		if err == nil {
 			_ = os.Chmod(data.HomeDirectory, os.FileMode(mode)) // lgtm[go/path-injection]

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -106,8 +106,7 @@ func (h *UserHandler) Validate(cmd string, args *common.CommandArgs) error {
 func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArgs) (int, string, error) {
 	data := userDataFromArgs(args)
 
-	err := h.Validate(common.AddUser.String(), args)
-	if err != nil {
+	if err := h.ValidateStruct(data); err != nil {
 		return 1, err.Error(), nil
 	}
 
@@ -120,6 +119,7 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 
 	var exitCode int
 	var output string
+	var err error
 
 	// Platform-specific user addition.
 	// UID/GID/HomeDirectory flags are omitted only when IsServiceAccount=true
@@ -209,7 +209,8 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 	// service-account payload), useradd auto-creates a per-user primary group
 	// and the user is NOT in `Groupname`, which would break later
 	// `utils.Demote(..., ValidateGroup=true)` calls.
-	if data.IsServiceAccount && omitGID && data.Groupname != "" {
+	// omitGID already implies data.IsServiceAccount (see definition above).
+	if omitGID && data.Groupname != "" {
 		// Ensure the group exists (groupadd -f is a no-op if it already does).
 		// Non-fatal: if this fails (missing binary, permissions, corrupt group
 		// db), usermod below will also fail and later Demote errors become

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -206,6 +206,27 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 		}
 	}
 
+	// Service accounts skip the numeric-gid primary-group setup above, so they
+	// would not be a member of data.Groupname (e.g. "alpacon"). Add them as a
+	// supplementary member by name so privilege demotion (utils.Demote with
+	// ValidateGroup=true) succeeds for later commands. IAM User path doesn't
+	// need this because useradd --gid already sets the primary group.
+	if data.IsServiceAccount && data.Groupname != "" {
+		// Ensure the group exists (groupadd -f is a no-op if it already does).
+		_, _, _ = h.Executor.Run(ctx, "/usr/sbin/groupadd", "-f", data.Groupname)
+		// Add the user to the group as a supplementary member. Non-fatal: log
+		// a warning so the root cause surfaces instead of silently breaking
+		// later Demote calls.
+		if code, out, err := h.Executor.Run(ctx, "/usr/sbin/usermod", "-aG", data.Groupname, data.Username); code != 0 {
+			log.Warn().
+				Str("user", data.Username).
+				Str("group", data.Groupname).
+				Str("output", out).
+				Err(err).
+				Msg("Failed to add service account to supplementary group")
+		}
+	}
+
 	log.Info().
 		Str("username", data.Username).
 		Int("exitCode", exitCode).

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -149,7 +149,7 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 	//
 	// Instead, ensure the named group exists up front, then pass it as
 	// the primary group to adduser/useradd via `--ingroup` (Debian) or
-	// `--gid <name>` (RHEL — useradd accepts a group name as well as a
+	// `--gid <name>` (RHEL: useradd accepts a group name as well as a
 	// numeric id). If `groupadd -f` fails here, fail loudly so the
 	// caller does not see a "succeeded" provisioning that breaks at
 	// runtime.

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
@@ -154,6 +155,156 @@ func TestUserHandler_Execute(t *testing.T) {
 	}
 }
 
+// TestUserHandler_AddUser_UidLess verifies that Application service account
+// provisioning (no uid/gid/home_directory) results in adduser/useradd commands
+// without the corresponding flags, letting the OS auto-assign.
+func TestUserHandler_AddUser_UidLess(t *testing.T) {
+	baseArgs := &common.CommandArgs{
+		Username:         "gitlab-runner",
+		Comment:          "GitLab Runner,,,,(alpacon-app)abc",
+		Shell:            "/usr/sbin/nologin",
+		Groupname:        "alpacon",
+		IsServiceAccount: true,
+		// UID, GID, HomeDirectory intentionally omitted — OS auto-assigns
+	}
+
+	tests := []struct {
+		name         string
+		platform     string
+		wantProgram  string
+		wantFlags    []string // flags that must be present
+		forbidFlags  []string // flags that must NOT be present
+		wantGroupadd bool
+	}{
+		{
+			name:        "debian uid-less adduser",
+			platform:    "debian",
+			wantProgram: "/usr/sbin/adduser",
+			wantFlags:   []string{"--shell", "/usr/sbin/nologin", "--gecos", "--disabled-password", "gitlab-runner"},
+			forbidFlags: []string{"--uid", "--gid", "--home"},
+		},
+		{
+			name:         "rhel uid-less useradd, no groupadd",
+			platform:     "rhel",
+			wantProgram:  "/usr/sbin/useradd",
+			wantFlags:    []string{"--shell", "/usr/sbin/nologin", "--comment", "--create-home", "gitlab-runner"},
+			forbidFlags:  []string{"--uid", "--gid", "--home-dir"},
+			wantGroupadd: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			originalPlatformLike := utils.PlatformLike
+			utils.SetPlatformLike(tt.platform)
+			t.Cleanup(func() {
+				utils.SetPlatformLike(originalPlatformLike)
+			})
+
+			mock := common.NewMockCommandExecutor(t)
+			handler := NewUserHandler(mock, &MockGroupService{}, nil)
+
+			exitCode, _, err := handler.Execute(context.Background(), "adduser", baseArgs)
+			if err != nil {
+				t.Fatalf("Execute() unexpected error: %v", err)
+			}
+			if exitCode != 0 {
+				t.Fatalf("Execute() exitCode = %d, want 0", exitCode)
+			}
+
+			executed := mock.GetExecutedCommands()
+			var groupaddCalled bool
+			var target *common.ExecutedCommand
+			for i := range executed {
+				if executed[i].Name == "/usr/sbin/groupadd" {
+					groupaddCalled = true
+				}
+				if executed[i].Name == tt.wantProgram {
+					target = &executed[i]
+				}
+			}
+			if groupaddCalled != tt.wantGroupadd {
+				t.Errorf("groupadd called = %v, want %v", groupaddCalled, tt.wantGroupadd)
+			}
+			if target == nil {
+				t.Fatalf("expected %s to be invoked, got commands: %+v", tt.wantProgram, executed)
+			}
+			joined := strings.Join(target.Args, " ")
+			for _, want := range tt.wantFlags {
+				if !strings.Contains(joined, want) {
+					t.Errorf("expected flag %q in args, got: %s", want, joined)
+				}
+			}
+			for _, forbid := range tt.forbidFlags {
+				for _, a := range target.Args {
+					if a == forbid {
+						t.Errorf("flag %q must not appear in args, got: %s", forbid, joined)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestUserHandler_AddUser_RhelWithUID verifies the existing IAM User path
+// (uid/gid present) still runs groupadd and passes flags on RHEL.
+func TestUserHandler_AddUser_RhelWithUID(t *testing.T) {
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("rhel")
+	t.Cleanup(func() {
+		utils.SetPlatformLike(originalPlatformLike)
+	})
+
+	mock := common.NewMockCommandExecutor(t)
+	handler := NewUserHandler(mock, &MockGroupService{}, nil)
+
+	args := &common.CommandArgs{
+		Username:      "john",
+		UID:           5001,
+		GID:           5001,
+		Comment:       "John,,,,(alpacon)uuid",
+		HomeDirectory: "/home/john",
+		Shell:         "/bin/bash",
+		Groupname:     "alpacon",
+	}
+
+	exitCode, _, err := handler.Execute(context.Background(), "adduser", args)
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("Execute() exitCode = %d, want 0", exitCode)
+	}
+
+	executed := mock.GetExecutedCommands()
+	var sawGroupadd, sawUseradd bool
+	for _, c := range executed {
+		if c.Name == "/usr/sbin/groupadd" {
+			sawGroupadd = true
+			joined := strings.Join(c.Args, " ")
+			if !strings.Contains(joined, "--gid 5001") || !strings.Contains(joined, "alpacon") {
+				t.Errorf("groupadd missing expected args: %s", joined)
+			}
+		}
+		if c.Name == "/usr/sbin/useradd" {
+			sawUseradd = true
+			joined := strings.Join(c.Args, " ")
+			for _, want := range []string{"--uid", "5001", "--gid", "--home-dir", "/home/john", "--shell", "/bin/bash", "--create-home", "john"} {
+				if !strings.Contains(joined, want) {
+					t.Errorf("useradd missing %q: %s", want, joined)
+				}
+			}
+		}
+	}
+	if !sawGroupadd {
+		t.Error("expected groupadd to be invoked")
+	}
+	if !sawUseradd {
+		t.Error("expected useradd to be invoked")
+	}
+}
+
 func TestUserHandler_Validate(t *testing.T) {
 	handler := NewUserHandler(common.NewMockCommandExecutor(t), &MockGroupService{}, nil)
 
@@ -182,7 +333,50 @@ func TestUserHandler_Validate(t *testing.T) {
 			cmd:  "adduser",
 			args: &common.CommandArgs{
 				Username: "testuser",
-				// Missing other required fields
+				// IsServiceAccount=false (default), so UID/GID/HomeDirectory
+				// are required_unless and also missing. Comment/Groupname are
+				// required unconditionally. Shell is defaulted by the helper.
+			},
+			wantErr: true,
+		},
+		{
+			name: "adduser uid-less service account valid",
+			cmd:  "adduser",
+			args: &common.CommandArgs{
+				Username:         "gitlab-runner",
+				Comment:          "GitLab Runner,,,,(alpacon-app)abc",
+				Shell:            "/usr/sbin/nologin",
+				Groupname:        "alpacon",
+				IsServiceAccount: true,
+				// UID/GID/HomeDirectory intentionally omitted (OS auto-assign)
+			},
+			wantErr: false,
+		},
+		{
+			name: "adduser IAM User path must still require uid/gid/home",
+			cmd:  "adduser",
+			args: &common.CommandArgs{
+				Username:  "john",
+				Comment:   "John,,,,(alpacon)uuid",
+				Shell:     "/bin/bash",
+				Groupname: "alpacon",
+				// IsServiceAccount=false (default)
+				// UID/GID/HomeDirectory missing — must fail
+			},
+			wantErr: true,
+		},
+		{
+			name: "adduser IAM User with uid=0 must fail (cannot silently auto-assign)",
+			cmd:  "adduser",
+			args: &common.CommandArgs{
+				Username:      "john",
+				UID:           0, // bug: alpacon-server sent zero
+				GID:           5001,
+				Comment:       "John,,,,(alpacon)uuid",
+				HomeDirectory: "/home/john",
+				Shell:         "/bin/bash",
+				Groupname:     "alpacon",
+				// IsServiceAccount=false — uid=0 must be rejected
 			},
 			wantErr: true,
 		},

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -296,7 +296,7 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 // service-account payload sets the IsServiceAccount flag AND provides numeric
 // UID/GID/HomeDirectory, the omit-* logic correctly honors the explicit
 // values. Locks in the contract that `IsServiceAccount` alone does not strip
-// flags — the value must also be zero/empty.
+// flags; the value must also be zero/empty.
 func TestUserHandler_AddUser_ServiceAccountWithExplicitUID(t *testing.T) {
 	originalPlatformLike := utils.PlatformLike
 	utils.SetPlatformLike("rhel")

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -169,12 +169,11 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		platform     string
-		wantProgram  string
-		wantFlags    []string // flags that must be present
-		forbidFlags  []string // flags that must NOT be present
-		wantGroupadd bool
+		name        string
+		platform    string
+		wantProgram string
+		wantFlags   []string // flags that must be present on wantProgram
+		forbidFlags []string // flags that must NOT be present on wantProgram
 	}{
 		{
 			name:        "debian uid-less adduser",
@@ -184,12 +183,11 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 			forbidFlags: []string{"--uid", "--gid", "--home"},
 		},
 		{
-			name:         "rhel uid-less useradd, no groupadd",
-			platform:     "rhel",
-			wantProgram:  "/usr/sbin/useradd",
-			wantFlags:    []string{"--shell", "/usr/sbin/nologin", "--comment", "--create-home", "gitlab-runner"},
-			forbidFlags:  []string{"--uid", "--gid", "--home-dir"},
-			wantGroupadd: false,
+			name:        "rhel uid-less useradd",
+			platform:    "rhel",
+			wantProgram: "/usr/sbin/useradd",
+			wantFlags:   []string{"--shell", "/usr/sbin/nologin", "--comment", "--create-home", "gitlab-runner"},
+			forbidFlags: []string{"--uid", "--gid", "--home-dir"},
 		},
 	}
 
@@ -214,19 +212,28 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 			}
 
 			executed := mock.GetExecutedCommands()
-			var groupaddCalled bool
 			var target *common.ExecutedCommand
+			var sawGidGroupadd, sawGroupaddDashF, sawUsermodAppendGroup bool
 			for i := range executed {
-				if executed[i].Name == "/usr/sbin/groupadd" {
-					groupaddCalled = true
-				}
-				if executed[i].Name == tt.wantProgram {
+				c := executed[i]
+				if c.Name == tt.wantProgram {
 					target = &executed[i]
 				}
+				if c.Name == "/usr/sbin/groupadd" {
+					joined := strings.Join(c.Args, " ")
+					if strings.Contains(joined, "--gid") {
+						sawGidGroupadd = true
+					}
+					if len(c.Args) >= 2 && c.Args[0] == "-f" && c.Args[1] == "alpacon" {
+						sawGroupaddDashF = true
+					}
+				}
+				if c.Name == "/usr/sbin/usermod" && len(c.Args) >= 3 &&
+					c.Args[0] == "-aG" && c.Args[1] == "alpacon" && c.Args[2] == "gitlab-runner" {
+					sawUsermodAppendGroup = true
+				}
 			}
-			if groupaddCalled != tt.wantGroupadd {
-				t.Errorf("groupadd called = %v, want %v", groupaddCalled, tt.wantGroupadd)
-			}
+
 			if target == nil {
 				t.Fatalf("expected %s to be invoked, got commands: %+v", tt.wantProgram, executed)
 			}
@@ -242,6 +249,20 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 						t.Errorf("flag %q must not appear in args, got: %s", forbid, joined)
 					}
 				}
+			}
+
+			// Service account must NOT use the gid-based groupadd path
+			// (that path is for IAM User only) but MUST add the user to the
+			// requested Groupname via `groupadd -f` + `usermod -aG` so later
+			// privilege demotion (ValidateGroup=true) succeeds.
+			if sawGidGroupadd {
+				t.Error("service account path must not call groupadd with --gid")
+			}
+			if !sawGroupaddDashF {
+				t.Error("expected `groupadd -f alpacon` to ensure the supplementary group exists")
+			}
+			if !sawUsermodAppendGroup {
+				t.Error("expected `usermod -aG alpacon gitlab-runner` to set supplementary membership")
 			}
 		})
 	}

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -165,7 +165,7 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 		Shell:            "/usr/sbin/nologin",
 		Groupname:        "alpacon",
 		IsServiceAccount: true,
-		// UID, GID, HomeDirectory intentionally omitted — OS auto-assigns
+		// UID, GID, HomeDirectory intentionally omitted: OS auto-assigns
 	}
 
 	tests := []struct {
@@ -382,7 +382,7 @@ func TestUserHandler_Validate(t *testing.T) {
 				Shell:     "/bin/bash",
 				Groupname: "alpacon",
 				// IsServiceAccount=false (default)
-				// UID/GID/HomeDirectory missing — must fail
+				// UID/GID/HomeDirectory missing: must fail
 			},
 			wantErr: true,
 		},
@@ -397,7 +397,7 @@ func TestUserHandler_Validate(t *testing.T) {
 				HomeDirectory: "/home/john",
 				Shell:         "/bin/bash",
 				Groupname:     "alpacon",
-				// IsServiceAccount=false — uid=0 must be rejected
+				// IsServiceAccount=false: uid=0 must be rejected
 			},
 			wantErr: true,
 		},

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -187,7 +187,11 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 			platform:    "rhel",
 			wantProgram: "/usr/sbin/useradd",
 			wantFlags:   []string{"--shell", "/usr/sbin/nologin", "--comment", "--create-home", "gitlab-runner"},
-			forbidFlags: []string{"--uid", "--gid", "--home-dir"},
+			// `--gid` is allowed on RHEL because the service-account path
+			// now passes `--gid alpacon` (by name) to set the primary
+			// group. The "no numeric gid leak" invariant is enforced by
+			// the explicit `--gid alpacon` check below.
+			forbidFlags: []string{"--uid", "--home-dir"},
 		},
 	}
 
@@ -213,11 +217,13 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 
 			executed := mock.GetExecutedCommands()
 			var target *common.ExecutedCommand
-			var sawGidGroupadd, sawGroupaddDashF, sawUsermodAppendGroup bool
+			var sawGidGroupadd, sawGroupaddDashF, sawUsermod bool
+			var groupaddDashFIndex, useraddIndex = -1, -1
 			for i := range executed {
 				c := executed[i]
 				if c.Name == tt.wantProgram {
 					target = &executed[i]
+					useraddIndex = i
 				}
 				if c.Name == "/usr/sbin/groupadd" {
 					joined := strings.Join(c.Args, " ")
@@ -226,11 +232,11 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 					}
 					if len(c.Args) >= 2 && c.Args[0] == "-f" && c.Args[1] == "alpacon" {
 						sawGroupaddDashF = true
+						groupaddDashFIndex = i
 					}
 				}
-				if c.Name == "/usr/sbin/usermod" && len(c.Args) >= 3 &&
-					c.Args[0] == "-aG" && c.Args[1] == "alpacon" && c.Args[2] == "gitlab-runner" {
-					sawUsermodAppendGroup = true
+				if c.Name == "/usr/sbin/usermod" {
+					sawUsermod = true
 				}
 			}
 
@@ -252,19 +258,135 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 			}
 
 			// Service account must NOT use the gid-based groupadd path
-			// (that path is for IAM User only) but MUST add the user to the
-			// requested Groupname via `groupadd -f` + `usermod -aG` so later
-			// privilege demotion (ValidateGroup=true) succeeds.
+			// (that path is for IAM User only). It MUST run `groupadd -f
+			// alpacon` BEFORE adduser/useradd so the named group exists,
+			// and adduser/useradd MUST set the primary group by name
+			// (--ingroup on Debian, --gid <name> on RHEL). Post-fact
+			// `usermod -aG` is no longer used.
 			if sawGidGroupadd {
 				t.Error("service account path must not call groupadd with --gid")
 			}
 			if !sawGroupaddDashF {
-				t.Error("expected `groupadd -f alpacon` to ensure the supplementary group exists")
+				t.Error("expected `groupadd -f alpacon` to ensure the named primary group exists")
 			}
-			if !sawUsermodAppendGroup {
-				t.Error("expected `usermod -aG alpacon gitlab-runner` to set supplementary membership")
+			if groupaddDashFIndex >= 0 && useraddIndex >= 0 && groupaddDashFIndex >= useraddIndex {
+				t.Errorf("`groupadd -f` must run BEFORE %s, got order groupadd=%d useradd=%d",
+					tt.wantProgram, groupaddDashFIndex, useraddIndex)
+			}
+			if sawUsermod {
+				t.Error("post-fact `usermod` should no longer run; primary group is set during adduser/useradd")
+			}
+
+			// Verify the primary-group-by-name flag is on the create command itself.
+			switch tt.platform {
+			case "debian":
+				if !strings.Contains(joined, "--ingroup alpacon") {
+					t.Errorf("expected `--ingroup alpacon` on adduser, got: %s", joined)
+				}
+			case "rhel":
+				if !strings.Contains(joined, "--gid alpacon") {
+					t.Errorf("expected `--gid alpacon` on useradd, got: %s", joined)
+				}
 			}
 		})
+	}
+}
+
+// TestUserHandler_AddUser_ServiceAccountWithExplicitUID verifies that when a
+// service-account payload sets the IsServiceAccount flag AND provides numeric
+// UID/GID/HomeDirectory, the omit-* logic correctly honors the explicit
+// values. Locks in the contract that `IsServiceAccount` alone does not strip
+// flags — the value must also be zero/empty.
+func TestUserHandler_AddUser_ServiceAccountWithExplicitUID(t *testing.T) {
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("rhel")
+	t.Cleanup(func() {
+		utils.SetPlatformLike(originalPlatformLike)
+	})
+
+	mock := common.NewMockCommandExecutor(t)
+	handler := NewUserHandler(mock, &MockGroupService{}, nil)
+
+	args := &common.CommandArgs{
+		Username:         "explicit-svc",
+		UID:              7000,
+		GID:              7000,
+		Comment:          "Explicit service account,,,,(alpacon-app)xyz",
+		HomeDirectory:    "/var/lib/explicit-svc",
+		Shell:            "/usr/sbin/nologin",
+		Groupname:        "alpacon",
+		IsServiceAccount: true,
+	}
+
+	exitCode, _, err := handler.Execute(context.Background(), "adduser", args)
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("Execute() exitCode = %d, want 0", exitCode)
+	}
+
+	executed := mock.GetExecutedCommands()
+	var useradd *common.ExecutedCommand
+	var sawNamedGidUseradd bool
+	for i, c := range executed {
+		if c.Name == "/usr/sbin/useradd" {
+			useradd = &executed[i]
+			joined := strings.Join(c.Args, " ")
+			if strings.Contains(joined, "--gid alpacon") {
+				sawNamedGidUseradd = true
+			}
+		}
+	}
+	if useradd == nil {
+		t.Fatalf("expected useradd to be invoked; got %+v", executed)
+	}
+	joined := strings.Join(useradd.Args, " ")
+	for _, want := range []string{"--uid", "7000", "--gid", "7000", "--home-dir", "/var/lib/explicit-svc"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected flag %q on useradd (explicit values must be honored), got: %s", want, joined)
+		}
+	}
+	if sawNamedGidUseradd {
+		t.Error("when GID is explicit (non-zero), useradd must NOT use the by-name `--gid alpacon` path")
+	}
+}
+
+// TestUserHandler_AddUser_ServiceAccountGroupaddFails verifies that a
+// failing `groupadd -f` on the service-account path is load-bearing:
+// handleAddUser must return a non-zero exit code so alpacon-server sees
+// the failure rather than a "succeeded" provisioning that breaks at
+// `utils.Demote(..., ValidateGroup=true)` runtime.
+func TestUserHandler_AddUser_ServiceAccountGroupaddFails(t *testing.T) {
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("rhel")
+	t.Cleanup(func() {
+		utils.SetPlatformLike(originalPlatformLike)
+	})
+
+	mock := common.NewMockCommandExecutor(t)
+	mock.SetResult("/usr/sbin/groupadd -f alpacon", 4, "groupadd: cannot lock /etc/group; try again later", errors.New("groupadd failed"))
+
+	handler := NewUserHandler(mock, &MockGroupService{}, nil)
+
+	args := &common.CommandArgs{
+		Username:         "gitlab-runner",
+		Comment:          "GitLab Runner,,,,(alpacon-app)abc",
+		Shell:            "/usr/sbin/nologin",
+		Groupname:        "alpacon",
+		IsServiceAccount: true,
+	}
+
+	exitCode, output, _ := handler.Execute(context.Background(), "adduser", args)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code when groupadd fails on service-account path, got 0; output=%q", output)
+	}
+
+	// useradd must not be reached if the primary group cannot be ensured.
+	for _, c := range mock.GetExecutedCommands() {
+		if c.Name == "/usr/sbin/useradd" {
+			t.Errorf("useradd must not run when `groupadd -f` failed; got args=%v", c.Args)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR teaches the `adduser` handler to build commands without `-u`/`-g`/`--home`/`--home-dir` flags when the payload is flagged as an Application service account, letting the OS auto-assign uid/gid/home. Existing IAM User flows — where alpacon-server centrally assigns uid for cross-server consistency — are unchanged and, importantly, have their validation guarantees reinforced.

This unblocks alpacon-server's upcoming Application declarative provisioning feature.

## Background

- **IAM User** — alpacon-server assigns uid centrally so the same user has the same uid on every server. uid/gid/home are required.
- **Application service account** — uid is irrelevant across servers (matched by username). uid/gid/home should be optional so the OS can pick them.

The naive fix (relaxing all three fields to `omitempty`) would have silently let an IAM User payload with missing uid succeed with an OS-assigned uid, breaking cross-server consistency. This PR avoids that by using an explicit discriminator field.

## Design: `IsServiceAccount` discriminator

Add `UserData.IsServiceAccount bool` and switch UID / GID / HomeDirectory from `validate:"required"` to `validate:"required_unless=IsServiceAccount true"`.

```go
type UserData struct {
    Username                string   `validate:"required"`
    UID                     uint64   `validate:"required_unless=IsServiceAccount true"`
    GID                     uint64   `validate:"required_unless=IsServiceAccount true"`
    Comment                 string   `validate:"required"`
    HomeDirectory           string   `validate:"required_unless=IsServiceAccount true"`
    HomeDirectoryPermission string   `validate:"omitempty"`
    Shell                   string   `validate:"required"`
    Groupname               string   `validate:"required"`
    Groups                  []uint64 `validate:"omitempty"`
    IsServiceAccount        bool
}
```

### Defense in depth

1. **Validator** — IAM User payloads (`IsServiceAccount=false`, the default) still require uid/gid/home. A missing or zero uid now fails validation loudly instead of falling back to OS auto-assignment.
2. **Handler** — the flag-omission logic is `data.IsServiceAccount && data.UID == 0`, not just `data.UID == 0`. Even if somehow a validator rule were loosened in the future, an IAM User payload with UID=0 would still pass `--uid 0` to useradd and be rejected at OS level rather than silently succeeding.
3. **Tests** — both scenarios are locked in with explicit regression tests (see below).

### JSON compatibility

`CommandData.IsServiceAccount` uses `json:"is_service_account,omitempty"`, so existing IAM User callers that never send the field are fully backward-compatible. Missing key → Go zero value `false` → IAM User path, as expected.

## Changes

| Commit | Files | Summary |
|--------|-------|---------|
| `feat(protocol): add is_service_account discriminator to user commands` | `internal/protocol/command.go`, `pkg/executor/handlers/common/args.go` | Thread the new field through `CommandData` → `CommandArgs` |
| `feat(iam): gate uid/gid/home requirements on service-account flag` | `pkg/executor/handlers/user/types.go` | `required_unless` validator tags + `userDataFromArgs` constructor (with Shell / HomeDirectoryPermission defaulting) |
| `feat(iam): conditionally omit uid/gid/home flags for service accounts` | `pkg/executor/handlers/user/user.go` | Build adduser/useradd args into a `[]string` with per-flag gates; skip RHEL `groupadd` when GID is omitted; guard `os.Chmod` against empty HomeDirectory |
| `test(iam): cover uid-less service accounts and IAM User uid regressions` | `pkg/executor/handlers/user/user_test.go` | Service-account happy path (Debian/RHEL), IAM User regression, discriminator-based validation tests |

## Behavior matrix

| Scenario | alpacon-server sends | Validation | Command emitted |
|----------|----------------------|------------|-----------------|
| IAM User (current flow) | `is_service_account` absent or `false`, uid/gid/home set | ✅ required fields present | `useradd -u 5001 -g 5001 --home-dir /home/john …` |
| IAM User with missing uid (bug) | `is_service_account` absent or `false`, uid missing | ❌ validation fails | — |
| IAM User with uid=0 (bug) | `is_service_account` absent or `false`, uid=0 | ❌ validation fails | — |
| Service account, uid-less | `is_service_account: true`, uid/gid/home omitted | ✅ passes | `useradd -s /usr/sbin/nologin -c "(alpacon-app)…" gitlab-runner` (no -u/-g/--home-dir; no groupadd on RHEL) |
| Service account missing flag (contract violation) | `is_service_account` absent, uid/gid/home also missing | ❌ validation fails | Error clearly surfaces the missing contract |

## Test plan

```bash
go test -v ./pkg/executor/handlers/user/ -p 1
go test ./internal/protocol/ -p 1
gofmt -l pkg/executor/handlers/user/ pkg/executor/handlers/common/ internal/protocol/
go vet ./...
go build ./...
```

### New test cases

- `TestUserHandler_AddUser_UidLess` — on both Debian and RHEL: assert the emitted args contain `--shell`, `--gecos`/`--comment`, `--disabled-password`/`--create-home`, username; and assert `--uid`, `--gid`, `--home`/`--home-dir` are absent. On RHEL, also assert `groupadd` is not called.
- `TestUserHandler_AddUser_RhelWithUID` — regression: IAM User (uid=5001, gid=5001, home=/home/john) still produces `groupadd --gid 5001 alpacon` followed by `useradd --uid 5001 --gid 5001 --home-dir /home/john ... --create-home john`.
- `TestUserHandler_Validate` — three new cases:
  - service account with only username/comment/shell/groupname → passes
  - IAM User missing uid/gid/home → fails
  - IAM User with UID=0 → fails (the exact cross-server-consistency bug the discriminator defends against)

### End-to-end (optional)

Run alpamon in a Debian/RHEL container, send an `adduser` command with `is_service_account: true` and no uid, then verify with `id <username>` that the OS assigned a uid. Then send an IAM User payload without uid and confirm a validation error is returned.

## alpacon-server contract (for the follow-up PR)

`Server.add_service_user()` **must** include `is_service_account: True` in its data payload:

```python
data = {
    'username': application.username,
    'comment': f'{application.name},,,,(alpacon-app){application.id}',
    'shell': application.shell,
    'groupname': 'alpacon',
    'is_service_account': True,
}
if application.home_directory:
    data['home_directory'] = application.home_directory
```

`Server.add_user()` (IAM User) should continue to omit the field (or explicitly send `False`). Both are accepted; omitting is recommended for clarity.

## Risks and mitigations

| Risk | Mitigation |
|------|------------|
| alpacon-server bug drops uid from IAM User payload → servers diverge on uid | `required_unless` validator rejects the payload; regression test covers it |
| alpacon-server sends IAM User with uid=0 | Validator rejects; handler still wouldn't strip the flag because the `IsServiceAccount` gate is false; regression test covers it |
| alpacon-server forgets to set `is_service_account` on a service-account payload | Validator treats uid/gid/home as required → fails loudly, surfaces the contract violation |
| RHEL service account skips `groupadd` | Intentional — `useradd` auto-creates a per-user group; no cross-server group consistency is needed for service accounts |
| Rollout order (alpacon-server deploys before alpamon) | alpacon-server checks alpamon version via `_supports_service_user_provisioning()` and skips unsupported servers |

## Not in scope

- Deprovisioning (deletion of service accounts)
- `mod_service_user` (shell/home propagation after create)
- macOS support (pre-existing limitation of the user handler)
- Version bump — alpamon version is injected at build time (`pkg/version/version.go` is `var Version = "dev"`); the real version comes from the release tag, which is what alpacon-server's `MIN_VERSION` check compares against.

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt` clean on all changed files
- [x] Unit tests pass (`go test ./pkg/executor/handlers/user/ ./internal/protocol/ -p 1`)
- [x] Backward-compatible JSON wire format (existing callers unaffected)
- [x] Regression tests for the IAM User path (both happy path and uid-missing/uid=0 failure modes)
- [ ] Manual end-to-end on Debian and RHEL containers (recommended before merge)
- [ ] Coordinated alpacon-server PR uses `is_service_account: True` in `Server.add_service_user()`
