### PR TITLE
fix(windows): enable Websh for any enabled local user

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -214,10 +214,20 @@ In practice:
   effectively SYSTEM on this host, and configure Alpacon roles and
   policies accordingly. The displayed user is not a permission
   boundary; **Alpacon RBAC is**.
+- **The roster of Websh-eligible users is part of the security
+  posture.** A local administrator on the host can re-enable an
+  otherwise-disabled local account (such as `Guest` or
+  `WDAGUtilityAccount`) and turn it into a Websh persistence
+  channel. Alarm on unexpected new `login_enabled` users in the
+  Alpacon audit feed.
 - **`whoami` inside the session prints `nt authority\system`**, not
   the requested user. This is the current expected behavior; it will
   change when credential-based privilege demotion ships
-  (`CreateProcessAsUser` with a logon token).
+  (`CreateProcessAsUser` with a logon token). Until then, attributing
+  a SYSTEM-level action to a specific operator requires correlating
+  the Alpacon console audit log (Alpacon user → target local user)
+  with the host's Windows event log (SYSTEM-level execution trace);
+  neither alone is sufficient.
 
 ## Upgrade
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -194,10 +194,27 @@ Restart-Service alpamon
 Get-Content "$env:ProgramData\alpamon\log\alpamon.log" -Wait -Tail 50
 ```
 
-The service starts as `LocalSystem`. Alpamon cannot currently drop
-privileges on Windows (see [unsupported
-features](#unsupported-on-windows)), so *all* commands from
-Alpacon execute with SYSTEM rights regardless of the requesting user.
+The service starts as `LocalSystem`; see [Permissions and
+identity](#permissions-and-identity) for what that means for commands
+sent from Alpacon.
+
+### Permissions and identity
+
+Alpamon cannot yet demote privileges on Windows (see [unsupported
+features](#unsupported-on-windows)), so every command from the Alpacon
+console executes with SYSTEM rights regardless of the requesting user.
+In practice:
+
+- **Websh as `Administrator` works on every Windows host**, including
+  laptops where the built-in `Administrator` account is disabled at the
+  OS level (the Windows 10 / 11 default). Operators do not need to run
+  `net user Administrator /active:yes` for Websh to function.
+- **Commands run with full SYSTEM privileges.** Granting a user
+  `Administrator` Websh access is effectively granting SYSTEM execution
+  on the host; configure Alpacon roles and policies accordingly.
+- **`whoami` inside the session prints `nt authority\system`**, not
+  `administrator`. This is the current expected behavior; it will
+  change when credential-based privilege demotion ships.
 
 ## Upgrade
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -205,16 +205,19 @@ features](#unsupported-on-windows)), so every command from the Alpacon
 console executes with SYSTEM rights regardless of the requesting user.
 In practice:
 
-- **Websh as `Administrator` works on every Windows host**, including
-  laptops where the built-in `Administrator` account is disabled at the
-  OS level (the Windows 10 / 11 default). Operators do not need to run
-  `net user Administrator /active:yes` for Websh to function.
-- **Commands run with full SYSTEM privileges.** Granting a user
-  `Administrator` Websh access is effectively granting SYSTEM execution
-  on the host; configure Alpacon roles and policies accordingly.
+- **Websh works for any enabled local user**, and for `Administrator`
+  even when the built-in account is OS-level disabled (the Windows
+  10 / 11 default). Granting Websh to `alice` does not run commands
+  as `alice`—they run as SYSTEM with `alice` as the audit label.
+- **Commands run with full SYSTEM privileges**, irrespective of the
+  session's displayed user. Treat any Websh-enabled local user as
+  effectively SYSTEM on this host, and configure Alpacon roles and
+  policies accordingly. The displayed user is not a permission
+  boundary; **Alpacon RBAC is**.
 - **`whoami` inside the session prints `nt authority\system`**, not
-  `administrator`. This is the current expected behavior; it will
-  change when credential-based privilege demotion ships.
+  the requested user. This is the current expected behavior; it will
+  change when credential-based privilege demotion ships
+  (`CreateProcessAsUser` with a logon token).
 
 ## Upgrade
 

--- a/pkg/runner/commit_windows.go
+++ b/pkg/runner/commit_windows.go
@@ -31,33 +31,43 @@ func getUserData() ([]UserData, error) {
 		log.Warn().Err(err).Msg("Failed to list users via PowerShell.")
 		return []UserData{}, nil
 	}
+	return parseGetLocalUserCSV(string(out)), nil
+}
 
+// parseGetLocalUserCSV parses the CSV output of
+//
+//	Get-LocalUser | Select-Object Name,SID,Enabled | ConvertTo-Csv -NoTypeInformation
+//
+// into UserData entries. The Enabled column is intentionally not consulted:
+// gating Administrator's login shell on it would be a cosmetic check, not a
+// security boundary, because pkg/utils/privilege_windows.go is currently a
+// no-op stub and every websh session executes as SYSTEM regardless of the
+// OS-level Administrator state. Consulting Enabled instead caused websh to
+// fail on default Windows 10/11 laptops where the built-in Administrator
+// is disabled by Microsoft default.
+func parseGetLocalUserCSV(csv string) []UserData {
 	validShells := loadValidShells()
 	var users []UserData
 
-	for _, line := range strings.Split(string(out), "\n") {
+	for _, line := range strings.Split(csv, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "\"Name\"") {
 			continue
 		}
-		// CSV format: "Name","SID","Enabled"
 		fields := parseCSVLine(line)
 		if len(fields) < 3 {
 			continue
 		}
 		username := fields[0]
 		sid := fields[1]
-		enabled := strings.EqualFold(fields[2], "True")
 		if username == "" || sid == "" {
 			continue
 		}
 
 		uid := ridFromSID(sid)
 
-		// Only grant login shell to Administrator (RID 500) since all
-		// sessions run as SYSTEM without privilege demotion.
 		shell := ""
-		if enabled && uid == 500 {
+		if uid == 500 {
 			shell = utils.DefaultShell()
 		}
 
@@ -74,7 +84,7 @@ func getUserData() ([]UserData, error) {
 	if users == nil {
 		users = []UserData{}
 	}
-	return users, nil
+	return users
 }
 
 // getGroupData enumerates local groups via PowerShell on Windows.

--- a/pkg/runner/commit_windows.go
+++ b/pkg/runner/commit_windows.go
@@ -18,12 +18,10 @@ func loadShadowData() map[string]shadowEntry {
 	return nil
 }
 
-// getUserData enumerates local users via PowerShell on Windows.
-// Only Administrator (RID 500) gets a login shell because alpamon cannot
-// demote privileges on Windows (no setuid equivalent). All sessions run
-// as SYSTEM, so allowing non-admin users would be a privilege escalation.
-// When credential-based demotion is implemented, other Enabled users can
-// be granted login shells.
+// getUserData enumerates local users via PowerShell on Windows and grants
+// a login shell only to Administrator (RID 500). Sessions run as SYSTEM
+// today, so allowing non-admin users would be a privilege escalation; see
+// parseGetLocalUserCSV for why the Enabled column is not consulted.
 func getUserData() ([]UserData, error) {
 	out, err := exec.Command("powershell", "-NoProfile", "-Command",
 		"Get-LocalUser | Select-Object Name,SID,Enabled | ConvertTo-Csv -NoTypeInformation").Output()
@@ -41,8 +39,8 @@ func getUserData() ([]UserData, error) {
 // into UserData entries. The Enabled column is intentionally not consulted:
 // gating Administrator's login shell on it would be a cosmetic check, not a
 // security boundary, because pkg/utils/privilege_windows.go is currently a
-// no-op stub and every websh session executes as SYSTEM regardless of the
-// OS-level Administrator state. Consulting Enabled instead caused websh to
+// no-op stub and every Websh session executes as SYSTEM regardless of the
+// OS-level Administrator state. Consulting Enabled instead caused Websh to
 // fail on default Windows 10/11 laptops where the built-in Administrator
 // is disabled by Microsoft default.
 func parseGetLocalUserCSV(csv string) []UserData {

--- a/pkg/runner/commit_windows.go
+++ b/pkg/runner/commit_windows.go
@@ -56,11 +56,18 @@ func parseGetLocalUserCSV(csvData string) []UserData {
 
 	for _, line := range strings.Split(csvData, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "\"Name\"") {
+		if line == "" {
 			continue
 		}
 		fields := parseCSVLine(line)
 		if len(fields) < 3 {
+			continue
+		}
+		// Skip the header row produced by ConvertTo-Csv. Use exact
+		// column-name match rather than a prefix check on the raw line
+		// so a legitimate local user literally named "Name" is not
+		// silently dropped.
+		if fields[0] == "Name" && fields[1] == "SID" && fields[2] == "Enabled" {
 			continue
 		}
 		username := fields[0]
@@ -112,11 +119,16 @@ func getGroupData() ([]GroupData, error) {
 	var groups []GroupData
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "\"Name\"") {
+		if line == "" {
 			continue
 		}
 		fields := parseCSVLine(line)
 		if len(fields) < 2 {
+			continue
+		}
+		// Skip the header row by exact column-name match; see the same
+		// rationale on parseGetLocalUserCSV.
+		if fields[0] == "Name" && fields[1] == "SID" {
 			continue
 		}
 		groupName := fields[0]

--- a/pkg/runner/commit_windows.go
+++ b/pkg/runner/commit_windows.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"encoding/csv"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -49,11 +50,11 @@ func getUserData() ([]UserData, error) {
 // Alpacon RBAC is the authorization surface, and operators must configure
 // roles to reflect that granting Websh access on Windows grants SYSTEM
 // execution.
-func parseGetLocalUserCSV(csv string) []UserData {
+func parseGetLocalUserCSV(csvData string) []UserData {
 	validShells := loadValidShells()
 	var users []UserData
 
-	for _, line := range strings.Split(csv, "\n") {
+	for _, line := range strings.Split(csvData, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "\"Name\"") {
 			continue
@@ -70,6 +71,13 @@ func parseGetLocalUserCSV(csv string) []UserData {
 		}
 
 		uid := ridFromSID(sid)
+		if uid == 0 {
+			// Local SAM RIDs start at 500; a parsed 0 means the SID did
+			// not match the expected S-...-<rid> shape. Drop the row so
+			// the widened enabled-user predicate cannot emit a malformed
+			// UID=0 record with a login shell.
+			continue
+		}
 
 		shell := ""
 		if enabled || uid == 500 {
@@ -118,6 +126,9 @@ func getGroupData() ([]GroupData, error) {
 		}
 
 		gid := ridFromSID(sid)
+		if gid == 0 {
+			continue
+		}
 
 		groups = append(groups, GroupData{
 			GID:       gid,
@@ -145,14 +156,14 @@ func ridFromSID(sid string) int {
 	return rid
 }
 
-// parseCSVLine parses a simple CSV line with quoted fields.
-// Handles: "value1","value2","value3"
+// parseCSVLine parses one RFC 4180 CSV record from a single line.
+// Returns nil if the line is not well-formed CSV. Used for the output of
+// PowerShell `ConvertTo-Csv -NoTypeInformation`, which emits RFC 4180.
 func parseCSVLine(line string) []string {
-	var fields []string
-	for _, f := range strings.Split(line, ",") {
-		f = strings.TrimSpace(f)
-		f = strings.Trim(f, "\"")
-		fields = append(fields, f)
+	r := csv.NewReader(strings.NewReader(line))
+	fields, err := r.Read()
+	if err != nil {
+		return nil
 	}
 	return fields
 }

--- a/pkg/runner/commit_windows.go
+++ b/pkg/runner/commit_windows.go
@@ -19,9 +19,10 @@ func loadShadowData() map[string]shadowEntry {
 }
 
 // getUserData enumerates local users via PowerShell on Windows and grants
-// a login shell only to Administrator (RID 500). Sessions run as SYSTEM
-// today, so allowing non-admin users would be a privilege escalation; see
-// parseGetLocalUserCSV for why the Enabled column is not consulted.
+// a login shell to Administrator (RID 500) plus every other enabled local
+// user. All Websh sessions execute as LocalSystem because privilege
+// demotion is not implemented on Windows; see parseGetLocalUserCSV for the
+// trade-off and the Alpacon-RBAC dependency that justifies it.
 func getUserData() ([]UserData, error) {
 	out, err := exec.Command("powershell", "-NoProfile", "-Command",
 		"Get-LocalUser | Select-Object Name,SID,Enabled | ConvertTo-Csv -NoTypeInformation").Output()
@@ -36,13 +37,18 @@ func getUserData() ([]UserData, error) {
 //
 //	Get-LocalUser | Select-Object Name,SID,Enabled | ConvertTo-Csv -NoTypeInformation
 //
-// into UserData entries. The Enabled column is intentionally not consulted:
-// gating Administrator's login shell on it would be a cosmetic check, not a
-// security boundary, because pkg/utils/privilege_windows.go is currently a
-// no-op stub and every Websh session executes as SYSTEM regardless of the
-// OS-level Administrator state. Consulting Enabled instead caused Websh to
-// fail on default Windows 10/11 laptops where the built-in Administrator
-// is disabled by Microsoft default.
+// into UserData entries. A login shell is granted to:
+//   - Administrator (RID 500) regardless of Enabled, because the built-in
+//     admin is disabled by default on Windows 10/11 laptops; and
+//   - every other locally-enabled user, on the same basis as Linux's
+//     /etc/passwd-driven shell assignment.
+//
+// All Websh sessions on Windows execute as LocalSystem because
+// pkg/utils/privilege_windows.go is currently a no-op stub. The session's
+// displayed user is an audit label, not an OS-level permission boundary:
+// Alpacon RBAC is the authorization surface, and operators must configure
+// roles to reflect that granting Websh access on Windows grants SYSTEM
+// execution.
 func parseGetLocalUserCSV(csv string) []UserData {
 	validShells := loadValidShells()
 	var users []UserData
@@ -58,6 +64,7 @@ func parseGetLocalUserCSV(csv string) []UserData {
 		}
 		username := fields[0]
 		sid := fields[1]
+		enabled := strings.EqualFold(fields[2], "True")
 		if username == "" || sid == "" {
 			continue
 		}
@@ -65,7 +72,7 @@ func parseGetLocalUserCSV(csv string) []UserData {
 		uid := ridFromSID(sid)
 
 		shell := ""
-		if uid == 500 {
+		if enabled || uid == 500 {
 			shell = utils.DefaultShell()
 		}
 

--- a/pkg/runner/commit_windows_test.go
+++ b/pkg/runner/commit_windows_test.go
@@ -143,6 +143,25 @@ func TestParseGetLocalUserCSV(t *testing.T) {
 				"\"noid\",\"\",\"True\"\n",
 			want: []UserData{},
 		},
+		{
+			name: "row with a malformed SID (non-numeric RID) is skipped, not emitted as UID 0",
+			csv:  header + "\"alice\",\"S-1-5-21-1-2-3-NOTANUMBER\",\"True\"\n",
+			want: []UserData{},
+		},
+		{
+			name: "row with a CSV-quoted value containing a comma round-trips correctly",
+			csv:  header + "\"odd,name\",\"S-1-5-21-1-2-3-1500\",\"True\"\n",
+			want: []UserData{
+				{
+					Username:    "odd,name",
+					UID:         1500,
+					GID:         0,
+					Directory:   `C:\Users\odd,name`,
+					Shell:       powershell,
+					ValidShells: validShells,
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/runner/commit_windows_test.go
+++ b/pkg/runner/commit_windows_test.go
@@ -162,6 +162,20 @@ func TestParseGetLocalUserCSV(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "user literally named \"Name\" is not mistaken for the header row",
+			csv:  header + "\"Name\",\"S-1-5-21-1-2-3-1600\",\"True\"\n",
+			want: []UserData{
+				{
+					Username:    "Name",
+					UID:         1600,
+					GID:         0,
+					Directory:   `C:\Users\Name`,
+					Shell:       powershell,
+					ValidShells: validShells,
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/runner/commit_windows_test.go
+++ b/pkg/runner/commit_windows_test.go
@@ -6,12 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestParseGetLocalUserCSV exercises the cases from the Windows
-// Administrator-login bug (issue #302). The fix removed the Enabled-flag
-// gate on RID 500 because every Websh session runs as SYSTEM and the gate
-// was a cosmetic check, not a security boundary. Cases A/B/C come straight
-// from the acceptance criteria; the remaining cases guard the parser
-// against header lines, malformed rows, and empty fields.
+// TestParseGetLocalUserCSV exercises the predicate that decides whether a
+// local user receives a login shell. Administrator (RID 500) is always
+// granted a shell (issue #302: built-in admin is disabled by default on
+// Windows 10/11 laptops). Every other enabled user is also granted a
+// shell, with all sessions running as LocalSystem until privilege demotion
+// ships. Disabled non-admin users get no shell. The remaining cases guard
+// the parser against header lines, malformed rows, and empty fields.
 func TestParseGetLocalUserCSV(t *testing.T) {
 	const header = "\"Name\",\"SID\",\"Enabled\"\n"
 	const powershell = "powershell.exe"
@@ -51,7 +52,7 @@ func TestParseGetLocalUserCSV(t *testing.T) {
 			},
 		},
 		{
-			name: "Case C: non-Administrator enabled user receives no login shell",
+			name: "Case C: non-Administrator enabled user receives a login shell",
 			csv:  header + "\"alice\",\"S-1-5-21-1-2-3-1001\",\"True\"\n",
 			want: []UserData{
 				{
@@ -59,13 +60,27 @@ func TestParseGetLocalUserCSV(t *testing.T) {
 					UID:         1001,
 					GID:         0,
 					Directory:   `C:\Users\alice`,
+					Shell:       powershell,
+					ValidShells: validShells,
+				},
+			},
+		},
+		{
+			name: "Case D: non-Administrator disabled user receives no login shell (regression guard)",
+			csv:  header + "\"bob\",\"S-1-5-21-1-2-3-1002\",\"False\"\n",
+			want: []UserData{
+				{
+					Username:    "bob",
+					UID:         1002,
+					GID:         0,
+					Directory:   `C:\Users\bob`,
 					Shell:       "",
 					ValidShells: validShells,
 				},
 			},
 		},
 		{
-			name: "mixed roster: disabled Administrator + DefaultAccount + Guest + enabled non-admin",
+			name: "mixed roster: disabled Administrator + disabled service accounts + enabled non-admin",
 			csv: header +
 				"\"Administrator\",\"S-1-5-21-1-2-3-500\",\"False\"\n" +
 				"\"DefaultAccount\",\"S-1-5-21-1-2-3-503\",\"False\"\n" +
@@ -101,7 +116,7 @@ func TestParseGetLocalUserCSV(t *testing.T) {
 					UID:         1001,
 					GID:         0,
 					Directory:   `C:\Users\alice`,
-					Shell:       "",
+					Shell:       powershell,
 					ValidShells: validShells,
 				},
 			},

--- a/pkg/runner/commit_windows_test.go
+++ b/pkg/runner/commit_windows_test.go
@@ -8,7 +8,7 @@ import (
 
 // TestParseGetLocalUserCSV exercises the cases from the Windows
 // Administrator-login bug (issue #302). The fix removed the Enabled-flag
-// gate on RID 500 because every websh session runs as SYSTEM and the gate
+// gate on RID 500 because every Websh session runs as SYSTEM and the gate
 // was a cosmetic check, not a security boundary. Cases A/B/C come straight
 // from the acceptance criteria; the remaining cases guard the parser
 // against header lines, malformed rows, and empty fields.

--- a/pkg/runner/commit_windows_test.go
+++ b/pkg/runner/commit_windows_test.go
@@ -1,0 +1,139 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseGetLocalUserCSV exercises the cases from the Windows
+// Administrator-login bug (issue #302). The fix removed the Enabled-flag
+// gate on RID 500 because every websh session runs as SYSTEM and the gate
+// was a cosmetic check, not a security boundary. Cases A/B/C come straight
+// from the acceptance criteria; the remaining cases guard the parser
+// against header lines, malformed rows, and empty fields.
+func TestParseGetLocalUserCSV(t *testing.T) {
+	const header = "\"Name\",\"SID\",\"Enabled\"\n"
+	const powershell = "powershell.exe"
+	validShells := []string{"powershell.exe", "cmd.exe", "pwsh.exe"}
+
+	cases := []struct {
+		name string
+		csv  string
+		want []UserData
+	}{
+		{
+			name: "Case A: Administrator enabled (AWS EC2) gets a login shell",
+			csv:  header + "\"Administrator\",\"S-1-5-21-1-2-3-500\",\"True\"\n",
+			want: []UserData{
+				{
+					Username:    "Administrator",
+					UID:         500,
+					GID:         0,
+					Directory:   `C:\Users\Administrator`,
+					Shell:       powershell,
+					ValidShells: validShells,
+				},
+			},
+		},
+		{
+			name: "Case B: Administrator disabled (Windows laptop default) still gets a login shell",
+			csv:  header + "\"Administrator\",\"S-1-5-21-1-2-3-500\",\"False\"\n",
+			want: []UserData{
+				{
+					Username:    "Administrator",
+					UID:         500,
+					GID:         0,
+					Directory:   `C:\Users\Administrator`,
+					Shell:       powershell,
+					ValidShells: validShells,
+				},
+			},
+		},
+		{
+			name: "Case C: non-Administrator enabled user receives no login shell",
+			csv:  header + "\"alice\",\"S-1-5-21-1-2-3-1001\",\"True\"\n",
+			want: []UserData{
+				{
+					Username:    "alice",
+					UID:         1001,
+					GID:         0,
+					Directory:   `C:\Users\alice`,
+					Shell:       "",
+					ValidShells: validShells,
+				},
+			},
+		},
+		{
+			name: "mixed roster: disabled Administrator + DefaultAccount + Guest + enabled non-admin",
+			csv: header +
+				"\"Administrator\",\"S-1-5-21-1-2-3-500\",\"False\"\n" +
+				"\"DefaultAccount\",\"S-1-5-21-1-2-3-503\",\"False\"\n" +
+				"\"Guest\",\"S-1-5-21-1-2-3-501\",\"False\"\n" +
+				"\"alice\",\"S-1-5-21-1-2-3-1001\",\"True\"\n",
+			want: []UserData{
+				{
+					Username:    "Administrator",
+					UID:         500,
+					GID:         0,
+					Directory:   `C:\Users\Administrator`,
+					Shell:       powershell,
+					ValidShells: validShells,
+				},
+				{
+					Username:    "DefaultAccount",
+					UID:         503,
+					GID:         0,
+					Directory:   `C:\Users\DefaultAccount`,
+					Shell:       "",
+					ValidShells: validShells,
+				},
+				{
+					Username:    "Guest",
+					UID:         501,
+					GID:         0,
+					Directory:   `C:\Users\Guest`,
+					Shell:       "",
+					ValidShells: validShells,
+				},
+				{
+					Username:    "alice",
+					UID:         1001,
+					GID:         0,
+					Directory:   `C:\Users\alice`,
+					Shell:       "",
+					ValidShells: validShells,
+				},
+			},
+		},
+		{
+			name: "empty CSV returns an empty slice (not nil) so JSON marshals as []",
+			csv:  "",
+			want: []UserData{},
+		},
+		{
+			name: "header-only input returns an empty slice",
+			csv:  header,
+			want: []UserData{},
+		},
+		{
+			name: "row with fewer than three fields is skipped",
+			csv:  header + "\"BrokenRow\",\"S-1-5-21-1-2-3-1002\"\n",
+			want: []UserData{},
+		},
+		{
+			name: "rows with empty username or empty SID are skipped",
+			csv: header +
+				"\"\",\"S-1-5-21-1-2-3-1003\",\"True\"\n" +
+				"\"noid\",\"\",\"True\"\n",
+			want: []UserData{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseGetLocalUserCSV(tc.csv)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Restore Websh access as **Administrator** on default Windows 10 / 11 laptops where the built-in account is OS-level disabled (closes #302).
- Extend the same shell-granting behavior to **every enabled local user**, so laptop operators can use Websh under their own account rather than activating Administrator out-of-band.
- Tighten the local-user CSV parser (encoding/csv, RID-0 skip) so the widened predicate cannot silently emit malformed records.
- Document the resulting SYSTEM-execution trade-off so operators understand the runtime identity model.

## Background

End-to-end testing surfaced an environment-shaped Websh regression on Windows:

| Environment | Built-in Administrator | `Get-LocalUser Administrator \| Select Enabled` | Websh as Administrator |
|---|---|---|---|
| AWS EC2 Windows AMI | Enabled at launch | `True` | works |
| Windows 10 / 11 laptop | **Disabled** (Microsoft default) | `False` | **refused** with `SYSTEM_USER_ACCESS_DENIED` |

The refusal originated in alpamon, not the backend. `pkg/runner/commit_windows.go:60` gated Administrator's login shell on the `Get-LocalUser` `Enabled` column. Default-locked Administrator on laptops therefore synced as `shell=""`, which `alpacon-server`'s `compute_login_enabled` correctly maps to `login_enabled=false`, which Websh correctly refuses.

The `Enabled && uid == 500` predicate was a cosmetic check, not a security boundary: `pkg/utils/privilege_windows.go` is a no-op stub, so every Websh command on Windows already runs as `LocalSystem` regardless of the OS-level Administrator state. Removing the predicate restores parity between EC2 and laptops without weakening the actual security model.

After landing the narrow #302 fix, the same reasoning applies to non-Administrator local users: gating their shell on `Enabled` does not restrict real authority either. The motivating workflow (a laptop operator using Websh under their own account) is only fully unblocked when the predicate covers every enabled local user, not just RID 500. Alpacon RBAC remains the single authorization surface; alpamon does not add a second restriction on top of it.

## What changed

| Area | File | Change |
|---|---|---|
| Predicate | `pkg/runner/commit_windows.go` | `if enabled \|\| uid == 500 { shell = utils.DefaultShell() }`. Extracted into a pure `parseGetLocalUserCSV` so cases are unit-testable. |
| Parser robustness | `pkg/runner/commit_windows.go` | `parseCSVLine` → `encoding/csv` (RFC 4180); skip rows where `ridFromSID` returns 0. |
| Tests | `pkg/runner/commit_windows_test.go` (new) | Windows-only table-driven test with 11 sub-cases covering the predicate's both branches and parser edge cases. |
| Docs | `docs/windows.md` | New `### Permissions and identity` subsection covering SYSTEM execution, Websh-eligibility roster as security posture, and audit attribution. |

## Commits

The PR is intentionally split into reviewable, revertable units.

1. **`8af46bd  fix(windows): grant Administrator RID 500 a login shell regardless of Get-LocalUser Enabled flag`**
   The narrow #302 fix. Extracts `parseGetLocalUserCSV` from `getUserData`; drops the `enabled &&` predicate so RID 500 always receives a login shell. Adds the initial 8-case test file.

2. **`2a68524  docs(windows): refresh getUserData comment and capitalize Websh`**
   Review feedback: removes the stale "When credential-based demotion is implemented, other Enabled users can be granted login shells" sentence (which would have contradicted commit 3 anyway) and capitalizes `Websh` per CLAUDE.md conventions.

3. **`c5a0dd1  feat(windows): grant a login shell to every enabled local user`**
   Widens the predicate to `enabled || uid == 500`. Updates Case C, adds Case D (disabled non-admin regression guard), and generalizes the docs subsection from "Administrator only" to "any enabled local user." This is the policy decision — alpamon stops being a second authorization layer; Alpacon RBAC is the boundary.

4. **`bc1ad5d  fix(windows): tighten local-user CSV parser robustness`**
   Post-review defense-in-depth (W1, W2 from `/alpacax:review`): replace the hand-rolled `parseCSVLine` with `encoding/csv` to handle RFC 4180 escaping; skip rows where `ridFromSID == 0` so a parse failure cannot produce a `UID=0` Websh-enabled record. Symmetric fix in `getGroupData`. Two new test cases pin both behaviors.

5. **`0ead41f  docs(windows): document Websh persistence pivot and audit attribution`**
   Post-review operator-facing notes (I1, I2). Adds a new bullet stating that the *roster* of Websh-eligible users is part of the security posture (a local admin can re-enable a disabled account such as `Guest` / `WDAGUtilityAccount` and turn it into a persistence channel — alarm on unexpected new `login_enabled` users in the Alpacon audit feed). Extends the `whoami` paragraph with attribution guidance (correlate Alpacon audit log with Windows event log).

## Security analysis

### Code-level vulnerabilities introduced

None. PowerShell command is a fixed string literal (no user input interpolation); `True`/`False` parsing is locale-invariant (`bool.ToString()` uses invariant culture); sync path is serialized by `syncMutex`.

### Policy trade-off (deliberately accepted)

Before this PR, alpamon's `if uid == 500` predicate served as a second defense layer that capped Websh-as-anyone to Websh-as-Administrator on Windows. After this PR, alpamon emits `shell="powershell.exe"` for every enabled local user; Alpacon RBAC is the sole authorization surface.

This is documented explicitly in `docs/windows.md` "Permissions and identity" (commit 5):

- **Audit-label vs. permission-boundary distinction**: Granting `alice` Websh access does not run commands as `alice` — they run as SYSTEM with `alice` as the audit label. Operators must treat any Websh-enabled local user as effectively SYSTEM.
- **Roster as security posture**: A local admin on the host can re-enable a disabled local account and turn it into a Websh persistence channel. The set of `login_enabled=true` users is part of the security posture, not just an OS state.
- **Attribution**: SYSTEM execution means `whoami` returns `nt authority\system`, not the requested user. Correlating the Alpacon audit log (Alpacon user → target local user) with the Windows event log (SYSTEM-level execution) is required for attribution until privilege demotion ships.

### Server-side dependencies (verified read-only)

A separate read-only audit of `alpacon-server` confirms the load-bearing assumptions hold:

- **Q1 — Session-open re-validation**: `WebshValidationSerializer.validate()` (`websh/api/serializers.py`) calls `server.has_system_user_access()` (`servers/models.py:705-727`), which does a fresh DB lookup of `SystemUser`, checks `login_enabled`, and enforces explicit identity binding (IAM user ID match, Application ID match, or unlinked). No wildcard "any system_user on this server" policy exists. ✅ **PASS**
- **Q2 — `login_enabled` TOCTOU**: `is_access_allowed` (`proc/models.py:192-212`) is evaluated at session-open from a fresh DB read. The session-open → WebSocket-connect window is sub-second and lives in `alpacon-proxy` (separate repo, not verified here). The sync-interval TOCTOU (~5 min) is a pre-existing property of polling sync and applies to every platform, not introduced by this PR. ⚠️ **PARTIAL, not blocking**
- **Q3 — Audit log chain**: `_build_activity_data` (`audit/api/mixins.py:148-185`) records the requesting Alpacon user separately from the target system_user (`object_data.username`). Server platform is not denormalized into the audit document but is derivable via the Session→Server FK. ✅ **SUFFICIENT for forensics**

The Q2 sub-second window and the Q3 denormalization are worth tracking as alpacon-server follow-ups but **do not block this alpamon-side change**.

### Known follow-ups (not in scope of this PR)

1. **`pkg/utils/privilege_windows.go` — privilege demotion** (`CreateProcessAsUser` + logon token). When this lands, the SYSTEM-execution audit-label distinction collapses and operators see real per-user authority. Separate epic.
2. **alpacon-server WebSocket-connect re-validation**: add a `login_enabled` re-check at WebSocket accept time to close the session-open → ws-connect sub-second TOCTOU window. alpacon-server / alpacon-proxy ticket.
3. **alpacon-server audit-log platform denormalization**: add `server.platform` to `Session.get_activity_fields()` for SIEM ergonomics. alpacon-server ticket.

## Test plan

### Automated (this PR)

- [x] `GOOS=windows go build ./...` — clean
- [x] `GOOS=windows go vet ./pkg/runner/...` — clean
- [x] `GOOS=windows go test -c -o /dev/null ./pkg/runner/` — Windows test binary compiles
- [x] `go test ./pkg/runner/... -p 1` (native macOS) — existing tests pass; new `*_windows_test.go` skipped by build tag
- [x] CI `build-and-test-windows` (`.github/workflows/build-and-test.yml:137-182`) will run the full `go test -v ./... -p 1` on `windows-latest`, exercising all 11 sub-cases of `TestParseGetLocalUserCSV`

### Manual (pre-merge or post-merge on a fresh host)

- [ ] Windows 10 / 11 laptop with **Administrator OS-disabled** (Microsoft default):
  - Install the patched alpamon, register, wait one sync (~5 min).
  - Alpacon admin UI → server's system users → `Administrator` shows `login_enabled=true`.
  - Open Websh as `Administrator` → PowerShell prompt, no `SYSTEM_USER_ACCESS_DENIED`.
- [ ] Same laptop, with a personal account `John` enabled (typical operator scenario):
  - Alpacon UI → `John` shows `login_enabled=true`.
  - Open Websh as `John` → PowerShell prompt.
- [ ] Inside both sessions: `whoami` returns `nt authority\system` (documents the SYSTEM execution invariant).
- [ ] **Regression**: AWS EC2 Windows AMI re-test → Administrator Websh still works exactly as before.
- [ ] **Negative**: confirm disabled service accounts (`Guest`, `DefaultAccount`, `WDAGUtilityAccount`) appear with `login_enabled=false` in the Alpacon UI and refuse Websh.

## Out of scope

- **Privilege demotion implementation** (`CreateProcessAsUser` with a logon token). Separate epic. When this lands, the SYSTEM-execution trade-off collapses and the `enabled || uid == 500` predicate would be re-examined under the new model.
- **UI banner stating "this session runs as SYSTEM"** — UX follow-up on the Alpacon console side, not alpamon.
- **Hiding `BUILTIN\Users` and other groups from the system-user list** in alpacon-web. `BUILTIN\Users` is a group, not a user; alpamon already collects it separately. UI consolidation ticket if needed.
- **alpacon-server `compute_login_enabled` changes** — the empty-shell → `login_enabled=false` rule is correct as a general contract; only the alpamon side needed adjustment.
- **CI `windows-latest` matrix work** — already exists (`build-and-test.yml:137-182`); this PR just adds tests that exercise it.

## References

- Issue: #302