### PR TITLE
fix(system): unregister server from console on byebye

### DIFF
--- a/pkg/executor/factory.go
+++ b/pkg/executor/factory.go
@@ -43,6 +43,7 @@ type platformHandlerDeps struct {
 	pool         *pool.Pool
 	infoAdapter  *SystemInfoAdapter
 	groupService services.GroupService
+	apiSession   common.APISession
 }
 
 // RegisterAll registers all handlers with the provided callbacks
@@ -78,6 +79,7 @@ func (f *HandlerFactory) RegisterAll(
 		pool:         pool,
 		infoAdapter:  infoAdapter,
 		groupService: groupService,
+		apiSession:   session,
 	}
 	handlers = append(handlers, platformHandlers(deps)...)
 

--- a/pkg/executor/factory_darwin.go
+++ b/pkg/executor/factory_darwin.go
@@ -9,7 +9,7 @@ import (
 
 func platformHandlers(deps platformHandlerDeps) []common.Handler {
 	return []common.Handler{
-		system.NewSystemHandler(deps.cmdExec, deps.wsClient, deps.ctxManager, deps.pool, utils.NewDefaultVersionResolver()),
+		system.NewSystemHandler(deps.cmdExec, deps.wsClient, deps.ctxManager, deps.pool, utils.NewDefaultVersionResolver(), deps.apiSession),
 		tunnel.NewTunnelHandler(deps.cmdExec),
 	}
 }

--- a/pkg/executor/factory_linux.go
+++ b/pkg/executor/factory_linux.go
@@ -12,7 +12,7 @@ import (
 
 func platformHandlers(deps platformHandlerDeps) []common.Handler {
 	return []common.Handler{
-		system.NewSystemHandler(deps.cmdExec, deps.wsClient, deps.ctxManager, deps.pool, utils.NewDefaultVersionResolver()),
+		system.NewSystemHandler(deps.cmdExec, deps.wsClient, deps.ctxManager, deps.pool, utils.NewDefaultVersionResolver(), deps.apiSession),
 		group.NewGroupHandler(deps.cmdExec, deps.infoAdapter),
 		user.NewUserHandler(deps.cmdExec, deps.groupService, deps.infoAdapter),
 		firewall.NewFirewallHandler(deps.cmdExec),

--- a/pkg/executor/factory_windows.go
+++ b/pkg/executor/factory_windows.go
@@ -8,6 +8,6 @@ import (
 
 func platformHandlers(deps platformHandlerDeps) []common.Handler {
 	return []common.Handler{
-		system.NewSystemHandler(deps.cmdExec, deps.wsClient, deps.ctxManager, deps.pool, utils.NewDefaultVersionResolver()),
+		system.NewSystemHandler(deps.cmdExec, deps.wsClient, deps.ctxManager, deps.pool, utils.NewDefaultVersionResolver(), deps.apiSession),
 	}
 }

--- a/pkg/executor/handlers/common/interfaces.go
+++ b/pkg/executor/handlers/common/interfaces.go
@@ -65,9 +65,10 @@ type SystemInfoManager interface {
 	SyncSystemInfo(keys []string)
 }
 
-// APISession interface for API operations (file upload)
+// APISession interface for API operations (file upload, server unregister)
 type APISession interface {
 	MultipartRequest(url string, body io.Reader, contentType string, contentLength int64, timeout time.Duration) ([]byte, int, error)
+	Delete(url string, rawBody interface{}, timeout time.Duration) ([]byte, int, error)
 }
 
 // VersionResolver provides version information for upgrade decisions.

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -21,13 +21,13 @@ import (
 // the authenticated agent's own server id.
 const unregisterURL = "/api/servers/servers/-/unregister/"
 
-// unregisterTimeout bounds the DELETE call issued during byebye. Kept short so
-// a network problem cannot stall the rest of the uninstall sequence; the
-// package removal must still run even when the console is unreachable. The
-// value is a seconds count because Session.Delete applies *time.Second
-// internally (matches the convention used by sibling callers like
-// session.Get(url, 10)).
-const unregisterTimeout = time.Duration(10)
+// unregisterTimeoutSeconds bounds the DELETE call issued during byebye. Kept
+// short so a network problem cannot stall the rest of the uninstall sequence;
+// the package removal must still run even when the console is unreachable.
+// The unit is seconds because Session.Delete (and every other Session method)
+// applies *time.Second internally — naming it explicitly avoids the foot-gun
+// of "fixing" this to 10*time.Second, which would balloon the deadline by ~1e9.
+const unregisterTimeoutSeconds = 10
 
 // SystemHandler handles system-level commands like restart, reboot, shutdown, upgrade
 type SystemHandler struct {
@@ -276,7 +276,7 @@ func (h *SystemHandler) unregisterFromConsole() {
 		return
 	}
 
-	_, statusCode, err := h.apiSession.Delete(unregisterURL, nil, unregisterTimeout)
+	_, statusCode, err := h.apiSession.Delete(unregisterURL, nil, time.Duration(unregisterTimeoutSeconds))
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to unregister server from console; continuing with local uninstall.")
 		return

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -16,6 +16,19 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// unregisterURL is the alpacon-server endpoint that removes the server record
+// corresponding to this agent. The `-` placeholder is resolved server-side to
+// the authenticated agent's own server id.
+const unregisterURL = "/api/servers/servers/-/unregister/"
+
+// unregisterTimeout bounds the DELETE call issued during byebye. Kept short so
+// a network problem cannot stall the rest of the uninstall sequence; the
+// package removal must still run even when the console is unreachable. The
+// value is a seconds count because Session.Delete applies *time.Second
+// internally (matches the convention used by sibling callers like
+// session.Get(url, 10)).
+const unregisterTimeout = time.Duration(10)
+
 // SystemHandler handles system-level commands like restart, reboot, shutdown, upgrade
 type SystemHandler struct {
 	*common.BaseHandler
@@ -23,11 +36,13 @@ type SystemHandler struct {
 	ctxManager      *agent.ContextManager
 	pool            *pool.Pool
 	versionResolver common.VersionResolver
+	apiSession      common.APISession
 }
 
 // NewSystemHandler creates a new system handler.
 // versionResolver must not be nil; pass utils.NewDefaultVersionResolver() for production.
-func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClient, ctxManager *agent.ContextManager, pool *pool.Pool, versionResolver common.VersionResolver) *SystemHandler {
+// apiSession may be nil in tests; byebye will skip the server-side unregister call when absent.
+func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClient, ctxManager *agent.ContextManager, pool *pool.Pool, versionResolver common.VersionResolver, apiSession common.APISession) *SystemHandler {
 	if versionResolver == nil {
 		panic("system: versionResolver must not be nil")
 	}
@@ -49,6 +64,7 @@ func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClie
 		ctxManager:      ctxManager,
 		pool:            pool,
 		versionResolver: versionResolver,
+		apiSession:      apiSession,
 	}
 	return h
 }
@@ -250,6 +266,28 @@ func (h *SystemHandler) handleQuit() (int, string, error) {
 	return 0, "Alpamon will shutdown in 1 second.", nil
 }
 
+// unregisterFromConsole issues DELETE /api/servers/servers/-/unregister/ so
+// alpacon-server removes the corresponding server record. Best-effort: a
+// network failure or non-2xx response is logged and ignored so the agent can
+// still purge itself locally.
+func (h *SystemHandler) unregisterFromConsole() {
+	if h.apiSession == nil {
+		log.Debug().Msg("Skipping server unregister: no API session configured.")
+		return
+	}
+
+	_, statusCode, err := h.apiSession.Delete(unregisterURL, nil, unregisterTimeout)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to unregister server from console; continuing with local uninstall.")
+		return
+	}
+	if statusCode < 200 || statusCode >= 300 {
+		log.Warn().Int("status_code", statusCode).Msg("Server unregister returned non-2xx status; continuing with local uninstall.")
+		return
+	}
+	log.Info().Msg("Server record removed from console.")
+}
+
 // handleUninstall handles the byebye (uninstall) command.
 // See handleRestart for the fire-and-forget pattern. executeUninstall uses
 // context.Background() intentionally because the uninstall must complete even
@@ -265,8 +303,15 @@ func (h *SystemHandler) handleUninstall() (int, string, error) {
 	return 0, "Starting uninstall process...", nil
 }
 
-// executeUninstall performs the actual uninstall
+// executeUninstall performs the actual uninstall.
+// Three-step sequence: (1) tell the console to drop our server record so the
+// agent stops appearing in the inventory, (2) schedule the package removal so
+// it survives our own shutdown, (3) shut the agent down. Step (1) is
+// best-effort: any failure is logged and the rest of the sequence still runs,
+// otherwise a network blip would leave the binary uninstallable.
 func (h *SystemHandler) executeUninstall() {
+	h.unregisterFromConsole()
+
 	var cmd string
 
 	switch utils.PlatformLike {

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -276,7 +276,7 @@ func (h *SystemHandler) unregisterFromConsole() {
 		return
 	}
 
-	_, statusCode, err := h.apiSession.Delete(unregisterURL, nil, time.Duration(unregisterTimeoutSeconds))
+	_, statusCode, err := h.apiSession.Delete(unregisterURL, nil, unregisterTimeoutSeconds)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to unregister server from console; continuing with local uninstall.")
 		return

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -2,7 +2,9 @@ package system
 
 import (
 	"context"
+	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -54,6 +56,45 @@ func newMockVersionResolver() *MockVersionResolver {
 	return &MockVersionResolver{LatestVersion: "v0.0.0-test", PamVersion: ""}
 }
 
+// MockAPISession records Delete calls and returns a configurable response so
+// tests can verify the byebye unregister flow without hitting the network.
+type MockAPISession struct {
+	mu               sync.Mutex
+	DeleteCalls      []string
+	DeleteStatusCode int
+	DeleteErr        error
+}
+
+func (m *MockAPISession) MultipartRequest(url string, body io.Reader, contentType string, contentLength int64, timeout time.Duration) ([]byte, int, error) {
+	return nil, 200, nil
+}
+
+func (m *MockAPISession) Delete(url string, rawBody interface{}, timeout time.Duration) ([]byte, int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.DeleteCalls = append(m.DeleteCalls, url)
+	statusCode := m.DeleteStatusCode
+	if statusCode == 0 {
+		statusCode = 204
+	}
+	return nil, statusCode, m.DeleteErr
+}
+
+func (m *MockAPISession) deleteCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.DeleteCalls)
+}
+
+func (m *MockAPISession) lastDeleteURL() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.DeleteCalls) == 0 {
+		return ""
+	}
+	return m.DeleteCalls[len(m.DeleteCalls)-1]
+}
+
 func TestSystemHandler_Name(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	mockWS := &MockWSClient{}
@@ -62,7 +103,7 @@ func TestSystemHandler_Name(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	if handler.Name() != common.System.String() {
 		t.Errorf("expected name %q, got %q", common.System.String(), handler.Name())
 	}
@@ -76,7 +117,7 @@ func TestSystemHandler_Commands(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	commands := handler.Commands()
 
 	expected := []string{
@@ -109,7 +150,7 @@ func TestSystemHandler_Restart_Collector(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{
@@ -140,7 +181,7 @@ func TestSystemHandler_Restart_Default(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{
@@ -170,7 +211,7 @@ func TestSystemHandler_Restart_Alpamon(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{
@@ -198,7 +239,7 @@ func TestSystemHandler_Quit(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -224,7 +265,7 @@ func TestSystemHandler_Reboot(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -250,7 +291,7 @@ func TestSystemHandler_Shutdown(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -276,7 +317,7 @@ func TestSystemHandler_UnknownCommand(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -302,7 +343,7 @@ func TestSystemHandler_Validate(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 
 	testCases := []struct {
 		name string
@@ -334,7 +375,7 @@ func TestSystemHandler_PoolShutdown(t *testing.T) {
 	ctxManager := agent.NewContextManager()
 	workerPool := pool.NewPool(2, 10)
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	// Shutdown pool first
@@ -372,7 +413,7 @@ func TestSystemHandler_Upgrade_UpToDate(t *testing.T) {
 		LatestVersion: version.Version, // same as current -> up-to-date
 		PamVersion:    "",
 	}
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -398,7 +439,7 @@ func TestSystemHandler_Update(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -428,7 +469,7 @@ func TestSystemHandler_Uninstall(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -444,4 +485,47 @@ func TestSystemHandler_Uninstall(t *testing.T) {
 	if !strings.Contains(output, "uninstall") {
 		t.Errorf("expected output to mention uninstall, got %q", output)
 	}
+}
+
+// TestSystemHandler_UnregisterFromConsole_CallsDelete verifies that byebye
+// hits DELETE /api/servers/servers/-/unregister/ so the console drops the
+// server record before the local package is purged. Exercising
+// unregisterFromConsole directly avoids touching the executeUninstall path,
+// which would invoke real package managers on the host.
+func TestSystemHandler_UnregisterFromConsole_CallsDelete(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockSession := &MockAPISession{}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), mockSession)
+
+	handler.unregisterFromConsole()
+
+	if mockSession.deleteCallCount() != 1 {
+		t.Fatalf("expected 1 Delete call, got %d", mockSession.deleteCallCount())
+	}
+	if got := mockSession.lastDeleteURL(); got != unregisterURL {
+		t.Errorf("expected DELETE to %q, got %q", unregisterURL, got)
+	}
+}
+
+// TestSystemHandler_UnregisterFromConsole_NilSession ensures the helper is a
+// no-op when the API session is absent, so tests and unusual startup paths
+// don't panic.
+func TestSystemHandler_UnregisterFromConsole_NilSession(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
+
+	// Must not panic.
+	handler.unregisterFromConsole()
 }

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"sync"
@@ -65,8 +66,11 @@ type MockAPISession struct {
 	DeleteErr        error
 }
 
+// MultipartRequest exists only to satisfy the APISession interface; SystemHandler
+// never calls it. Tripwiring with panic makes any accidental future use loud
+// instead of silently returning a fake success.
 func (m *MockAPISession) MultipartRequest(url string, body io.Reader, contentType string, contentLength int64, timeout time.Duration) ([]byte, int, error) {
-	return nil, 200, nil
+	panic("MockAPISession.MultipartRequest: unexpected call (system handler should not invoke MultipartRequest)")
 }
 
 func (m *MockAPISession) Delete(url string, rawBody interface{}, timeout time.Duration) ([]byte, int, error) {
@@ -528,4 +532,49 @@ func TestSystemHandler_UnregisterFromConsole_NilSession(t *testing.T) {
 
 	// Must not panic.
 	handler.unregisterFromConsole()
+}
+
+// TestSystemHandler_UnregisterFromConsole_NonSuccessStatus pins the best-effort
+// behavior on a non-2xx response: the helper must log and return cleanly
+// without panicking or aborting the surrounding uninstall sequence. Without
+// this test a future refactor could silently turn the warn-and-continue branch
+// into an error path that bricks local uninstall on any console hiccup.
+func TestSystemHandler_UnregisterFromConsole_NonSuccessStatus(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockSession := &MockAPISession{DeleteStatusCode: 500}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), mockSession)
+
+	handler.unregisterFromConsole()
+
+	if mockSession.deleteCallCount() != 1 {
+		t.Fatalf("expected 1 Delete call, got %d", mockSession.deleteCallCount())
+	}
+}
+
+// TestSystemHandler_UnregisterFromConsole_DeleteError pins the best-effort
+// behavior on a transport-level failure (network down, DNS error, etc.): the
+// helper must log and return cleanly so the local package purge still runs.
+// Pairs with NonSuccessStatus above.
+func TestSystemHandler_UnregisterFromConsole_DeleteError(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockSession := &MockAPISession{DeleteErr: errors.New("network unreachable")}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), mockSession)
+
+	handler.unregisterFromConsole()
+
+	if mockSession.deleteCallCount() != 1 {
+		t.Fatalf("expected 1 Delete call, got %d", mockSession.deleteCallCount())
+	}
 }


### PR DESCRIPTION
## Summary

The `byebye` uninstall command purged the local package and shut the agent down, but never called `DELETE /api/servers/servers/-/unregister/`. The alpacon-server endpoint and its self-reference auth (`pk='-'`) have been in place since the byebye command was added (commit `66e39c2`), but the alpamon caller has been missing from day one — every uninstall left an orphaned server record in the console.

This wires a session into `SystemHandler` and calls the unregister endpoint at the start of `executeUninstall`, before scheduling the package removal. The call is best-effort: a network failure or non-2xx response is logged and ignored so the local purge still runs — otherwise a transient outage would leave the binary uninstallable.

## Pipeline Results

- Tests: APPROVED (709 tests pass, 0 fixes)
- Review: APPROVED (0 critical, 0 warning, 2 informational)
- Auto-fix: SKIPPED (no AUTO-FIX items)

## Changes

- `pkg/executor/handlers/common/interfaces.go` — extend `APISession` with `Delete`
- `pkg/executor/handlers/system/system.go` — add `unregisterURL` const, `unregisterFromConsole()` helper, call it at the start of `executeUninstall`
- `pkg/executor/factory.go`, `factory_{linux,darwin,windows}.go` — thread the API session through `platformHandlerDeps` into `NewSystemHandler`
- `pkg/executor/handlers/system/system_test.go` — add `MockAPISession`, two new tests (`TestSystemHandler_UnregisterFromConsole_CallsDelete`, `TestSystemHandler_UnregisterFromConsole_NilSession`)

## Design Notes

- **Order**: unregister API → schedule package removal → `wsClient.ShutDown()`. Matches the intended three-step sequence.
- **Best-effort**: transport errors and non-2xx responses both log a warning and proceed. A bricked binary on every network blip is worse than a stale DB record that operators can clean up.
- **Timeout**: 10s, expressed as `time.Duration(10)` because `session.Delete` applies `*time.Second` internally — same convention used by `session.Get(url, 10)` in `pkg/runner/commit.go`.
- **Nil session allowed**: tests construct handlers with `nil`; the helper short-circuits with a debug log. Production wires the real session through the factory.

## Testing

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -p 1` — 709/709 pass
- [x] New unit tests cover both the success path and the nil-session guard
- [ ] Manual end-to-end test against an alpacon-dev server pending