### PR TITLE
ci(release): pin GORELEASER_CURRENT_TAG to github.ref_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           # (e.g. an RC tag that was cut first and a GA tag attached
           # to the same SHA after dev validation). The other steps in
           # this workflow already key off `github.ref_name` for the
-          # same reason — this aligns goreleaser with that convention.
+          # same reason: this aligns goreleaser with that convention.
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       # Fail-fast guard: if `.goreleaser.yaml` silently drops the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,15 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          # Pin the tag goreleaser treats as "current" to the tag that
+          # actually triggered this workflow. Without this, goreleaser
+          # falls back to `git describe --tags`, which picks the
+          # earliest-created tag when multiple tags share a commit
+          # (e.g. an RC tag that was cut first and a GA tag attached
+          # to the same SHA after dev validation). The other steps in
+          # this workflow already key off `github.ref_name` for the
+          # same reason — this aligns goreleaser with that convention.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       # Fail-fast guard: if `.goreleaser.yaml` silently drops the
       # stable-alias archive (e.g. a future config edit moves it under


### PR DESCRIPTION
Closes #295.

## Summary

Without an explicit current-tag override, goreleaser falls back to `git describe --tags`. When multiple tags point to the same commit — for example after an RC is validated on dev and a GA tag is attached to the same SHA — `git describe` picks the **earliest-created tag** (the RC), and goreleaser rebuilds assets under the RC name. Those uploads then collide with the existing RC release and the entire publish step fails with `422 already_exists` for every asset, leaving the GA release on GitHub as an empty shell.

This PR pins `GORELEASER_CURRENT_TAG` to `${{ github.ref_name }}` so goreleaser uses the exact tag that triggered the workflow regardless of how many tags share the underlying commit.

## Why this approach

The other steps in this same workflow already key off `github.ref_name` for the same reason:
- ${"{"}{"{"} channel detection at line 26-48
- stable-alias checksums upload at line 116
- Windows smoke-test release URL at line 217

Goreleaser was the one site that didn't, so it was the one that fell through to the `git describe` fallback. This change brings it in line with the rest of the workflow.

Alternatives considered (deleting the RC tag, putting RC and GA on different commits, hoping a goreleaser version bump changes behavior) all either lose validation traceability, require an empty marker commit at every release, or rely on undocumented behavior changes. None address the root cause.

## Evidence

Failing run: https://github.com/alpacax/alpamon/actions/runs/25161068177

Decisive log line:
\`\`\`
goreleaser  •  using tags     previous=v2.1.3   current=v2.1.4-rc.1
\`\`\`

The workflow was triggered by \`v2.1.4\` but goreleaser picked rc.1.

## Test plan

- [ ] CI green on this PR (build-and-test still passes; release.yml does not run on PR merges).
- [ ] After merge: re-tag v2.1.4 on a commit that includes this fix and push. Observe \`current=v2.1.4\` in the goreleaser log and assets named \`alpamon-2.1.4-*\` uploaded to a fresh \`v2.1.4\` release. \`gh release view v2.1.4 --json assets\` returns 13 assets.
- [ ] After merge, optional: cut a throwaway dry-run tag (e.g. \`v2.1.4-dry.1\`) on the same SHA before \`v2.1.4\` to validate end-to-end without committing to the real GA, then \`gh release delete v2.1.4-dry.1 --cleanup-tag\`.
- [ ] Standard scenario regression check: when a single tag is on a commit (the common case), \`github.ref_name\` matches what \`git describe\` would have returned, so behavior is unchanged.

## Out of scope

- Cleanup of the empty v2.1.4 release / misplaced v2.1.4 tag on \`8bbf81c8\` — release engineer handles after merge (\`gh release delete v2.1.4 --cleanup-tag\`).
- alpamon application code (\`cmd/alpamon\`, \`pkg/...\`); this is CI-only.
- Changes to \`.goreleaser.yaml\`; the workflow not passing the right tag was the cause, not goreleaser config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)