### PR TITLE
fix(register): normalize Windows BinaryPathName to avoid double-encoding

### DIFF
--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -192,13 +192,13 @@ func quoteServicePath(p string) string {
 }
 
 // normalizeServiceBinaryPath rewrites the service's BinaryPathName to
-// binaryPathName via UpdateConfig. Used immediately after mgr.CreateService
-// to undo the double-encoding caused by syscall.EscapeArg inside
-// CreateService — see the call site in startService for the full
-// rationale. UpdateConfig writes BinaryPathName verbatim (no EscapeArg),
-// so the stored ImagePath ends up as the command line we constructed via
-// quoteServicePath, wrapped once with a single pair of double quotes when
-// needed.
+// the provided binaryPathName via UpdateConfig. Used immediately after
+// mgr.CreateService to undo the double-encoding caused by
+// syscall.EscapeArg inside CreateService — see the call site in
+// startService for the full rationale. UpdateConfig writes
+// BinaryPathName verbatim (no EscapeArg), so the stored ImagePath ends
+// up as the command line we constructed via quoteServicePath, wrapped
+// once with a single pair of double quotes when needed.
 func normalizeServiceBinaryPath(s *mgr.Service, binaryPathName string) error {
 	cfg, err := s.Config()
 	if err != nil {

--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -89,9 +89,16 @@ func startService() error {
 		// does not call EscapeArg) so the stored ImagePath ends up as
 		// the canonical "<path>" command line.
 		if err := normalizeServiceBinaryPath(s, serviceBinPath); err != nil {
-			// Close explicitly: the deferred close below has not been
-			// registered yet at this point in the function flow.
+			// Best-effort rollback: delete the freshly-created service
+			// so a failed register does not leave a broken
+			// (double-encoded) ImagePath entry behind. Close
+			// explicitly afterward — the deferred close below has not
+			// been registered yet at this point in the function flow.
+			deleteErr := s.Delete()
 			_ = s.Close()
+			if deleteErr != nil {
+				return fmt.Errorf("normalize service binary path: %w (rollback delete service: %v)%s", err, deleteErr, elevationHint(err))
+			}
 			return fmt.Errorf("normalize service binary path: %w%s", err, elevationHint(err))
 		}
 	} else {
@@ -185,18 +192,19 @@ func quoteServicePath(p string) string {
 }
 
 // normalizeServiceBinaryPath rewrites the service's BinaryPathName to
-// binPath via UpdateConfig. Used immediately after mgr.CreateService to
-// undo the double-encoding caused by syscall.EscapeArg inside
+// binaryPathName via UpdateConfig. Used immediately after mgr.CreateService
+// to undo the double-encoding caused by syscall.EscapeArg inside
 // CreateService — see the call site in startService for the full
 // rationale. UpdateConfig writes BinaryPathName verbatim (no EscapeArg),
-// so the stored ImagePath ends up as the single-quoted command line we
-// constructed via quoteServicePath.
-func normalizeServiceBinaryPath(s *mgr.Service, binPath string) error {
+// so the stored ImagePath ends up as the command line we constructed via
+// quoteServicePath, wrapped once with a single pair of double quotes when
+// needed.
+func normalizeServiceBinaryPath(s *mgr.Service, binaryPathName string) error {
 	cfg, err := s.Config()
 	if err != nil {
 		return fmt.Errorf("read service config: %w", err)
 	}
-	cfg.BinaryPathName = binPath
+	cfg.BinaryPathName = binaryPathName
 	if err := s.UpdateConfig(cfg); err != nil {
 		return fmt.Errorf("update service config: %w", err)
 	}

--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -78,6 +78,22 @@ func startService() error {
 		if err != nil {
 			return fmt.Errorf("create service: %w%s", err, elevationHint(err))
 		}
+
+		// mgr.CreateService internally calls syscall.EscapeArg on
+		// exepath, which sees our already-quoted serviceBinPath,
+		// escapes the inner quotes as \", and wraps the whole thing
+		// in another pair of "...". SCM stores that 42-character
+		// value in ImagePath verbatim, then can't spawn it because
+		// CommandLineToArgvW interprets \" as a literal quote in
+		// argv[0]. Rewrite BinaryPathName via UpdateConfig (which
+		// does not call EscapeArg) so the stored ImagePath ends up as
+		// the canonical "<path>" command line.
+		if err := normalizeServiceBinaryPath(s, serviceBinPath); err != nil {
+			// Close explicitly: the deferred close below has not been
+			// registered yet at this point in the function flow.
+			_ = s.Close()
+			return fmt.Errorf("normalize service binary path: %w%s", err, elevationHint(err))
+		}
 	} else {
 		// Service already exists. Refresh its config so re-running
 		// register is idempotent and corrects any drift: a binPath
@@ -166,4 +182,23 @@ func quoteServicePath(p string) string {
 		return p
 	}
 	return `"` + p + `"`
+}
+
+// normalizeServiceBinaryPath rewrites the service's BinaryPathName to
+// binPath via UpdateConfig. Used immediately after mgr.CreateService to
+// undo the double-encoding caused by syscall.EscapeArg inside
+// CreateService — see the call site in startService for the full
+// rationale. UpdateConfig writes BinaryPathName verbatim (no EscapeArg),
+// so the stored ImagePath ends up as the single-quoted command line we
+// constructed via quoteServicePath.
+func normalizeServiceBinaryPath(s *mgr.Service, binPath string) error {
+	cfg, err := s.Config()
+	if err != nil {
+		return fmt.Errorf("read service config: %w", err)
+	}
+	cfg.BinaryPathName = binPath
+	if err := s.UpdateConfig(cfg); err != nil {
+		return fmt.Errorf("update service config: %w", err)
+	}
+	return nil
 }

--- a/cmd/alpamon/command/register/service_windows_test.go
+++ b/cmd/alpamon/command/register/service_windows_test.go
@@ -3,6 +3,7 @@
 package register
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -101,6 +102,15 @@ func TestStartService_BinaryPathNotDoubleEncoded(t *testing.T) {
 		},
 	)
 	if err != nil {
+		// mgr.Connect can succeed with read-only SCM access on some
+		// hosts (e.g. limited local accounts), so CreateService is the
+		// real privilege gate. Treat ACCESS_DENIED here as a skip to
+		// match the docstring's intent and avoid hard-failing
+		// non-Administrator local runs.
+		var errno windows.Errno
+		if errors.As(err, &errno) && errno == windows.ERROR_ACCESS_DENIED {
+			t.Skipf("requires Administrator + SCM create access (CreateService: %v)", err)
+		}
 		t.Fatalf("CreateService: %v", err)
 	}
 	t.Cleanup(func() {

--- a/cmd/alpamon/command/register/service_windows_test.go
+++ b/cmd/alpamon/command/register/service_windows_test.go
@@ -1,0 +1,141 @@
+//go:build windows
+
+package register
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+func TestQuoteServicePath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty input is returned as-is",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "no-whitespace path is returned unchanged",
+			in:   `C:\alpamon\alpamon.exe`,
+			want: `C:\alpamon\alpamon.exe`,
+		},
+		{
+			name: "space in path triggers wrapping",
+			in:   `C:\Program Files\alpamon\alpamon.exe`,
+			want: `"C:\Program Files\alpamon\alpamon.exe"`,
+		},
+		{
+			name: "tab in path triggers wrapping",
+			in:   "C:\\with\ttab\\alpamon.exe",
+			want: "\"C:\\with\ttab\\alpamon.exe\"",
+		},
+		{
+			name: "already-quoted path is returned unchanged (do not double-quote our own input)",
+			in:   `"C:\Program Files\alpamon\alpamon.exe"`,
+			want: `"C:\Program Files\alpamon\alpamon.exe"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := quoteServicePath(tc.in)
+			if got != tc.want {
+				t.Fatalf("quoteServicePath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStartService_BinaryPathNotDoubleEncoded exercises the production
+// composition of quoteServicePath + mgr.CreateService +
+// normalizeServiceBinaryPath against the real local SCM, and asserts
+// that the resulting ImagePath registry value is the single-quoted
+// canonical form. This is the regression gate for the double-encoding
+// bug fixed by normalizeServiceBinaryPath — the bug only reproduces
+// against the real SCM (mgr.CreateService applies syscall.EscapeArg
+// internally, which we cannot observe via a unit test of helpers).
+//
+// Skipped if the test process can't open the SCM with create
+// privileges (i.e. not running as Administrator). GitHub-hosted
+// windows-latest runners are admin so CI does exercise this path.
+func TestStartService_BinaryPathNotDoubleEncoded(t *testing.T) {
+	m, err := mgr.Connect()
+	if err != nil {
+		t.Skipf("requires Administrator + SCM access (mgr.Connect: %v)", err)
+	}
+	t.Cleanup(func() { _ = m.Disconnect() })
+
+	// Sentinel name to avoid colliding with a real alpamon install or
+	// a parallel test invocation. Long enough to make accidental
+	// reuse practically impossible.
+	svcName := fmt.Sprintf("alpamon-test-%d-%d", os.Getpid(), time.Now().UnixNano())
+
+	// The bug only fires on whitespace-containing paths, because
+	// quoteServicePath only wraps those. Force the condition by
+	// constructing a path with a space under t.TempDir(); the file
+	// does not need to exist — SCM stores BinaryPathName at create
+	// time and validates it only at service start, which we never
+	// invoke here.
+	binPath := filepath.Join(t.TempDir(), "with space", "alpamon.exe")
+	serviceBinPath := quoteServicePath(binPath)
+
+	s, err := m.CreateService(
+		svcName,
+		serviceBinPath,
+		mgr.Config{
+			DisplayName:  "Alpamon Test Service (transient)",
+			StartType:    mgr.StartManual,
+			ServiceType:  windows.SERVICE_WIN32_OWN_PROCESS,
+			ErrorControl: mgr.ErrorNormal,
+		},
+	)
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Delete()
+		_ = s.Close()
+	})
+
+	if err := normalizeServiceBinaryPath(s, serviceBinPath); err != nil {
+		t.Fatalf("normalizeServiceBinaryPath: %v", err)
+	}
+
+	// Read the stored ImagePath directly from the registry — sc.exe
+	// qc and s.Config() both go back through the SCM API, which can
+	// be lossy in either direction. The registry is the ground truth
+	// for what SCM will hand to CreateProcess at start time.
+	keyPath := `SYSTEM\CurrentControlSet\Services\` + svcName
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, keyPath, registry.QUERY_VALUE)
+	if err != nil {
+		t.Fatalf("open registry key %q: %v", keyPath, err)
+	}
+	defer func() { _ = k.Close() }()
+
+	imagePath, _, err := k.GetStringValue("ImagePath")
+	if err != nil {
+		t.Fatalf("read ImagePath value: %v", err)
+	}
+
+	if imagePath != serviceBinPath {
+		t.Errorf("ImagePath = %q (len %d), want %q (len %d)",
+			imagePath, len(imagePath), serviceBinPath, len(serviceBinPath))
+	}
+	if !strings.HasPrefix(imagePath, `"`) {
+		t.Errorf("ImagePath %q does not start with a literal quote", imagePath)
+	}
+	if strings.Contains(imagePath, `\"`) {
+		t.Errorf("ImagePath %q contains backslash-escaped quote — double-encoding regressed", imagePath)
+	}
+}

--- a/cmd/alpamon/command/register/service_windows_test.go
+++ b/cmd/alpamon/command/register/service_windows_test.go
@@ -61,19 +61,27 @@ func TestQuoteServicePath(t *testing.T) {
 // TestStartService_BinaryPathNotDoubleEncoded exercises the production
 // composition of quoteServicePath + mgr.CreateService +
 // normalizeServiceBinaryPath against the real local SCM, and asserts
-// that the resulting ImagePath registry value is the single-quoted
-// canonical form. This is the regression gate for the double-encoding
-// bug fixed by normalizeServiceBinaryPath — the bug only reproduces
-// against the real SCM (mgr.CreateService applies syscall.EscapeArg
-// internally, which we cannot observe via a unit test of helpers).
+// that the resulting ImagePath registry value is the canonical form
+// wrapped once in double quotes. This is the regression gate for the
+// double-encoding bug fixed by normalizeServiceBinaryPath — the bug
+// only reproduces against the real SCM (mgr.CreateService applies
+// syscall.EscapeArg internally, which we cannot observe via a unit
+// test of helpers).
 //
 // Skipped if the test process can't open the SCM with create
 // privileges (i.e. not running as Administrator). GitHub-hosted
 // windows-latest runners are admin so CI does exercise this path.
+// Connect failures other than ACCESS_DENIED (e.g. SCM/RPC issues) are
+// surfaced via t.Fatalf rather than silently skipped, so CI does not
+// mask real regressions behind the elevation skip.
 func TestStartService_BinaryPathNotDoubleEncoded(t *testing.T) {
 	m, err := mgr.Connect()
 	if err != nil {
-		t.Skipf("requires Administrator + SCM access (mgr.Connect: %v)", err)
+		var errno windows.Errno
+		if errors.As(err, &errno) && errno == windows.ERROR_ACCESS_DENIED {
+			t.Skipf("requires Administrator + SCM access (mgr.Connect: %v)", err)
+		}
+		t.Fatalf("mgr.Connect failed: %v", err)
 	}
 	t.Cleanup(func() { _ = m.Disconnect() })
 


### PR DESCRIPTION
## Summary

Every fresh Windows install of alpamon v2.1.3 fails to auto-start the SCM service. `register` exits with `Server registered successfully!`, but the service never reaches `Running` and the Alpacon console shows the host as disconnected. The visible error in `register` output is generic and misleading:

```
Starting alpamon service...
Warning: Failed to start service: start service: Access is denied.
Please start alpamon manually:
  sc.exe start alpamon
```

The root cause is that `mgr.CreateService` (in `golang.org/x/sys/windows/svc/mgr`) internally calls `syscall.EscapeArg(exepath)` on the path argument. Our `quoteServicePath` helper had already wrapped a whitespace-containing path in `"..."` to defend against the classic [unquoted-service-path](https://attack.mitre.org/techniques/T1574/009/) attack, so `EscapeArg` saw an already-quoted string with embedded `"` characters, escaped them as `\"`, and wrapped another pair of `"..."` around the whole thing. SCM stored the resulting 42-character value verbatim in `ImagePath`:

```
"\"C:\Program Files\alpamon\alpamon.exe\""
```

When SCM later parsed that as a command line via `CommandLineToArgvW`, the backslash-escaped quotes were resolved as literal `"` characters inside `argv[0]`, leaving SCM trying to execute a file whose name literally contains quote characters — which does not exist on disk. SCM converted the resulting `CreateProcess` failure into a generic 7000 event (`Access is denied`).

This PR fixes the encoding without weakening the unquoted-service-path defense. It also adds the first Windows-only test file in this package, seeding regression coverage for the area.

## Why this shipped without an upstream complaint loop

The `mgr` package is asymmetric:

| Path | Wraps `BinaryPathName` with `EscapeArg`? |
|---|---|
| `mgr.CreateService` | yes (corrupts our pre-quoted path) |
| `Service.UpdateConfig` | no (writes value verbatim) |

`alpamon register`'s "service exists" branch already runs `s.UpdateConfig` to refresh config drift, so re-registering on a host that already has the service silently self-heals to the canonical 38-character form. The bug is therefore visible only on the very first install of a host. Developers and CI who repeatedly install on the same machine never see it; only operators deploying to a fresh machine do.

Diagnosis from a live EC2 host produced the registry raw bytes that confirm the encoding:

```powershell
$ip = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\alpamon' -Name ImagePath).ImagePath
"Length: $($ip.Length)"
"Bytes: $([System.Text.Encoding]::UTF8.GetBytes($ip) -join ',')"
# Length: 42
# Bytes: 34,92,34,67,58,...,92,34,34   (i.e. " \ " ... \ " ")
```

## Approach

Introduce `normalizeServiceBinaryPath`, called immediately after `m.CreateService` succeeds, that re-writes `BinaryPathName` via `s.UpdateConfig` (which does not call `EscapeArg`). Result: both the fresh-install and re-register code paths converge on the same single-quoted 38-character `ImagePath`.

Trade-offs considered:

- **Bypass `mgr.CreateService` and call `windows.CreateService` directly** — would require re-implementing `mgr`'s convenience plumbing (`SidType`, `Description`, recovery actions). Large diff, no benefit beyond removing one extra SCM round-trip on first install.
- **Drop `quoteServicePath` and pass the raw path to `CreateService`** — `EscapeArg` would then quote correctly on the create path, but the `UpdateConfig` branch stores `BinaryPathName` verbatim, so the unquoted-service-path defense would need its own quoting just before that call. The asymmetry just moves rather than disappearing, hurting readability.

The chosen approach is the smallest-footprint fix that produces a consistent on-disk shape across both branches.

## Changes

### `cmd/alpamon/command/register/service_windows.go`

Two additions:

1. **Inside `startService`'s create branch**, immediately after a successful `m.CreateService`, call the new helper. The helper failure path closes the freshly-acquired SCM handle explicitly because the function-tail `defer func() { _ = s.Close() }()` has not been registered yet at this point in the flow. `elevationHint(err)` is reused so an `ACCESS_DENIED` from `UpdateConfig` produces the same "run as Administrator" annotation the rest of this file uses.
2. **`normalizeServiceBinaryPath`** as a small private helper near `quoteServicePath`. Reads the service config back, rewrites `BinaryPathName`, and pushes via `UpdateConfig`. Hard-fails on either read or write — without normalization the service cannot start, so silently continuing would just reproduce the original "Access is denied" symptom for the operator.

The existing "service exists" branch is **not** modified — its `UpdateConfig` call already produces the correct stored value, and its `Warning: ...; continue` semantics on config-read failure is the right resilience posture for re-register (config drift correction is best-effort).

`quoteServicePath` is **not** modified — the unquoted-service-path defense is still required, and the helper is correct given that `UpdateConfig` is now also a write path.

### `cmd/alpamon/command/register/service_windows_test.go` (new)

`//go:build windows`. Two tests, no third-party deps beyond the already-vendored `golang.org/x/sys/windows/registry`.

- **`TestQuoteServicePath`** — table-driven, locks the contract of the helper across five inputs (empty, no-whitespace, space, tab, already-quoted). Doesn't catch the double-encoding bug directly, but prevents regressions of the load-bearing "do not re-quote already-quoted input" branch.
- **`TestStartService_BinaryPathNotDoubleEncoded`** — integration test against the real local SCM. Creates a sentinel service with a name that cannot collide with a real install (`alpamon-test-<pid>-<unixnano>`), runs the full `quoteServicePath + mgr.CreateService + normalizeServiceBinaryPath` composition, then reads `ImagePath` directly from the registry as ground truth. Asserts that the stored value equals the single-quoted command line and contains no `\"`. Skipped automatically on hosts where the test process can't open the SCM with create privileges (i.e. non-Administrator); GitHub-hosted `windows-latest` runners run with the elevated token, so CI does exercise this path.

## Behavior matrix

| Scenario | Before this PR | After this PR |
|---|---|---|
| Fresh Windows host, `register` once | ❌ `ImagePath` stored as 42-char `"\"...\""`, SCM start → `Access is denied` | ✅ `ImagePath` is 38-char single-quoted, SCM auto-start succeeds |
| Same host, `register` again (re-register) | ✅ self-heals via `UpdateConfig` branch | ✅ unchanged (no regression) |
| `register` from a non-elevated PowerShell | ✅ existing `Hint: run from Administrator` (correct) | ✅ unchanged |
| `s.UpdateConfig` denied for a real reason (e.g. GPO) | n/a (not reached before this PR) | ❌ register fails with `normalize service binary path: <wrapped error>` and the `elevationHint`. Operator gets actionable info immediately instead of a misleading start failure later. |

## Test plan

CI runs the new tests automatically on the `build-and-test-windows` job. Manual end-to-end check on a clean Windows host (Server 2019/2022, EC2 default AMI, etc.) in an elevated PowerShell:

```powershell
# 1. Run register
& "<dist>\alpamon.exe" register --url <ALPACON_URL> --token <TOKEN>
# Expect: no `Warning: Failed to start service: Access is denied.` line.

# 2. Inspect the registry
$ip = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\alpamon' -Name ImagePath).ImagePath
"Length: $($ip.Length)"          # 38
$ip                              # "C:\Program Files\alpamon\alpamon.exe"
[bool]($ip -match '\\"')         # False

# 3. Service state
Get-Service alpamon              # Status : Running
sc.exe qc alpamon                # START_TYPE: 2 AUTO_START (DELAYED), single-quoted BINARY_PATH_NAME
```

Checklist:

- [ ] `register` output contains no `Warning: Failed to start service: Access is denied.`
- [ ] `ImagePath` length is 38 and does not contain `\"`
- [ ] `Get-Service alpamon` reports `Running`
- [ ] Alpacon console shows the new server entry as connected within ~60s
- [ ] Re-register on the same host (UpdateConfig branch). `ImagePath` length is still 38 — no regression on the previously-working path.
- [ ] On a non-Administrator local Windows machine, `go test ./cmd/alpamon/command/register/...` reports `TestStartService_BinaryPathNotDoubleEncoded` as `SKIP` with a descriptive message, while `TestQuoteServicePath` passes.

## Out of scope

- Authenticode code signing for alpamon Windows builds (separate, pre-existing concern). Tracked separately.
- The alpacon-server side install-script regression (PowerShell 5.1 `Invoke-WebRequest.Content` byte[] issue). Tracked separately on the server side; both must ship for the end-to-end Windows install flow to be hands-off.
- Reporting the `mgr.CreateService` / `mgr.UpdateConfig` `EscapeArg` asymmetry upstream to `golang.org/x/sys`. Worth doing on a separate track but does not block this fix.
- Polishing the `register` CLI's "Failed to start service" warning to be more actionable. With this fix, the warning no longer fires on the bug-affected path. Genuine permission failures (non-elevated shell) already produce a useful hint via `elevationHint`.

## References

- Affected component: `cmd/alpamon/command/register/service_windows.go` — `startService`'s `m.CreateService` branch and the new helper.
- Library behavior: `mgr.CreateService` applying `syscall.EscapeArg` ([source](https://cs.opensource.google/go/x/sys/+/refs/tags/v0.30.0:windows/svc/mgr/mgr.go;l=121)); `Service.UpdateConfig` does not.
- Module pin: `go.mod` — `golang.org/x/sys v0.42.0`.
- Field signature for triage: SCM event id 7000 with `The Alpamon Agent service failed to start due to the following error: Access is denied.`, system event id 7045 `Service File Name` displayed as `"\"C:\...alpamon.exe\""`, symptom persists after adding Defender exclusions and verifying ACLs/AppLocker/CodeIntegrity are clean.
