### PR TITLE
fix(file): memory peak regression on download path (#199)

### DIFF
--- a/configs/alpamon.conf
+++ b/configs/alpamon.conf
@@ -31,3 +31,10 @@ debug = {{.Debug}}
 # Set to 0 to disable idle timeout
 # Default: 60
 # idle_timeout = 60
+
+[file]
+# Maximum download size in bytes for URL fetches
+# Caps payloads from malicious or misbehaving servers before they fill the disk
+# If not set or 0, no size limit is applied (unlimited)
+# Example: 10737418240 (10 GiB)
+# max_download_bytes = 0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -226,6 +226,14 @@ func validateConfig(config Config, wsPath string, controlWsPath string) (bool, S
 		log.Debug().Msgf("Using default editor idle timeout: %d minutes.", settings.EditorIdleTimeout)
 	}
 
+	// File download size cap. 0 (or unset) means unlimited.
+	if config.File.MaxDownloadBytes > 0 {
+		settings.MaxDownloadBytes = config.File.MaxDownloadBytes
+		log.Debug().Msgf("Using configured max download bytes: %d", settings.MaxDownloadBytes)
+	} else {
+		log.Debug().Msg("No download size limit configured (unlimited).")
+	}
+
 	// Validate pool settings are reasonable
 	if settings.PoolMaxWorkers > MaxReasonableWorkers {
 		log.Warn().Msgf("Pool max workers (%d) seems very high, consider reducing it", settings.PoolMaxWorkers)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -110,3 +110,21 @@ func TestEditorIdleTimeoutCustom(t *testing.T) {
 	}
 }
 
+func TestMaxDownloadBytesDefault(t *testing.T) {
+	config := Config{}
+	_, settings := validateConfig(config, "/ws/test/", "/ws/control/")
+
+	if settings.MaxDownloadBytes != 0 {
+		t.Errorf("Expected default MaxDownloadBytes to be 0 (unlimited), got %d", settings.MaxDownloadBytes)
+	}
+}
+
+func TestMaxDownloadBytesConfigured(t *testing.T) {
+	config := Config{}
+	config.File.MaxDownloadBytes = 1024 * 1024 * 100 // 100 MiB
+	_, settings := validateConfig(config, "/ws/test/", "/ws/control/")
+
+	if settings.MaxDownloadBytes != 1024*1024*100 {
+		t.Errorf("Expected MaxDownloadBytes to be %d, got %d", 1024*1024*100, settings.MaxDownloadBytes)
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -11,10 +11,11 @@ type Settings struct {
 	HTTPThreads        int
 	ID                 string
 	Key                string
-	PoolMaxWorkers     int // Maximum number of workers in the global worker pool
-	PoolQueueSize      int // Size of the job queue for the global worker pool
-	PoolDefaultTimeout int // Default timeout in seconds for pool tasks (0 = no timeout)
-	EditorIdleTimeout  int // Editor idle timeout in minutes (0 = no timeout)
+	PoolMaxWorkers     int   // Maximum number of workers in the global worker pool
+	PoolQueueSize      int   // Size of the job queue for the global worker pool
+	PoolDefaultTimeout int   // Default timeout in seconds for pool tasks (0 = no timeout)
+	EditorIdleTimeout  int   // Editor idle timeout in minutes (0 = no timeout)
+	MaxDownloadBytes   int64 // Cap for URL download payloads in bytes (0 = unlimited)
 
 	// Command signature verification (hardcoded, not configurable via INI)
 	AIServerURL    string // AI server URL for public key fetch
@@ -43,4 +44,7 @@ type Config struct {
 	Editor struct {
 		IdleTimeout *int `ini:"idle_timeout"`
 	} `ini:"editor"`
+	File struct {
+		MaxDownloadBytes int64 `ini:"max_download_bytes"`
+	} `ini:"file"`
 }

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -399,8 +399,6 @@ func (h *FileHandler) fileUpload(args *common.CommandArgs, src io.ReadCloser, si
 }
 
 // getFileData returns a streaming reader for the file content. Caller owns Close.
-// text/base64 wrap in-memory data via NopCloser; url returns the live HTTP body
-// so payloads never accumulate in []byte.
 func (h *FileHandler) getFileData(ctx context.Context, args *common.CommandArgs) (io.ReadCloser, error) {
 	switch args.Type {
 	case "url":
@@ -414,8 +412,7 @@ func (h *FileHandler) getFileData(ctx context.Context, args *common.CommandArgs)
 	}
 }
 
-// fetchFromURL streams the response body to the caller. The returned ReadCloser
-// is the live resp.Body — caller must Close to release the connection.
+// fetchFromURL returns the response body. Caller must Close to release the connection.
 func (h *FileHandler) fetchFromURL(ctx context.Context, contentURL string) (io.ReadCloser, error) {
 	parsedRequestURL, err := url.Parse(contentURL)
 	if err != nil {

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -251,12 +251,16 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 		return 1, "You do not have permission to write to the directory, or directory does not exist"
 	}
 
-	if args.AllowUnzip && utils.IsZipFileFromPath(args.Path, filepath.Ext(args.Path)) {
-		if err := utils.Unzip(args.Path, filepath.Dir(args.Path)); err != nil {
-			log.Error().Err(err).Msg("Failed to unzip file.")
-			return 1, err.Error()
+	if args.AllowUnzip {
+		if rc := utils.OpenIfZip(args.Path, filepath.Ext(args.Path)); rc != nil {
+			err := utils.UnzipReader(rc, filepath.Dir(args.Path))
+			_ = rc.Close()
+			if err != nil {
+				log.Error().Err(err).Msg("Failed to unzip file.")
+				return 1, err.Error()
+			}
+			_ = os.Remove(args.Path)
 		}
-		_ = os.Remove(args.Path)
 	}
 
 	return 0, fmt.Sprintf("Successfully downloaded %s.", args.Path)

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -221,10 +221,11 @@ func (h *FileHandler) handleDownload(ctx context.Context, args *common.CommandAr
 
 // fileDownload handles single file download
 func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs, sysProcAttr *syscall.SysProcAttr, homeDirectory string) (int, string) {
-	content, err := h.getFileData(args)
+	src, err := h.getFileData(ctx, args)
 	if err != nil {
 		return 1, err.Error()
 	}
+	defer func() { _ = src.Close() }()
 
 	// Paths arrive in wire format from the web client.
 	downloadPath, err := utils.SanitizePath(utils.FromWirePath(args.Path))
@@ -245,13 +246,12 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 	}
 
 	// Write file, preserving privilege demotion on Unix when available.
-	if err := writeFileAs(ctx, args.Path, content, sysProcAttr); err != nil {
+	if err := writeFileAs(ctx, args.Path, src, sysProcAttr); err != nil {
 		log.Error().Err(err).Msg("Failed to write file.")
 		return 1, "You do not have permission to write to the directory, or directory does not exist"
 	}
 
-	isZip := utils.IsZipFile(content, filepath.Ext(args.Path))
-	if isZip && args.AllowUnzip {
+	if args.AllowUnzip && utils.IsZipFileFromPath(args.Path, filepath.Ext(args.Path)) {
 		if err := utils.Unzip(args.Path, filepath.Dir(args.Path)); err != nil {
 			log.Error().Err(err).Msg("Failed to unzip file.")
 			return 1, err.Error()
@@ -398,32 +398,31 @@ func (h *FileHandler) fileUpload(args *common.CommandArgs, src io.ReadCloser, si
 	return code, err
 }
 
-// getFileData fetches file content from URL, text, or base64
-func (h *FileHandler) getFileData(args *common.CommandArgs) ([]byte, error) {
+// getFileData returns a streaming reader for the file content. Caller owns Close.
+// text/base64 wrap in-memory data via NopCloser; url returns the live HTTP body
+// so payloads never accumulate in []byte.
+func (h *FileHandler) getFileData(ctx context.Context, args *common.CommandArgs) (io.ReadCloser, error) {
 	switch args.Type {
 	case "url":
-		return h.fetchFromURL(args.Content)
+		return h.fetchFromURL(ctx, args.Content)
 	case "text":
-		return []byte(args.Content), nil
+		return io.NopCloser(strings.NewReader(args.Content)), nil
 	case "base64":
-		content, err := base64.StdEncoding.DecodeString(args.Content)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode base64 content: %w", err)
-		}
-		return content, nil
+		return io.NopCloser(base64.NewDecoder(base64.StdEncoding, strings.NewReader(args.Content))), nil
 	default:
 		return nil, fmt.Errorf("unknown file type: %s", args.Type)
 	}
 }
 
-// fetchFromURL downloads content from a URL
-func (h *FileHandler) fetchFromURL(contentURL string) ([]byte, error) {
+// fetchFromURL streams the response body to the caller. The returned ReadCloser
+// is the live resp.Body — caller must Close to release the connection.
+func (h *FileHandler) fetchFromURL(ctx context.Context, contentURL string) (io.ReadCloser, error) {
 	parsedRequestURL, err := url.Parse(contentURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL '%s': %w", contentURL, err)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, parsedRequestURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedRequestURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -444,19 +443,14 @@ func (h *FileHandler) fetchFromURL(contentURL string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to download content from URL: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode/100 != 2 {
+		_ = resp.Body.Close()
 		log.Error().Msgf("Failed to download content from URL: %d %s", resp.StatusCode, parsedRequestURL)
 		return nil, errors.New("downloading content failed")
 	}
 
-	content, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	return content, nil
+	return resp.Body, nil
 }
 
 // statFileTransfer reports the file transfer status

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -30,6 +30,14 @@ type FileHandler struct {
 	apiSession common.APISession
 }
 
+// limitedReadCloser wraps an io.ReadCloser and returns an error when the byte
+// limit is exceeded, avoiding the nil-ResponseWriter panic of http.MaxBytesReader.
+type limitedReadCloser struct {
+	rc    io.ReadCloser
+	limit int64
+	read  int64
+}
+
 // NewFileHandler creates a new file handler
 func NewFileHandler(cmdExecutor common.CommandExecutor, apiSession common.APISession) *FileHandler {
 	h := &FileHandler{
@@ -458,8 +466,8 @@ func (h *FileHandler) fetchFromURL(ctx context.Context, contentURL string) (io.R
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf("download too large: %d bytes (max %d)", resp.ContentLength, limit)
 		}
-		// MaxBytesReader catches servers that lie in Content-Length or use chunked encoding.
-		return http.MaxBytesReader(nil, resp.Body, limit), nil
+		// limitedReadCloser catches servers that lie in Content-Length or use chunked encoding.
+		return &limitedReadCloser{rc: resp.Body, limit: limit}, nil
 	}
 
 	return resp.Body, nil
@@ -481,4 +489,18 @@ func (h *FileHandler) statFileTransfer(code int, transferType transferType, mess
 		Type:    transferType,
 	}
 	scheduler.Rqueue.Post(statURL, payload, 10, time.Time{})
+}
+
+func (l *limitedReadCloser) Read(p []byte) (int, error) {
+	n, err := l.rc.Read(p)
+	l.read += int64(n)
+	if l.read > l.limit {
+		_ = l.rc.Close()
+		return n, fmt.Errorf("download too large: exceeds max %d bytes", l.limit)
+	}
+	return n, err
+}
+
+func (l *limitedReadCloser) Close() error {
+	return l.rc.Close()
 }

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -256,7 +256,10 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 	// Write file, preserving privilege demotion on Unix when available.
 	if err := writeFileAs(ctx, args.Path, src, sysProcAttr); err != nil {
 		log.Error().Err(err).Msg("Failed to write file.")
-		return 1, "You do not have permission to write to the directory, or directory does not exist"
+		if os.IsPermission(err) || errors.Is(err, syscall.EACCES) {
+			return 1, "You do not have permission to write to the directory, or directory does not exist"
+		}
+		return 1, err.Error()
 	}
 
 	if args.AllowUnzip {

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -451,6 +451,16 @@ func (h *FileHandler) fetchFromURL(ctx context.Context, contentURL string) (io.R
 		return nil, errors.New("downloading content failed")
 	}
 
+	// Apply size cap only when configured (0 = unlimited).
+	if limit := config.GlobalSettings.MaxDownloadBytes; limit > 0 {
+		if resp.ContentLength > limit {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("download too large: %d bytes (max %d)", resp.ContentLength, limit)
+		}
+		// MaxBytesReader catches servers that lie in Content-Length or use chunked encoding.
+		return http.MaxBytesReader(nil, resp.Body, limit), nil
+	}
+
 	return resp.Body, nil
 }
 

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -270,7 +270,8 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 				log.Error().Err(err).Msg("Failed to unzip file.")
 				return 1, err.Error()
 			}
-			// lgtm[go/path-injection]: args.Path sanitized above via SanitizePath + ResolveAndEnsureUnderHome
+			// lgtm[go/path-injection]: args.Path sanitized via SanitizePath; Windows additionally
+			// enforces ResolveAndEnsureUnderHome. Wire input is admin-authenticated.
 			_ = os.Remove(args.Path) // lgtm[go/path-injection]
 		}
 	}

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -259,7 +259,8 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 				log.Error().Err(err).Msg("Failed to unzip file.")
 				return 1, err.Error()
 			}
-			_ = os.Remove(args.Path)
+			// lgtm[go/path-injection]: args.Path sanitized above via SanitizePath + ResolveAndEnsureUnderHome
+			_ = os.Remove(args.Path) // lgtm[go/path-injection]
 		}
 	}
 

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -30,6 +30,19 @@ type FileHandler struct {
 	apiSession common.APISession
 }
 
+// base64Reader wraps a base64 decoder and re-tags decode errors for clearer diagnostics.
+type base64Reader struct {
+	r io.Reader
+}
+
+func (b *base64Reader) Read(p []byte) (int, error) {
+	n, err := b.r.Read(p)
+	if err != nil && err != io.EOF {
+		return n, fmt.Errorf("failed to decode base64 content: %w", err)
+	}
+	return n, err
+}
+
 // limitedReadCloser wraps an io.ReadCloser and returns an error when the byte
 // limit is exceeded, avoiding the nil-ResponseWriter panic of http.MaxBytesReader.
 // r is wrapped with io.LimitReader(rc, limit+1) so the overshoot is at most 1 byte.
@@ -425,7 +438,7 @@ func (h *FileHandler) getFileData(ctx context.Context, args *common.CommandArgs)
 	case "text":
 		return io.NopCloser(strings.NewReader(args.Content)), nil
 	case "base64":
-		return io.NopCloser(base64.NewDecoder(base64.StdEncoding, strings.NewReader(args.Content))), nil
+		return io.NopCloser(&base64Reader{r: base64.NewDecoder(base64.StdEncoding, strings.NewReader(args.Content))}), nil
 	default:
 		return nil, fmt.Errorf("unknown file type: %s", args.Type)
 	}

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -32,7 +32,9 @@ type FileHandler struct {
 
 // limitedReadCloser wraps an io.ReadCloser and returns an error when the byte
 // limit is exceeded, avoiding the nil-ResponseWriter panic of http.MaxBytesReader.
+// r is wrapped with io.LimitReader(rc, limit+1) so the overshoot is at most 1 byte.
 type limitedReadCloser struct {
+	r     io.Reader
 	rc    io.ReadCloser
 	limit int64
 	read  int64
@@ -471,7 +473,7 @@ func (h *FileHandler) fetchFromURL(ctx context.Context, contentURL string) (io.R
 			return nil, fmt.Errorf("download too large: %d bytes (max %d)", resp.ContentLength, limit)
 		}
 		// limitedReadCloser catches servers that lie in Content-Length or use chunked encoding.
-		return &limitedReadCloser{rc: resp.Body, limit: limit}, nil
+		return &limitedReadCloser{r: io.LimitReader(resp.Body, limit+1), rc: resp.Body, limit: limit}, nil
 	}
 
 	return resp.Body, nil
@@ -496,7 +498,7 @@ func (h *FileHandler) statFileTransfer(code int, transferType transferType, mess
 }
 
 func (l *limitedReadCloser) Read(p []byte) (int, error) {
-	n, err := l.rc.Read(p)
+	n, err := l.r.Read(p)
 	l.read += int64(n)
 	if l.read > l.limit {
 		_ = l.rc.Close()

--- a/pkg/executor/handlers/file/file_benchmark_test.go
+++ b/pkg/executor/handlers/file/file_benchmark_test.go
@@ -155,12 +155,17 @@ func BenchmarkDownload_FetchFromURL(b *testing.B) {
 			runtime.ReadMemStats(&ms0)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				content, err := h.fetchFromURL(srv.URL)
+				body, err := h.fetchFromURL(context.Background(), srv.URL)
 				if err != nil {
 					b.Fatal(err)
 				}
-				if len(content) != size {
-					b.Fatalf("size mismatch: got %d, want %d", len(content), size)
+				n, err := io.Copy(io.Discard, body)
+				_ = body.Close()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if n != int64(size) {
+					b.Fatalf("size mismatch: got %d, want %d", n, size)
 				}
 			}
 			b.StopTimer()
@@ -185,11 +190,13 @@ func BenchmarkDownload_E2E(b *testing.B) {
 			runtime.ReadMemStats(&ms0)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				content, err := h.fetchFromURL(srv.URL)
+				body, err := h.fetchFromURL(context.Background(), srv.URL)
 				if err != nil {
 					b.Fatal(err)
 				}
-				if err := writeFileAs(context.Background(), outPath, content, nil); err != nil {
+				err = writeFileAs(context.Background(), outPath, body, nil)
+				_ = body.Close()
+				if err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/pkg/executor/handlers/file/file_benchmark_test.go
+++ b/pkg/executor/handlers/file/file_benchmark_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 )
 
@@ -75,6 +76,31 @@ func newSinkServer(b *testing.B) *httptest.Server {
 	return srv
 }
 
+// newSourceServer serves `size` bytes per request — used as the download source.
+// A 4 MiB random block is cycled to avoid /dev/urandom cost on GB sizes.
+func newSourceServer(b *testing.B, size int) *httptest.Server {
+	b.Helper()
+	const blockSize = 4 << 20
+	block := make([]byte, blockSize)
+	if _, err := io.ReadFull(rand.Reader, block); err != nil {
+		b.Fatalf("ReadFull: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(size))
+		w.WriteHeader(http.StatusOK)
+		remaining := size
+		for remaining > 0 {
+			n := min(remaining, len(block))
+			if _, err := w.Write(block[:n]); err != nil {
+				return
+			}
+			remaining -= n
+		}
+	}))
+	b.Cleanup(srv.Close)
+	return srv
+}
+
 // reportGC records GC count and pause delta as bench-only metrics.
 func reportGC(b *testing.B, before, after runtime.MemStats) {
 	b.Helper()
@@ -107,6 +133,65 @@ func BenchmarkUpload_MultipartBody(b *testing.B) {
 					b.Fatal(err)
 				}
 				_ = body.Close()
+			}
+			b.StopTimer()
+			runtime.ReadMemStats(&ms1)
+			reportGC(b, ms0, ms1)
+		})
+	}
+}
+
+// BenchmarkDownload_FetchFromURL measures the URL fetch in isolation.
+func BenchmarkDownload_FetchFromURL(b *testing.B) {
+	h := &FileHandler{}
+	for _, size := range benchSizes {
+		b.Run(sizeLabel(size), func(b *testing.B) {
+			skipIfLargeShort(b, size)
+			srv := newSourceServer(b, size)
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			var ms0, ms1 runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&ms0)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				content, err := h.fetchFromURL(srv.URL)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(content) != size {
+					b.Fatalf("size mismatch: got %d, want %d", len(content), size)
+				}
+			}
+			b.StopTimer()
+			runtime.ReadMemStats(&ms1)
+			reportGC(b, ms0, ms1)
+		})
+	}
+}
+
+// BenchmarkDownload_E2E exercises the full download pipeline against a loopback HTTP source.
+func BenchmarkDownload_E2E(b *testing.B) {
+	h := &FileHandler{}
+	for _, size := range benchSizes {
+		b.Run(sizeLabel(size), func(b *testing.B) {
+			skipIfLargeShort(b, size)
+			srv := newSourceServer(b, size)
+			outPath := filepath.Join(b.TempDir(), "out.bin")
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			var ms0, ms1 runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&ms0)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				content, err := h.fetchFromURL(srv.URL)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := writeFileAs(context.Background(), outPath, content, nil); err != nil {
+					b.Fatal(err)
+				}
 			}
 			b.StopTimer()
 			runtime.ReadMemStats(&ms1)

--- a/pkg/executor/handlers/file/file_io_test.go
+++ b/pkg/executor/handlers/file/file_io_test.go
@@ -1,0 +1,77 @@
+package file
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// failingReader emits payload on first Read, then returns err on the next call.
+// io.Copy writes the first chunk, so the partial file exists when err surfaces.
+type failingReader struct {
+	payload []byte
+	served  bool
+	err     error
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if !r.served {
+		n := copy(p, r.payload)
+		r.served = true
+		return n, nil
+	}
+	return 0, r.err
+}
+
+// TestWriteFileAs_DirectPath_Success covers the happy path on both Unix and Windows.
+func TestWriteFileAs_DirectPath_Success(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.bin")
+	payload := []byte("hello world")
+
+	if err := writeFileAs(context.Background(), path, bytes.NewReader(payload), nil); err != nil {
+		t.Fatalf("writeFileAs: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("content mismatch: got %q want %q", got, payload)
+	}
+}
+
+// TestWriteFileAs_DirectPath_RemovesPartialOnReadError verifies the cleanup branch:
+// once src errors mid-stream, the partial file must be removed so a retry
+// isn't blocked by AllowOverwrite=false.
+func TestWriteFileAs_DirectPath_RemovesPartialOnReadError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.bin")
+	src := &failingReader{
+		payload: bytes.Repeat([]byte("x"), 4096),
+		err:     errors.New("simulated stream failure"),
+	}
+
+	err := writeFileAs(context.Background(), path, src, nil)
+	if err == nil {
+		t.Fatal("expected writeFileAs to return error")
+	}
+
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("expected partial file removed, stat err = %v", statErr)
+	}
+}
+
+// TestWriteFileAs_DirectPath_CreatesParentDir verifies MkdirAll runs before OpenFile.
+func TestWriteFileAs_DirectPath_CreatesParentDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "deep", "out.bin")
+
+	if err := writeFileAs(context.Background(), path, bytes.NewReader([]byte("ok")), nil); err != nil {
+		t.Fatalf("writeFileAs: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s, got %v", path, err)
+	}
+}

--- a/pkg/executor/handlers/file/file_io_test.go
+++ b/pkg/executor/handlers/file/file_io_test.go
@@ -4,9 +4,16 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/alpacax/alpamon/pkg/config"
+	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
 )
 
 // failingReader emits payload on first Read, then returns err on the next call.
@@ -73,5 +80,99 @@ func TestWriteFileAs_DirectPath_CreatesParentDir(t *testing.T) {
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected file at %s, got %v", path, err)
+	}
+}
+
+// closeSpy wraps a Reader and records whether Close was called.
+type closeSpy struct {
+	io.Reader
+	closed bool
+}
+
+func (c *closeSpy) Close() error {
+	c.closed = true
+	return nil
+}
+
+func newLimitedRC(data []byte, limit int64) (*limitedReadCloser, *closeSpy) {
+	spy := &closeSpy{Reader: bytes.NewReader(data)}
+	return &limitedReadCloser{r: io.LimitReader(spy, limit+1), rc: spy, limit: limit}, spy
+}
+
+// TestLimitedReadCloser_UnderLimit verifies all bytes are delivered and Close is not called.
+func TestLimitedReadCloser_UnderLimit(t *testing.T) {
+	data := []byte("hello")
+	lr, spy := newLimitedRC(data, 10)
+
+	buf := make([]byte, 32)
+	n, err := lr.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("got %d bytes, want %d", n, len(data))
+	}
+	if spy.closed {
+		t.Fatal("Close must not be called under limit")
+	}
+}
+
+// TestLimitedReadCloser_OverLimit verifies an error is returned and Close is called.
+func TestLimitedReadCloser_OverLimit(t *testing.T) {
+	limit := int64(5)
+	lr, spy := newLimitedRC(bytes.Repeat([]byte("x"), 20), limit)
+
+	_, err := lr.Read(make([]byte, 32))
+	if err == nil {
+		t.Fatal("expected error for over-limit read")
+	}
+	if !strings.Contains(err.Error(), "download too large") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+	if !spy.closed {
+		t.Fatal("Close must be called on over-limit")
+	}
+}
+
+// TestLimitedReadCloser_OvershootAtMostOneByte verifies that io.LimitReader(rc, limit+1)
+// caps the total bytes delivered to at most limit+1.
+func TestLimitedReadCloser_OvershootAtMostOneByte(t *testing.T) {
+	limit := int64(10)
+	lr, _ := newLimitedRC(bytes.Repeat([]byte("x"), 20), limit)
+
+	var total int
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := lr.Read(buf)
+		total += n
+		if err != nil {
+			break
+		}
+	}
+	if int64(total) > limit+1 {
+		t.Fatalf("overshoot: read %d bytes, limit=%d (max limit+1=%d)", total, limit, limit+1)
+	}
+}
+
+// TestFetchFromURL_ContentLengthExceedsLimit verifies the upfront Content-Length check.
+func TestFetchFromURL_ContentLengthExceedsLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1000")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	orig := config.GlobalSettings.MaxDownloadBytes
+	config.GlobalSettings.MaxDownloadBytes = 100
+	defer func() { config.GlobalSettings.MaxDownloadBytes = orig }()
+
+	h := NewFileHandler(common.NewMockCommandExecutor(t), nil)
+	rc, err := h.fetchFromURL(context.Background(), srv.URL)
+	if err == nil {
+		_ = rc.Close()
+		t.Fatal("expected error when Content-Length exceeds limit")
+	}
+	if !strings.Contains(err.Error(), "download too large") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -59,6 +59,9 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 		if cerr := f.Close(); err == nil {
 			err = cerr
 		}
+		if err != nil {
+			_ = os.Remove(path) // drop partial write so retry isn't blocked by AllowOverwrite=false
+		}
 		return err
 	}
 	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("tee %s > /dev/null", utils.Quote(path)))
@@ -69,6 +72,7 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	errW := &stderrCap{cap: stderrCapSize}
 	cmd.Stderr = errW
 	if err := cmd.Run(); err != nil {
+		_ = os.Remove(path) // drop partial write
 		if msg := strings.TrimSpace(errW.buf.String()); msg != "" {
 			return fmt.Errorf("%w: %s", err, msg)
 		}

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -3,7 +3,6 @@
 package file
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -42,17 +41,27 @@ func readFileAs(ctx context.Context, path string, sysProcAttr *syscall.SysProcAt
 	return rc, st.Size(), nil
 }
 
-// writeFileAs writes a file, using a demoted tee process when privilege demotion is active.
-func writeFileAs(ctx context.Context, path string, content []byte, sysProcAttr *syscall.SysProcAttr) error {
+// writeFileAs streams src into a file, using a demoted tee process when privilege
+// demotion is active. The caller retains ownership of src; writeFileAs does not
+// close it. cmd.Run() is synchronous, so by the time this returns, os/exec's
+// internal stdin-copy goroutine has already finished consuming src.
+func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *syscall.SysProcAttr) error {
 	if sysProcAttr == nil {
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err
 		}
-		return os.WriteFile(path, content, 0644)
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(f, src)
+		if cerr := f.Close(); err == nil {
+			err = cerr
+		}
+		return err
 	}
 	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("tee %s > /dev/null", utils.Quote(path)))
 	cmd.SysProcAttr = sysProcAttr
-	cmd.Stdin = bytes.NewReader(content)
-	_, err := cmd.Output()
-	return err
+	cmd.Stdin = src
+	return cmd.Run()
 }

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -88,7 +88,9 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	runErr := cmd.Run()
 
 	if runErr != nil || erc.err != nil {
-		_ = os.Remove(path) // lgtm[go/path-injection] drop partial write
+		// lgtm[go/path-injection]: path sanitized via SanitizePath; Windows additionally
+		// enforces ResolveAndEnsureUnderHome. Wire input is admin-authenticated.
+		_ = os.Remove(path) // lgtm[go/path-injection]
 		if runErr != nil {
 			var details []string
 			if msg := strings.TrimSpace(errW.buf.String()); msg != "" {

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -42,10 +42,7 @@ func readFileAs(ctx context.Context, path string, sysProcAttr *syscall.SysProcAt
 	return rc, st.Size(), nil
 }
 
-// writeFileAs streams src into a file, using a demoted tee process when privilege
-// demotion is active. The caller retains ownership of src; writeFileAs does not
-// close it. cmd.Run() is synchronous, so by the time this returns, os/exec's
-// internal stdin-copy goroutine has already finished consuming src.
+// writeFileAs streams src to a file, demoting via tee when sysProcAttr is set. Caller owns src.
 func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *syscall.SysProcAttr) error {
 	if sysProcAttr == nil {
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
@@ -67,8 +64,7 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("tee %s > /dev/null", utils.Quote(path)))
 	cmd.SysProcAttr = sysProcAttr
 	cmd.Stdin = src
-	// Capture tee stderr so non-zero exits surface a diagnostic message
-	// (Permission denied, ENOSPC, ...) instead of a bare "exit status 1".
+	// capture tee stderr so failures surface a real message, not "exit status 1"
 	errW := &stderrCap{cap: stderrCapSize}
 	cmd.Stderr = errW
 	if err := cmd.Run(); err != nil {

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -15,6 +15,20 @@ import (
 	"github.com/alpacax/alpamon/pkg/utils"
 )
 
+// errCapReader records the last non-EOF read error so it survives broken-pipe overwrites.
+type errCapReader struct {
+	r   io.Reader
+	err error
+}
+
+func (e *errCapReader) Read(p []byte) (int, error) {
+	n, err := e.r.Read(p)
+	if err != nil && err != io.EOF {
+		e.err = err
+	}
+	return n, err
+}
+
 // readFileAs reads a file, using a demoted cat process when privilege demotion is active.
 func readFileAs(ctx context.Context, path string, sysProcAttr *syscall.SysProcAttr) (io.ReadCloser, int64, error) {
 	if sysProcAttr == nil {
@@ -64,16 +78,31 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	}
 	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("tee %s > /dev/null", utils.Quote(path)))
 	cmd.SysProcAttr = sysProcAttr
-	cmd.Stdin = src
+	// Wrap src to preserve its read error even if a subsequent broken-pipe write
+	// overwrites it before cmd.Wait collects the goroutine result.
+	erc := &errCapReader{r: src}
+	cmd.Stdin = erc
 	// capture tee stderr so failures surface a real message, not "exit status 1"
 	errW := &stderrCap{cap: stderrCapSize}
 	cmd.Stderr = errW
-	if err := cmd.Run(); err != nil {
+	runErr := cmd.Run()
+
+	if runErr != nil || erc.err != nil {
 		_ = os.Remove(path) // lgtm[go/path-injection] drop partial write
-		if msg := strings.TrimSpace(errW.buf.String()); msg != "" {
-			return fmt.Errorf("%w: %s", err, msg)
+		if runErr != nil {
+			var details []string
+			if msg := strings.TrimSpace(errW.buf.String()); msg != "" {
+				details = append(details, msg)
+			}
+			if erc.err != nil && erc.err != runErr {
+				details = append(details, erc.err.Error())
+			}
+			if len(details) > 0 {
+				return fmt.Errorf("%w: %s", runErr, strings.Join(details, "; "))
+			}
+			return runErr
 		}
-		return err
+		return fmt.Errorf("failed to read source: %w", erc.err)
 	}
 	return nil
 }

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -43,12 +43,13 @@ func readFileAs(ctx context.Context, path string, sysProcAttr *syscall.SysProcAt
 }
 
 // writeFileAs streams src to a file, demoting via tee when sysProcAttr is set. Caller owns src.
+// path is sanitized by callers via utils.SanitizePath + (Windows) ResolveAndEnsureUnderHome.
 func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *syscall.SysProcAttr) error {
 	if sysProcAttr == nil {
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err
 		}
-		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // lgtm[go/path-injection]
 		if err != nil {
 			return err
 		}
@@ -57,7 +58,7 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 			err = cerr
 		}
 		if err != nil {
-			_ = os.Remove(path) // drop partial write so retry isn't blocked by AllowOverwrite=false
+			_ = os.Remove(path) // lgtm[go/path-injection] drop partial write so retry isn't blocked by AllowOverwrite=false
 		}
 		return err
 	}
@@ -68,7 +69,7 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	errW := &stderrCap{cap: stderrCapSize}
 	cmd.Stderr = errW
 	if err := cmd.Run(); err != nil {
-		_ = os.Remove(path) // drop partial write
+		_ = os.Remove(path) // lgtm[go/path-injection] drop partial write
 		if msg := strings.TrimSpace(errW.buf.String()); msg != "" {
 			return fmt.Errorf("%w: %s", err, msg)
 		}

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/alpacax/alpamon/pkg/utils"
@@ -63,5 +64,15 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("tee %s > /dev/null", utils.Quote(path)))
 	cmd.SysProcAttr = sysProcAttr
 	cmd.Stdin = src
-	return cmd.Run()
+	// Capture tee stderr so non-zero exits surface a diagnostic message
+	// (Permission denied, ENOSPC, ...) instead of a bare "exit status 1".
+	errW := &stderrCap{cap: stderrCapSize}
+	cmd.Stderr = errW
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(errW.buf.String()); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
 }

--- a/pkg/executor/handlers/file/file_io_windows.go
+++ b/pkg/executor/handlers/file/file_io_windows.go
@@ -35,5 +35,8 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	if cerr := f.Close(); err == nil {
 		err = cerr
 	}
+	if err != nil {
+		_ = os.Remove(path) // drop partial write so retry isn't blocked by AllowOverwrite=false
+	}
 	return err
 }

--- a/pkg/executor/handlers/file/file_io_windows.go
+++ b/pkg/executor/handlers/file/file_io_windows.go
@@ -22,10 +22,18 @@ func readFileAs(ctx context.Context, path string, sysProcAttr *syscall.SysProcAt
 	return f, st.Size(), nil
 }
 
-// writeFileAs writes a file directly on Windows (no privilege demotion available).
-func writeFileAs(ctx context.Context, path string, content []byte, sysProcAttr *syscall.SysProcAttr) error {
+// writeFileAs streams src into a file directly on Windows (no privilege demotion available).
+func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *syscall.SysProcAttr) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	return os.WriteFile(path, content, 0644)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(f, src)
+	if cerr := f.Close(); err == nil {
+		err = cerr
+	}
+	return err
 }

--- a/pkg/executor/handlers/file/file_test.go
+++ b/pkg/executor/handlers/file/file_test.go
@@ -164,49 +164,6 @@ func TestFileHandler_Execute_DownloadUnknownType(t *testing.T) {
 	}
 }
 
-func TestIsZipFile(t *testing.T) {
-	tests := []struct {
-		name    string
-		content []byte
-		ext     string
-		want    bool
-	}{
-		{
-			name:    "jar file extension",
-			content: []byte("PK\x03\x04"), // zip magic bytes
-			ext:     ".jar",
-			want:    false, // Should be excluded
-		},
-		{
-			name:    "war file extension",
-			content: []byte("PK\x03\x04"),
-			ext:     ".war",
-			want:    false, // Should be excluded
-		},
-		{
-			name:    "regular zip content",
-			content: []byte("PK\x03\x04"),
-			ext:     ".zip",
-			want:    false, // Invalid zip (too short)
-		},
-		{
-			name:    "non-zip content",
-			content: []byte("hello world"),
-			ext:     ".txt",
-			want:    false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := utils.IsZipFile(tt.content, tt.ext)
-			if got != tt.want {
-				t.Errorf("IsZipFile() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestFileExists(t *testing.T) {
 	// Test with non-existent file
 	if utils.FileExists("/nonexistent/path/file.txt") {
@@ -276,18 +233,3 @@ func TestFileHandler_parsePaths(t *testing.T) {
 	}
 }
 
-func TestNonZipExtensions(t *testing.T) {
-	// Test that zip-like extensions are excluded from IsZipFile
-	zipContent := []byte("PK\x03\x04") // zip magic bytes (but invalid/short)
-	excludedExtensions := []string{
-		".jar", ".war", ".ear", ".apk", ".xpi",
-		".vsix", ".crx", ".egg", ".whl", ".appx",
-		".msix", ".ipk", ".nupkg", ".kmz",
-	}
-
-	for _, ext := range excludedExtensions {
-		if utils.IsZipFile(zipContent, ext) {
-			t.Errorf("Expected extension %s to be excluded from IsZipFile", ext)
-		}
-	}
-}

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -85,7 +85,12 @@ func Unzip(src, destDir string) error {
 		return fmt.Errorf("failed to open zip: %w", err)
 	}
 	defer func() { _ = r.Close() }()
+	return UnzipReader(r, destDir)
+}
 
+// UnzipReader extracts an already-opened zip into destDir. Caller owns r.
+// Used when the caller has pre-validated the same handle to close TOCTOU windows.
+func UnzipReader(r *zip.ReadCloser, destDir string) error {
 	for _, f := range r.File {
 		fpath := filepath.Join(destDir, f.Name)
 

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -261,8 +261,7 @@ func IsZipFile(content []byte, ext string) bool {
 	return err == nil
 }
 
-// IsZipFileFromPath checks if the file at path is a valid zip file. Used by
-// streaming download paths that never hold full content in memory.
+// IsZipFileFromPath checks if the file at path is a valid zip file.
 func IsZipFileFromPath(path, ext string) bool {
 	if _, found := nonZipExt[ext]; found {
 		return false

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -250,10 +250,10 @@ func FileExists(path string) bool {
 	return !os.IsNotExist(err)
 }
 
-// OpenIfZip returns a zip handle if path is a valid zip with allow-listed ext, else nil.
+// OpenIfZip returns a zip handle if path is a valid zip and ext is not in the denylist, else nil.
 // Caller must Close. Reusing this handle for extraction closes the TOCTOU window.
 func OpenIfZip(path, ext string) *zip.ReadCloser {
-	if _, found := nonZipExt[ext]; found {
+	if _, found := nonZipExt[strings.ToLower(ext)]; found {
 		return nil
 	}
 	rc, err := zip.OpenReader(path)

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"archive/zip"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -249,16 +248,6 @@ func FileExists(path string) bool {
 	}
 	_, err := os.Stat(filepath.Clean(path))
 	return !os.IsNotExist(err)
-}
-
-// IsZipFile checks if the content is a valid zip file
-func IsZipFile(content []byte, ext string) bool {
-	if _, found := nonZipExt[ext]; found {
-		return false
-	}
-
-	_, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
-	return err == nil
 }
 
 // OpenIfZip returns a zip handle if path is a valid zip with allow-listed ext, else nil.

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -260,3 +260,18 @@ func IsZipFile(content []byte, ext string) bool {
 	_, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
 	return err == nil
 }
+
+// IsZipFileFromPath checks if the file at path is a valid zip file. Used by
+// streaming download paths that never hold full content in memory.
+func IsZipFileFromPath(path, ext string) bool {
+	if _, found := nonZipExt[ext]; found {
+		return false
+	}
+
+	rc, err := zip.OpenReader(path)
+	if err != nil {
+		return false
+	}
+	_ = rc.Close()
+	return true
+}

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -261,16 +261,15 @@ func IsZipFile(content []byte, ext string) bool {
 	return err == nil
 }
 
-// IsZipFileFromPath checks if the file at path is a valid zip file.
-func IsZipFileFromPath(path, ext string) bool {
+// OpenIfZip returns a zip handle if path is a valid zip with allow-listed ext, else nil.
+// Caller must Close. Reusing this handle for extraction closes the TOCTOU window.
+func OpenIfZip(path, ext string) *zip.ReadCloser {
 	if _, found := nonZipExt[ext]; found {
-		return false
+		return nil
 	}
-
 	rc, err := zip.OpenReader(path)
 	if err != nil {
-		return false
+		return nil
 	}
-	_ = rc.Close()
-	return true
+	return rc
 }

--- a/pkg/utils/fs_test.go
+++ b/pkg/utils/fs_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"archive/zip"
 	"os"
 	"path/filepath"
 	"testing"
@@ -249,6 +250,60 @@ func TestChownRecursive(t *testing.T) {
 		err := ChownRecursive("/nonexistent/path", 1000, 1000)
 		if err == nil {
 			t.Fatal("ChownRecursive() expected error for non-existent path")
+		}
+	})
+}
+
+func makeZipFile(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := zip.NewWriter(f)
+	_ = w.Close()
+	_ = f.Close()
+}
+
+func TestOpenIfZip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("valid zip returns handle", func(t *testing.T) {
+		p := filepath.Join(tmpDir, "valid.zip")
+		makeZipFile(t, p)
+		rc := OpenIfZip(p, ".zip")
+		if rc == nil {
+			t.Fatal("expected non-nil ReadCloser for valid zip")
+		}
+		_ = rc.Close()
+	})
+
+	t.Run("non-zip file returns nil", func(t *testing.T) {
+		p := filepath.Join(tmpDir, "plain.txt")
+		if err := os.WriteFile(p, []byte("hello"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if rc := OpenIfZip(p, ".txt"); rc != nil {
+			_ = rc.Close()
+			t.Fatal("expected nil for non-zip content")
+		}
+	})
+
+	t.Run("denylisted extension returns nil", func(t *testing.T) {
+		p := filepath.Join(tmpDir, "lib.jar")
+		makeZipFile(t, p)
+		if rc := OpenIfZip(p, ".jar"); rc != nil {
+			_ = rc.Close()
+			t.Fatal("expected nil for denylisted .jar extension")
+		}
+	})
+
+	t.Run("uppercase denylisted extension returns nil", func(t *testing.T) {
+		p := filepath.Join(tmpDir, "lib.JAR")
+		makeZipFile(t, p)
+		if rc := OpenIfZip(p, ".JAR"); rc != nil {
+			_ = rc.Close()
+			t.Fatal("expected nil for denylisted .JAR extension")
 		}
 	})
 }


### PR DESCRIPTION
Closes #199

## Changes

### Stream the download path
- `getFileData` returns `io.ReadCloser` instead of `[]byte`
- url / text / base64 branches all use streaming readers
- `writeFileAs(... src io.Reader)` — direct-to-disk via 32KB `io.Copy`
- demote(tee) branch wires `cmd.Stdin = src` directly

### Close zip-validate/extract TOCTOU window
- `IsZipFileFromPath` (validate-then-close, then re-open) → `OpenIfZip` (keep handle) + `UnzipReader`
- Validation and extraction share one fd; the inode is pinned, so a symlink swap of the path between the two steps cannot redirect extraction

### Correctness fixes
- Capture tee stderr via a capped buffer so failures surface a real message instead of `exit status 1`
- Remove the partial file when streaming fails mid-write so retries aren't blocked by `AllowOverwrite=false`

### Configurable download size cap (opt-in)
- New INI option `[file] max_download_bytes` — `0` or unset means unlimited (backwards-compatible)
- When set, reject upfront on `Content-Length`; body is wrapped in a custom `limitedReadCloser` (rather than `http.MaxBytesReader`, which panics with a nil `ResponseWriter`) to enforce the cap on chunked or lying servers
- Content-Length is checked after `http.Get` rather than via a HEAD pre-check to avoid a double RTT; only headers are inspected before any body bytes are buffered

### Dead code cleanup
- The streaming refactor leaves `utils.IsZipFile([]byte, ext)` with no production callers; the function and its tests (`TestIsZipFile`, `TestNonZipExtensions`) are removed
- Side fix: `IsZipFile`'s extension denylist is now case-insensitive — `.JAR` previously bypassed it due to missing `strings.ToLower`

### Tests
- Download size sweep benchmarks (1KB-1GB): `BenchmarkDownload_FetchFromURL`, `BenchmarkDownload_E2E`
- `writeFileAs` unit tests: success / partial cleanup on read error / parent-dir creation

## Compatibility
- Download size cap is opt-in. Existing deployments leave it unset and keep the prior unlimited behavior
- `pkg/utils.IsZipFileFromPath` removed (only exposed on the previous PR for this issue). `Unzip(path, destDir)` is kept as a thin wrapper, so external callers are unaffected

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/utils/... ./pkg/executor/handlers/file/...`
- [x] VM end-to-end: 1KB-1GB sweep, MD5 matches across all sizes, RSS reduced 67× at 1GB
- [x] Same sweep against the OLD binary to confirm the regression and bracket the win

## Measurements

### Benchmarks (`BenchmarkDownload_E2E`)
| size | OLD B/op | NEW B/op | reduction |
|---|---|---|---|
| 100MB | 615 MB | 40 KB | 15,394× |
| 1GB | 5.74 GB | 38.6 KB | 148,571× |

### Real-world (alpacon cp, ARM64 Ubuntu VM, 3.3 GB RAM, 100ms RSS sampling)
| size | OLD peak RSS | NEW peak RSS | reduction | OLD ΔRSS | NEW ΔRSS |
|---|---|---|---|---|---|
| 100MB | 161.8 MB | 31.4 MB | 5.2× | +134.2 MB | +0.6 MB |
| 500MB | 820.4 MB | 31.6 MB | 26.0× | +792.7 MB | +0.8 MB |
| 1GB | 2,171 MB | 32.3 MB | 67.2× | +2,135 MB | +1.4 MB |

Baseline RSS: OLD 36 MB / NEW 30.8 MB. MD5 matches for every measured size (1KB-1GB).

### Throughput (informational, not a meaningful difference)
| size | OLD | NEW | delta |
|---|---|---|---|
| 100MB | 3.82 MiB/s | 4.48 MiB/s | +17% |
| 500MB | 4.53 MiB/s | 5.15 MiB/s | +14% |
| 1GB | 6.37 MiB/s | 6.49 MiB/s | +2% |

The Alpacon FTP path caps around ~6.5 MiB/s, so the gain is marginal end-to-end. This PR targets the memory regression; throughput is reported only to show there's no regression there either.