### PR TITLE
ci: bump action versions to Node 24 runtimes and reorder checkout/setup-go

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -113,16 +113,16 @@ jobs:
         if: matrix.pkg_manager == 'dnf'
         run: dnf install -y --allowerasing git curl gcc glibc-devel tar
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Mark workspace as safe for Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Generate go code
         run: go run -mod=mod entgo.io/ent/cmd/ent@${{ env.ENT_VERSION }} generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
@@ -138,13 +138,13 @@ jobs:
     name: Build and Test (windows-amd64)
     runs-on: windows-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Check out code
-        uses: actions/checkout@v4
 
       - name: Generate go code
         run: go run -mod=mod entgo.io/ent/cmd/ent@${{ env.ENT_VERSION }} generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
@@ -185,13 +185,13 @@ jobs:
     name: Build and Test (macos-arm64)
     runs-on: macos-14
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Check out code
-        uses: actions/checkout@v4
 
       - name: Generate go code
         run: go run -mod=mod entgo.io/ent/cmd/ent@${{ env.ENT_VERSION }} generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -113,11 +113,11 @@ jobs:
         if: matrix.pkg_manager == 'dnf'
         run: dnf install -y --allowerasing git curl gcc glibc-devel tar
 
-      - name: Check out code
-        uses: actions/checkout@v6
-
       - name: Mark workspace as safe for Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Check out code
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,8 @@ jobs:
       CGO_ENABLED: 0
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -34,7 +34,7 @@ jobs:
         run: go run -mod=mod entgo.io/ent/cmd/ent@${{ env.ENT_VERSION }} generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
 
       - name: GolangCI-Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
           args: --timeout=5m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,11 @@ jobs:
       CGO_ENABLED: 0
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           echo "tag=${TAG_WITHOUT_V}" >> $GITHUB_OUTPUT
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -56,12 +56,12 @@ jobs:
         run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest
@@ -129,25 +129,25 @@ jobs:
         run: echo "TAG_NAME=${{ steps.channel.outputs.tag }}" >> $GITHUB_ENV
 
       - name: Upload AMD64 DEB artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: alpamon_${{ env.TAG_NAME }}_linux_amd64.deb
           path: dist/alpamon_${{ env.TAG_NAME }}_linux_amd64.deb
 
       - name: Upload ARM64 DEB artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: alpamon_${{ env.TAG_NAME }}_linux_arm64.deb
           path: dist/alpamon_${{ env.TAG_NAME }}_linux_arm64.deb
 
       - name: Upload AMD64 RPM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: alpamon-${{ env.TAG_NAME }}-1.linux.amd64.rpm
           path: dist/alpamon-${{ env.TAG_NAME }}-1.linux.amd64.rpm
 
       - name: Upload ARM64 RPM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: alpamon-${{ env.TAG_NAME }}-1.linux.arm64.rpm
           path: dist/alpamon-${{ env.TAG_NAME }}-1.linux.arm64.rpm
@@ -179,7 +179,7 @@ jobs:
           fi
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.PKG_NAME }}
 
@@ -341,7 +341,7 @@ jobs:
           fi
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.PKG_NAME }}
 


### PR DESCRIPTION
## Summary

Resolves #266. Bumps every GitHub Action pinned to a Node.js 20 runtime to its latest Node 24 major, and fixes the `setup-go` cache-restore warning by reordering `checkout` before `setup-go`.

GitHub Actions runners force-upgrade Node.js 20 → 24 on **2026-06-02** and remove Node.js 20 entirely on **2026-09-16**. Without this change the workflows will break in June.

## Changes

### 1. Action version bumps

| Action | From | To | Files |
|---|---|---|---|
| `actions/checkout` | v4 | **v6** | all workflows |
| `actions/setup-go` | v5 | **v6** | all workflows |
| `actions/upload-artifact` | v4 | **v7** | `release.yml` (4 places) |
| `actions/download-artifact` | v4 | **v8** | `release.yml` (2 places) |
| `golangci/golangci-lint-action` | v7 | **v9** | `lint.yml` |
| `goreleaser/goreleaser-action` | v6 | **v7** | `release.yml` |

### 2. Cache-restore failure fix (`build-and-test.yml`)

Previously `setup-go` ran before `checkout`, so `go.sum` was missing when the cache restore was attempted, producing:

```
Dependencies file is not found in /_w/alpamon/alpamon. Supported file pattern: go.sum
```

Reordered `Check out code` to run before `Set up Go` in all three jobs (Linux container matrix, Windows, macOS). The container jobs already install `git` in the preceding dependency-install step, so `checkout` has `git` available when it runs first.

## Breaking-change review

Release notes for each action were checked. Nothing in this codebase's usage pattern is impacted:

| Change | Impact here |
|---|---|
| `checkout@v6`: credentials stored in `$RUNNER_TEMP` instead of git config | `release.yml`'s `git fetch --tags` is read-only public — no impact |
| `setup-go@v6`: improved toolchain handling | `go.mod` has no `toolchain` directive and `GO_VERSION` matches `go 1.25.7` — no impact |
| `upload-artifact@v7`: ESM migration | No user-facing change |
| `download-artifact@v8`: hash mismatch is now an error; Content-Type-based auto-decompression | Same-workflow v7 upload → v8 download chain — no mismatch in normal operation |
| `golangci-lint-action@v9`: requires `golangci-lint >= v2.1.0` | Currently pinned to `v2.9.0` — satisfied. `working-directory` is not used |
| `goreleaser-action@v7`: ESM migration | Inputs unchanged — no impact |

## Test plan

Workflow changes can only be validated by an actual CI run.

- [ ] All 17 `Build and Test` Linux container matrix entries pass
  - [ ] Pay special attention to **rocky-8 / rhel-8** — glibc 2.28 sits at the lower bound of Node 24's prebuilt-binary requirements
- [ ] `Build and Test (windows-amd64)` passes
- [ ] `Build and Test (macos-arm64)` passes
- [ ] `golangci-lint` passes
- [ ] CI Annotations tab shows Node.js 20 deprecation warnings and the `go.sum not found` cache warnings are gone
- [ ] `release.yml` will be exercised on the next tag — monitor that release run

Closes #266