### PR TITLE
chore(dockerfiles): restore per-OS default PLUGIN_ID for local test images

### DIFF
--- a/Dockerfiles/build.sh
+++ b/Dockerfiles/build.sh
@@ -9,7 +9,8 @@
 #   docker run \
 #     --add-host="<your-domain>:host-gateway" \
 #     -e ALPACON_URL="http://host.docker.internal:8000" \
-#     -e PLUGIN_ID="<your-plugin-id>" \   # optional; image ships a placeholder for local smoke tests
+#     # PLUGIN_ID is optional; the image ships a placeholder for local smoke tests.
+#     -e PLUGIN_ID="<your-plugin-id>" \
 #     -e PLUGIN_KEY="<your-plugin-key>" \
 #     alpamon:<distro>
 #

--- a/Dockerfiles/build.sh
+++ b/Dockerfiles/build.sh
@@ -9,7 +9,7 @@
 #   docker run \
 #     --add-host="<your-domain>:host-gateway" \
 #     -e ALPACON_URL="http://host.docker.internal:8000" \
-#     -e PLUGIN_ID="<your-plugin-id>" \
+#     -e PLUGIN_ID="<your-plugin-id>" \   # optional; image ships a placeholder for local smoke tests
 #     -e PLUGIN_KEY="<your-plugin-key>" \
 #     alpamon:<distro>
 #

--- a/Dockerfiles/centos/7/entrypoint.sh
+++ b/Dockerfiles/centos/7/entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"959ae5c7-84b0-4fba-8c1e-5b8a3d6dcadc"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
-
-if [ -z "$PLUGIN_ID" ]; then
-    echo "Error: PLUGIN_ID environment variable is required."
-    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
-    exit 1
-fi
 
 mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
 chmod 700 /etc/alpamon

--- a/Dockerfiles/debian/10/entrypoint.sh
+++ b/Dockerfiles/debian/10/entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"d59bc536-2f33-43e0-8d78-bca3ecd91b8e"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
-
-if [ -z "$PLUGIN_ID" ]; then
-    echo "Error: PLUGIN_ID environment variable is required."
-    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
-    exit 1
-fi
 
 mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
 chmod 700 /etc/alpamon

--- a/Dockerfiles/debian/11/entrypoint.sh
+++ b/Dockerfiles/debian/11/entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"71e4e4f9-3553-4554-8695-6425c34eb955"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
-
-if [ -z "$PLUGIN_ID" ]; then
-    echo "Error: PLUGIN_ID environment variable is required."
-    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
-    exit 1
-fi
 
 mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
 chmod 700 /etc/alpamon

--- a/Dockerfiles/redhat/8/entrypoint.sh
+++ b/Dockerfiles/redhat/8/entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"ff79dd66-0cfa-4a29-902a-b023038b12e3"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
-
-if [ -z "$PLUGIN_ID" ]; then
-    echo "Error: PLUGIN_ID environment variable is required."
-    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
-    exit 1
-fi
 
 mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
 chmod 700 /etc/alpamon

--- a/Dockerfiles/redhat/9/entrypoint.sh
+++ b/Dockerfiles/redhat/9/entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"97a27261-6029-48b3-89df-b31040a43722"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
-
-if [ -z "$PLUGIN_ID" ]; then
-    echo "Error: PLUGIN_ID environment variable is required."
-    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
-    exit 1
-fi
 
 mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
 chmod 700 /etc/alpamon

--- a/Dockerfiles/ubuntu/18.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/18.04/entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"756d1a97-a4ec-4d76-a9a0-688f15416abf"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
-
-if [ -z "$PLUGIN_ID" ]; then
-    echo "Error: PLUGIN_ID environment variable is required."
-    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
-    exit 1
-fi
 
 mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
 chmod 700 /etc/alpamon

--- a/Dockerfiles/ubuntu/20.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/20.04/entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"617cfd44-a25e-4fc7-90e1-bfafe429c649"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
-
-if [ -z "$PLUGIN_ID" ]; then
-    echo "Error: PLUGIN_ID environment variable is required."
-    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
-    exit 1
-fi
 
 mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
 chmod 700 /etc/alpamon

--- a/Dockerfiles/ubuntu/22.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/22.04/entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"a7282bea-31d7-4b55-a43e-97e1240c90ab"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
-
-if [ -z "$PLUGIN_ID" ]; then
-    echo "Error: PLUGIN_ID environment variable is required."
-    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
-    exit 1
-fi
 
 mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
 chmod 700 /etc/alpamon


### PR DESCRIPTION
## Summary

This PR partially reverts commit [af0ba9f](https://github.com/alpacax/alpamon/commit/af0ba9f) for the **PLUGIN_ID portion only**, restoring the one-liner `./Dockerfiles/build.sh && docker run alpamon:<distro>` smoke-test workflow. All 8 distro entrypoints once again ship with a per-OS placeholder PLUGIN_ID default, and the strict required-env check is removed. Every other improvement from af0ba9f is kept intact.

## Background

The `Dockerfiles/` tree exists solely for **local distro smoke testing** (see `CLAUDE.md` § "Docker testing"). It is never pushed to a registry and is never shipped externally.

af0ba9f removed the hardcoded default PLUGIN_ID from all 8 entrypoints and added an `[ -z "$PLUGIN_ID" ] && exit 1` check at the top of each one. The intent (avoid baking credentials into images, fail-fast on misconfig) is sound for production artifacts, but does not apply to this directory:

| Concern | Production image | Reality of `Dockerfiles/` |
|---|---|---|
| Credential leakage | Real risk | Placeholder UUIDs were never issued — no asset to leak |
| Fail-fast benefit | Speeds production debugging | Locally, just one extra line of server-side auth-rejection log |
| 12-factor "config in env" | Applies | No reason to enforce on a test fixture |
| One-liner `docker run <image>` | Secondary | The **reason this directory exists** |

The trade-off does not balance: the security cost of placeholder PLUGIN_IDs here is effectively zero, while the DX cost of the strict check was paid on every smoke-test run.

> Strictly, `docker build` itself was always fine — the regression manifested only at `docker run` time when no env was supplied. The original report phrased it as "Dockerfiles fail to build", but this PR treats the issue as a runtime smoke-test workflow regression.

## Design: per-OS placeholder UUIDs

Before af0ba9f each distro shipped a **distinct** placeholder UUID, so each image had its own identity at the alpacon-server side. This PR restores those exact UUIDs rather than collapsing them to a single value:

| OS | PLUGIN_ID |
|---|---|
| `debian/10` | `d59bc536-2f33-43e0-8d78-bca3ecd91b8e` |
| `debian/11` | `71e4e4f9-3553-4554-8695-6425c34eb955` |
| `ubuntu/18.04` | `756d1a97-a4ec-4d76-a9a0-688f15416abf` |
| `ubuntu/20.04` | `617cfd44-a25e-4fc7-90e1-bfafe429c649` |
| `ubuntu/22.04` | `a7282bea-31d7-4b55-a43e-97e1240c90ab` |
| `redhat/8` | `ff79dd66-0cfa-4a29-902a-b023038b12e3` |
| `redhat/9` | `97a27261-6029-48b3-89df-b31040a43722` |
| `centos/7` | `959ae5c7-84b0-4fba-8c1e-5b8a3d6dcadc` |

Each entrypoint also drops the strict required-env check:

```diff
 ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"<per-OS UUID>"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}

-if [ -z "$PLUGIN_ID" ]; then
-    echo "Error: PLUGIN_ID environment variable is required."
-    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
-    exit 1
-fi
-
 mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
```

The `Dockerfiles/build.sh` header comment now marks PLUGIN_ID as an **optional override** rather than a required env:

```diff
-#     -e PLUGIN_ID="<your-plugin-id>" \
+#     -e PLUGIN_ID="<your-plugin-id>" \   # optional; image ships a placeholder for local smoke tests
```

## Kept intact from af0ba9f

This PR deliberately does **not** touch any of the following:

- Removal of `systemd` and dev packages (`build-essential`, `libpam0g-dev`, `libjansson-dev`, etc.) from all Dockerfiles.
- `ALPACON_URL` default of `http://host.docker.internal:8000` (the HTTP API port; previously incorrectly defaulted to backhaul `:8081`).
- Unified `mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon` plus permission setup in entrypoints.
- `debian/10` quoting bug fix.
- The `build.sh` header usage comment block (only the PLUGIN_ID line is annotated).

## Changes

| Commit | Files | Summary |
|--------|-------|---------|
| `chore(dockerfiles): restore per-OS default PLUGIN_ID for local test images` | `Dockerfiles/{debian/10,debian/11,ubuntu/18.04,ubuntu/20.04,ubuntu/22.04,redhat/8,redhat/9,centos/7}/entrypoint.sh`, `Dockerfiles/build.sh` | Restore per-OS placeholder PLUGIN_ID defaults, drop strict required-env check, mark PLUGIN_ID as optional override in build.sh comment |

Diffstat: **9 files changed, 9 insertions(+), 49 deletions(-)**.

## Behavior matrix

| Scenario | Before this PR (post-af0ba9f) | After this PR |
|---|---|---|
| `docker build -f Dockerfiles/<distro>/Dockerfile .` | ✅ succeeds | ✅ succeeds (no change) |
| `docker run alpamon:<distro>` (no env) | ❌ `Error: PLUGIN_ID environment variable is required.` (exit 1) | ✅ writes alpamon.conf with per-OS placeholder UUID and execs the binary; server-side auth rejection is the expected next step |
| `docker run -e PLUGIN_ID=<real> alpamon:<distro>` | ✅ works | ✅ works (override still honored) |
| `docker run -e ALPACON_URL=<...> alpamon:<distro>` | ✅ works | ✅ works (override still honored) |

## Test plan

- [ ] `./Dockerfiles/build.sh` — all 8 images build cleanly (unchanged from before).
- [ ] For each distro, `docker run alpamon:<distro>` boots without extra env, writes `/etc/alpamon/alpamon.conf` with the OS-specific UUID, and execs the alpamon binary.
- [ ] `docker run -e PLUGIN_ID=<custom> alpamon:<distro>` overrides the placeholder.
- [ ] `grep -rn "PLUGIN_ID=\${PLUGIN_ID" Dockerfiles/` shows 8 distinct UUIDs (one per distro).
- [ ] `grep -rn "PLUGIN_ID environment variable is required" Dockerfiles/` returns no matches.

## Out of scope

- Automating PLUGIN_ID issuance/injection on the alpacon-server side.
- Defining production Docker images (this directory is local-test-only; production images live on a separate track).
- CI-side container smoke-test automation.

## References

- Regression-introducing commit: `af0ba9f` "chore: update Dockerfiles for container support without systemd"
- Directory purpose: `CLAUDE.md` § "Docker testing"
