### PR TITLE
feat(cloud): self-report cloud metadata via IMDS for deterministic Server↔CloudInstance match

### DIFF
--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -242,7 +242,7 @@ func detectCloudTags(parent context.Context) map[string]string {
 
 	switch {
 	case err != nil:
-		fmt.Printf("Cloud detected (partial): %s — %v\n", meta.Provider, err)
+		fmt.Printf("Cloud detected (partial) for %s: %v\n", meta.Provider, err)
 	case meta.InstanceID != "":
 		fmt.Printf("Cloud detected: %s (instance=%s)\n", meta.Provider, meta.InstanceID)
 	default:

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -198,6 +198,17 @@ func runRegister(cmd *cobra.Command, args []string) error {
 
 // detectCloudTags runs the IMDS probe and returns the cloud:* tag set, or nil
 // when no provider responds / when the operator passed --no-cloud-probe.
+//
+// cloud.Detect can return four shapes:
+//   - (nil, nil, ErrNoCloudProvider): on-prem / dev path → no tags, log normal
+//   - (provider, fullMeta, nil): happy path → use tags, log instance
+//   - (provider, partialMeta, fetchErr): IMDS partially answered → use whatever
+//     tags we have, log degraded
+//   - (nil, nil, other err): unrecoverable detection error → no tags, log error
+//
+// Surfacing the partial case (rather than throwing away meta on err != nil)
+// matters because the partial tags still help reconcile when at least the
+// provider name was captured.
 func detectCloudTags() map[string]string {
 	if noCloudProbe {
 		fmt.Println("Cloud detection skipped (--no-cloud-probe).")
@@ -208,11 +219,11 @@ func detectCloudTags() map[string]string {
 	defer cancel()
 
 	meta, err := detectCloud(ctx)
-	if err != nil {
-		if errors.Is(err, cloud.ErrNoCloudProvider) {
-			fmt.Println("No cloud provider detected; registering as plain server.")
-			return nil
-		}
+	if errors.Is(err, cloud.ErrNoCloudProvider) {
+		fmt.Println("No cloud provider detected; registering as plain server.")
+		return nil
+	}
+	if err != nil && meta == nil {
 		fmt.Printf("Cloud detection error: %v (continuing without cloud tags)\n", err)
 		return nil
 	}
@@ -223,7 +234,15 @@ func detectCloudTags() map[string]string {
 	if len(tags) == 0 {
 		return nil
 	}
-	fmt.Printf("Cloud detected: %s (instance=%s)\n", meta.Provider, meta.InstanceID)
+
+	switch {
+	case err != nil:
+		fmt.Printf("Cloud detected (partial): %s — %v\n", meta.Provider, err)
+	case meta.InstanceID != "":
+		fmt.Printf("Cloud detected: %s (instance=%s)\n", meta.Provider, meta.InstanceID)
+	default:
+		fmt.Printf("Cloud detected: %s\n", meta.Provider)
+	}
 	return tags
 }
 

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -2,9 +2,11 @@ package register
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +17,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/alpacax/alpamon/pkg/cloud"
 	"github.com/alpacax/alpamon/pkg/utils"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/spf13/cobra"
@@ -26,14 +29,27 @@ var (
 )
 
 var (
-	serverURL  string
-	apiToken   string
-	serverName string
-	platform   string
-	sslVerify  bool
-	caCert     string
-	tags       map[string]string
+	serverURL    string
+	apiToken     string
+	serverName   string
+	platform     string
+	sslVerify    bool
+	caCert       string
+	tags         map[string]string
+	noCloudProbe bool
+
+	// detectCloud is overridable in tests to inject a stub detector. Production
+	// uses cloud.Detect with the default provider list.
+	detectCloud = func(ctx context.Context) (*cloud.Metadata, error) {
+		_, meta, err := cloud.Detect(ctx, cloud.DefaultProviders())
+		return meta, err
+	}
 )
+
+// registerCloudDetectTimeout caps the synchronous cloud probe at register time
+// so a non-cloud host (where all probes time out) still finishes registration
+// within a reasonable budget.
+const registerCloudDetectTimeout = 5 * time.Second
 
 // RegisterRequest represents the request body for server registration
 type RegisterRequest struct {
@@ -57,19 +73,26 @@ var RegisterCmd = &cobra.Command{
 Requires an API token with servers:register scope.
 Groups are automatically assigned from the token's allowed_groups configuration.
 
+On cloud hosts (AWS / GCP / Azure), alpamon probes the link-local IMDS to
+auto-detect provider metadata (instance_id, region, instance_type, ...) and
+includes the results as cloud:* tags. Operator-supplied --tag flags override
+auto-detected values on key conflicts. Pass --no-cloud-probe to skip detection.
+
 Examples:
   sudo alpamon register --url https://alpacon.example.com --token <TOKEN>
   sudo alpamon register --url https://alpacon.example.com --token <TOKEN> --name my-server
   sudo alpamon register --url https://alpacon.example.com --token <TOKEN> --tag env=prod --tag role=web
+  sudo alpamon register --url https://alpacon.example.com --token <TOKEN> --no-cloud-probe
 
 Options:
-  --url         Alpacon server URL (required)
-  --token       API token (servers:register scope required)
-  --name        Server name (optional, defaults to hostname)
-  --platform    Platform (debian/rhel, auto-detect if omitted)
-  --ssl-verify  SSL certificate verification (default: true)
-  --ca-cert     CA certificate path
-  --tag         Server tags in key=value format (repeatable, or comma-separated: "k1=v1,k2=v2")`,
+  --url             Alpacon server URL (required)
+  --token           API token (servers:register scope required)
+  --name            Server name (optional, defaults to hostname)
+  --platform        Platform (debian/rhel, auto-detect if omitted)
+  --ssl-verify      SSL certificate verification (default: true)
+  --ca-cert         CA certificate path
+  --tag             Server tags in key=value format (repeatable, or comma-separated: "k1=v1,k2=v2")
+  --no-cloud-probe  Skip cloud metadata IMDS probe`,
 	RunE: runRegister,
 }
 
@@ -81,6 +104,7 @@ func init() {
 	RegisterCmd.Flags().BoolVar(&sslVerify, "ssl-verify", true, "SSL certificate verification")
 	RegisterCmd.Flags().StringVar(&caCert, "ca-cert", "", "CA certificate path")
 	RegisterCmd.Flags().StringToStringVar(&tags, "tag", nil, "Server tags in key=value format (repeatable, or comma-separated: \"k1=v1,k2=v2\")")
+	RegisterCmd.Flags().BoolVar(&noCloudProbe, "no-cloud-probe", false, "Skip cloud metadata IMDS probe at registration")
 
 	_ = RegisterCmd.MarkFlagRequired("url")
 	_ = RegisterCmd.MarkFlagRequired("token")
@@ -122,39 +146,45 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Platform auto-detected: %s\n", platform)
 	}
 
-	// 4. Create registration request body
+	// 4. Auto-detect cloud provider metadata (best-effort) and merge with
+	// operator-supplied --tag flags. User-supplied tags win over auto-detected
+	// values so an operator can override a misdetection (e.g. forcing
+	// `--tag cloud:provider=aws` on a host where IMDS is restricted).
+	finalTags := mergeCloudAndUserTags(detectCloudTags(), tags)
+
+	// 5. Create registration request body
 	reqBody := RegisterRequest{
 		Name:     serverName,
 		Platform: platform,
-		Tags:     tags,
+		Tags:     finalTags,
 	}
 
 	fmt.Printf("Registering server: %s\n", serverURL)
 
-	// 5. API call
+	// 6. API call
 	resp, err := sendRegisterRequest(reqBody)
 	if err != nil {
 		return err
 	}
 
-	// 6. Create config file
+	// 7. Create config file
 	if err := writeConfigFile(resp); err != nil {
 		return fmt.Errorf("failed to create config file: %w", err)
 	}
 
-	// 7. Create required directories
+	// 8. Create required directories
 	if err := ensureDirectories(); err != nil {
 		return fmt.Errorf("failed to create directories: %w", err)
 	}
 
-	// 8. Start service
+	// 9. Start service
 	fmt.Println("\nStarting alpamon service...")
 	if err := startService(); err != nil {
 		fmt.Printf("Warning: Failed to start service: %v\n", err)
 		printManualStartHint()
 	}
 
-	// 9. Success message
+	// 10. Success message
 	fmt.Printf("\n==========================================\n")
 	fmt.Printf("Server registered successfully!\n")
 	fmt.Printf("==========================================\n")
@@ -164,6 +194,54 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	fmt.Printf("==========================================\n")
 
 	return nil
+}
+
+// detectCloudTags runs the IMDS probe and returns the cloud:* tag set, or nil
+// when no provider responds / when the operator passed --no-cloud-probe.
+func detectCloudTags() map[string]string {
+	if noCloudProbe {
+		fmt.Println("Cloud detection skipped (--no-cloud-probe).")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), registerCloudDetectTimeout)
+	defer cancel()
+
+	meta, err := detectCloud(ctx)
+	if err != nil {
+		if errors.Is(err, cloud.ErrNoCloudProvider) {
+			fmt.Println("No cloud provider detected; registering as plain server.")
+			return nil
+		}
+		fmt.Printf("Cloud detection error: %v (continuing without cloud tags)\n", err)
+		return nil
+	}
+	if meta == nil {
+		return nil
+	}
+	tags := meta.ToTags()
+	if len(tags) == 0 {
+		return nil
+	}
+	fmt.Printf("Cloud detected: %s (instance=%s)\n", meta.Provider, meta.InstanceID)
+	return tags
+}
+
+// mergeCloudAndUserTags returns a single map combining auto-detected tags with
+// operator-supplied --tag flags. User-supplied tags win on key conflicts so
+// the operator can override a misdetection.
+func mergeCloudAndUserTags(auto, user map[string]string) map[string]string {
+	if len(auto) == 0 && len(user) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(auto)+len(user))
+	for k, v := range auto {
+		out[k] = v
+	}
+	for k, v := range user {
+		out[k] = v
+	}
+	return out
 }
 
 // normalizeHostname strips the domain part from FQDN hostnames

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -150,7 +150,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	// operator-supplied --tag flags. User-supplied tags win over auto-detected
 	// values so an operator can override a misdetection (e.g. forcing
 	// `--tag cloud:provider=aws` on a host where IMDS is restricted).
-	finalTags := mergeCloudAndUserTags(detectCloudTags(), tags)
+	finalTags := mergeCloudAndUserTags(detectCloudTags(cmd.Context()), tags)
 
 	// 5. Create registration request body
 	reqBody := RegisterRequest{
@@ -199,23 +199,28 @@ func runRegister(cmd *cobra.Command, args []string) error {
 // detectCloudTags runs the IMDS probe and returns the cloud:* tag set, or nil
 // when no provider responds / when the operator passed --no-cloud-probe.
 //
+// The parent ctx comes from cmd.Context() so a future signal-aware
+// RootCmd.ExecuteContext (e.g. wrapping with signal.NotifyContext) will
+// propagate Ctrl-C / SIGTERM into the IMDS probe without further changes here.
+//
 // cloud.Detect can return four shapes:
 //   - (nil, nil, ErrNoCloudProvider): on-prem / dev path → no tags, log normal
 //   - (provider, fullMeta, nil): happy path → use tags, log instance
 //   - (provider, partialMeta, fetchErr): IMDS partially answered → use whatever
 //     tags we have, log degraded
-//   - (nil, nil, other err): unrecoverable detection error → no tags, log error
+//   - (nil, nil, other err): unrecoverable detection error (incl. ctx
+//     cancel/deadline) → no tags, log error
 //
 // Surfacing the partial case (rather than throwing away meta on err != nil)
 // matters because the partial tags still help reconcile when at least the
 // provider name was captured.
-func detectCloudTags() map[string]string {
+func detectCloudTags(parent context.Context) map[string]string {
 	if noCloudProbe {
 		fmt.Println("Cloud detection skipped (--no-cloud-probe).")
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), registerCloudDetectTimeout)
+	ctx, cancel := context.WithTimeout(parent, registerCloudDetectTimeout)
 	defer cancel()
 
 	meta, err := detectCloud(ctx)

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -329,6 +329,29 @@ func TestDetectCloudTags_NonGracefulErrorDoesNotFail(t *testing.T) {
 	}
 }
 
+func TestDetectCloudTags_PartialMetadataReturnsAvailableTags(t *testing.T) {
+	// cloud.Detect now returns (partialMeta, fetchErr) when Probe succeeds but
+	// Fetch errors mid-read. detectCloudTags must use whatever tags we have
+	// rather than dropping them on the floor.
+	old := detectCloud
+	t.Cleanup(func() { detectCloud = old; noCloudProbe = false })
+
+	detectCloud = func(_ context.Context) (*cloud.Metadata, error) {
+		return &cloud.Metadata{
+			Provider: cloud.ProviderAWS,
+			Region:   "us-east-1",
+			// InstanceID intentionally absent — partial detection
+		}, errors.New("imds document 500")
+	}
+	noCloudProbe = false
+
+	got := detectCloudTags()
+	assert.Equal(t, cloud.ProviderAWS, got[cloud.TagProvider])
+	assert.Equal(t, "us-east-1", got[cloud.TagRegion])
+	_, hasInstanceID := got[cloud.TagInstanceID]
+	assert.False(t, hasInstanceID, "partial detection should not include empty cloud:instance_id")
+}
+
 func TestTagFlagParsing(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -340,7 +340,7 @@ func TestDetectCloudTags_PartialMetadataReturnsAvailableTags(t *testing.T) {
 		return &cloud.Metadata{
 			Provider: cloud.ProviderAWS,
 			Region:   "us-east-1",
-			// InstanceID intentionally absent — partial detection
+			// InstanceID intentionally absent: partial detection
 		}, errors.New("imds document 500")
 	}
 	noCloudProbe = false

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -1,11 +1,14 @@
 package register
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/alpacax/alpamon/pkg/cloud"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -203,6 +206,126 @@ func TestHostnameFQDNStripping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, normalizeHostname(tt.hostname))
 		})
+	}
+}
+
+func TestMergeCloudAndUserTags(t *testing.T) {
+	tests := []struct {
+		name string
+		auto map[string]string
+		user map[string]string
+		want map[string]string
+	}{
+		{
+			name: "both nil returns nil",
+			auto: nil,
+			user: nil,
+			want: nil,
+		},
+		{
+			name: "user only",
+			auto: nil,
+			user: map[string]string{"env": "prod"},
+			want: map[string]string{"env": "prod"},
+		},
+		{
+			name: "auto only",
+			auto: map[string]string{"cloud:provider": "aws", "cloud:instance_id": "i-1"},
+			user: nil,
+			want: map[string]string{"cloud:provider": "aws", "cloud:instance_id": "i-1"},
+		},
+		{
+			name: "user wins on key conflict",
+			auto: map[string]string{"cloud:provider": "aws", "cloud:instance_id": "i-1"},
+			user: map[string]string{"cloud:provider": "manual-override", "env": "prod"},
+			want: map[string]string{
+				"cloud:provider":    "manual-override",
+				"cloud:instance_id": "i-1",
+				"env":               "prod",
+			},
+		},
+		{
+			name: "disjoint keys merge cleanly",
+			auto: map[string]string{"cloud:region": "us-east-1"},
+			user: map[string]string{"role": "web"},
+			want: map[string]string{
+				"cloud:region": "us-east-1",
+				"role":         "web",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeCloudAndUserTags(tt.auto, tt.user)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectCloudTags_NoProviderReturnsNil(t *testing.T) {
+	old := detectCloud
+	t.Cleanup(func() { detectCloud = old; noCloudProbe = false })
+
+	detectCloud = func(_ context.Context) (*cloud.Metadata, error) {
+		return nil, cloud.ErrNoCloudProvider
+	}
+	noCloudProbe = false
+
+	if got := detectCloudTags(); got != nil {
+		t.Errorf("detectCloudTags() = %v, want nil", got)
+	}
+}
+
+func TestDetectCloudTags_HappyPathReturnsTags(t *testing.T) {
+	old := detectCloud
+	t.Cleanup(func() { detectCloud = old; noCloudProbe = false })
+
+	detectCloud = func(_ context.Context) (*cloud.Metadata, error) {
+		return &cloud.Metadata{
+			Provider:   cloud.ProviderAWS,
+			InstanceID: "i-x",
+			Region:     "us-east-1",
+		}, nil
+	}
+	noCloudProbe = false
+
+	got := detectCloudTags()
+	assert.Equal(t, cloud.ProviderAWS, got[cloud.TagProvider])
+	assert.Equal(t, "i-x", got[cloud.TagInstanceID])
+	assert.Equal(t, "us-east-1", got[cloud.TagRegion])
+}
+
+func TestDetectCloudTags_NoCloudProbeFlagSkipsDetection(t *testing.T) {
+	old := detectCloud
+	t.Cleanup(func() { detectCloud = old; noCloudProbe = false })
+
+	called := false
+	detectCloud = func(_ context.Context) (*cloud.Metadata, error) {
+		called = true
+		return nil, nil
+	}
+	noCloudProbe = true
+
+	if got := detectCloudTags(); got != nil {
+		t.Errorf("detectCloudTags() with --no-cloud-probe should return nil, got %v", got)
+	}
+	if called {
+		t.Error("detectCloud must not run when --no-cloud-probe is set")
+	}
+}
+
+func TestDetectCloudTags_NonGracefulErrorDoesNotFail(t *testing.T) {
+	old := detectCloud
+	t.Cleanup(func() { detectCloud = old; noCloudProbe = false })
+
+	detectCloud = func(_ context.Context) (*cloud.Metadata, error) {
+		return nil, errors.New("imds gateway timeout")
+	}
+	noCloudProbe = false
+
+	if got := detectCloudTags(); got != nil {
+		t.Errorf("detectCloudTags() should return nil on unexpected errors, got %v", got)
 	}
 }
 

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -272,8 +272,8 @@ func TestDetectCloudTags_NoProviderReturnsNil(t *testing.T) {
 	}
 	noCloudProbe = false
 
-	if got := detectCloudTags(); got != nil {
-		t.Errorf("detectCloudTags() = %v, want nil", got)
+	if got := detectCloudTags(context.Background()); got != nil {
+		t.Errorf("detectCloudTags(context.Background()) = %v, want nil", got)
 	}
 }
 
@@ -290,7 +290,7 @@ func TestDetectCloudTags_HappyPathReturnsTags(t *testing.T) {
 	}
 	noCloudProbe = false
 
-	got := detectCloudTags()
+	got := detectCloudTags(context.Background())
 	assert.Equal(t, cloud.ProviderAWS, got[cloud.TagProvider])
 	assert.Equal(t, "i-x", got[cloud.TagInstanceID])
 	assert.Equal(t, "us-east-1", got[cloud.TagRegion])
@@ -307,8 +307,8 @@ func TestDetectCloudTags_NoCloudProbeFlagSkipsDetection(t *testing.T) {
 	}
 	noCloudProbe = true
 
-	if got := detectCloudTags(); got != nil {
-		t.Errorf("detectCloudTags() with --no-cloud-probe should return nil, got %v", got)
+	if got := detectCloudTags(context.Background()); got != nil {
+		t.Errorf("detectCloudTags(context.Background()) with --no-cloud-probe should return nil, got %v", got)
 	}
 	if called {
 		t.Error("detectCloud must not run when --no-cloud-probe is set")
@@ -324,8 +324,8 @@ func TestDetectCloudTags_NonGracefulErrorDoesNotFail(t *testing.T) {
 	}
 	noCloudProbe = false
 
-	if got := detectCloudTags(); got != nil {
-		t.Errorf("detectCloudTags() should return nil on unexpected errors, got %v", got)
+	if got := detectCloudTags(context.Background()); got != nil {
+		t.Errorf("detectCloudTags(context.Background()) should return nil on unexpected errors, got %v", got)
 	}
 }
 
@@ -345,7 +345,7 @@ func TestDetectCloudTags_PartialMetadataReturnsAvailableTags(t *testing.T) {
 	}
 	noCloudProbe = false
 
-	got := detectCloudTags()
+	got := detectCloudTags(context.Background())
 	assert.Equal(t, cloud.ProviderAWS, got[cloud.TagProvider])
 	assert.Equal(t, "us-east-1", got[cloud.TagRegion])
 	_, hasInstanceID := got[cloud.TagInstanceID]

--- a/pkg/cloud/aws.go
+++ b/pkg/cloud/aws.go
@@ -153,7 +153,7 @@ func (p *AWSProvider) fetchToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("token http %d", resp.StatusCode)
 	}
 
-	body, err := readLimitedN(resp.Body, awsResponseLimit)
+	body, err := readLimited(resp.Body, awsResponseLimit)
 	if err != nil {
 		return "", err
 	}
@@ -208,5 +208,5 @@ func (p *AWSProvider) imdsGet(ctx context.Context, token, path string) ([]byte, 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("imds %s http %d", path, resp.StatusCode)
 	}
-	return readLimitedN(resp.Body, awsResponseLimit)
+	return readLimited(resp.Body, awsResponseLimit)
 }

--- a/pkg/cloud/aws.go
+++ b/pkg/cloud/aws.go
@@ -1,0 +1,212 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// AWS IMDSv2 endpoints. Production IMDS lives on the link-local address
+// 169.254.169.254 — every EC2 instance has it routed locally.
+const (
+	awsDefaultBase = "http://169.254.169.254"
+
+	awsTokenPath    = "/latest/api/token"
+	awsDocumentPath = "/latest/dynamic/instance-identity/document"
+	awsMACPath      = "/latest/meta-data/mac"
+	awsVPCPathFmt   = "/latest/meta-data/network/interfaces/macs/%s/vpc-id"
+
+	// awsTokenTTLHeader bounds the token lifetime. 6 hours is AWS's documented
+	// maximum and is fine for a one-shot probe-then-fetch sequence.
+	awsTokenTTLHeader = "21600"
+
+	awsHdrTokenTTL = "X-aws-ec2-metadata-token-ttl-seconds"
+	awsHdrToken    = "X-aws-ec2-metadata-token"
+
+	awsResponseLimit = 8 * 1024 // 8 KB — IMDS payloads are tiny
+)
+
+// awsProbeTimeout / awsFetchTimeout bound individual HTTP attempts. Detect
+// further bounds the whole probe+fetch sequence via ctx.
+const (
+	awsProbeTimeout = 800 * time.Millisecond
+	awsFetchTimeout = 2 * time.Second
+)
+
+// awsIdentityDocument is the subset of the instance-identity document we care
+// about. AWS keeps this stable across instance families.
+type awsIdentityDocument struct {
+	InstanceID       string `json:"instanceId"`
+	Region           string `json:"region"`
+	AvailabilityZone string `json:"availabilityZone"`
+	InstanceType     string `json:"instanceType"`
+	AccountID        string `json:"accountId"`
+}
+
+// AWSProvider implements Provider against EC2 IMDSv2.
+type AWSProvider struct {
+	base   string
+	client *http.Client
+}
+
+// NewAWS returns an AWS provider targeting the link-local IMDS endpoint.
+func NewAWS() *AWSProvider {
+	return NewAWSWithBase(awsDefaultBase)
+}
+
+// NewAWSWithBase constructs an AWS provider against an arbitrary IMDS base URL.
+// Tests inject an httptest server URL here.
+func NewAWSWithBase(base string) *AWSProvider {
+	return &AWSProvider{
+		base: strings.TrimRight(base, "/"),
+		client: &http.Client{
+			Timeout: awsFetchTimeout + 500*time.Millisecond,
+		},
+	}
+}
+
+// Name implements Provider.
+func (p *AWSProvider) Name() string { return ProviderAWS }
+
+// Probe attempts the IMDSv2 token PUT. Success confirms an AWS-style IMDS is
+// reachable. Failures (network, timeout, non-2xx) are silent — Detect treats
+// them as "not AWS, try next provider".
+func (p *AWSProvider) Probe(ctx context.Context) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, awsProbeTimeout)
+	defer cancel()
+
+	_, err := p.fetchToken(probeCtx)
+	return err == nil
+}
+
+// Fetch reads the instance-identity document and the primary ENI's VPC ID.
+// If Probe-positive but Fetch encounters an error mid-read, we return whatever
+// partial Metadata we managed to populate and let the caller log — we do NOT
+// fall back to a different provider, because the host IS on AWS.
+func (p *AWSProvider) Fetch(ctx context.Context) (*Metadata, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, awsFetchTimeout)
+	defer cancel()
+
+	token, err := p.fetchToken(fetchCtx)
+	if err != nil {
+		return nil, fmt.Errorf("aws imds token: %w", err)
+	}
+
+	meta := &Metadata{Provider: ProviderAWS}
+
+	doc, docErr := p.fetchDocument(fetchCtx, token)
+	if docErr == nil {
+		meta.InstanceID = doc.InstanceID
+		meta.Region = doc.Region
+		meta.AvailabilityZone = doc.AvailabilityZone
+		meta.InstanceType = doc.InstanceType
+		meta.AccountID = doc.AccountID
+	}
+
+	// VPC ID is best-effort: requires two extra hops (mac → vpc-id). If either
+	// fails we leave NetworkID empty. The Server↔CloudInstance match uses
+	// cloud:instance_id, so missing cloud:network_id does not break reconcile —
+	// but we log at debug so field investigators can correlate "why is vpc empty"
+	// with the real IMDS error.
+	mac, macErr := p.fetchMAC(fetchCtx, token)
+	switch {
+	case macErr != nil:
+		log.Debug().Err(macErr).Msg("aws imds mac fetch failed; cloud:network_id will be empty")
+	case mac == "":
+		log.Debug().Msg("aws imds returned empty mac; cloud:network_id will be empty")
+	default:
+		if vpc, vpcErr := p.fetchVPCID(fetchCtx, token, mac); vpcErr != nil {
+			log.Debug().Err(vpcErr).Msg("aws imds vpc-id fetch failed; cloud:network_id will be empty")
+		} else {
+			meta.NetworkID = vpc
+		}
+	}
+
+	// Only surface document error if it left us with no useful data beyond the
+	// provider tag — gives callers a chance to log Warn but still report cloud:provider=aws.
+	if docErr != nil && meta.InstanceID == "" {
+		return meta, fmt.Errorf("aws identity document: %w", docErr)
+	}
+	return meta, nil
+}
+
+func (p *AWSProvider) fetchToken(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, p.base+awsTokenPath, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set(awsHdrTokenTTL, awsTokenTTLHeader)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token http %d", resp.StatusCode)
+	}
+
+	body, err := readLimitedN(resp.Body, awsResponseLimit)
+	if err != nil {
+		return "", err
+	}
+	tok := strings.TrimSpace(string(body))
+	if tok == "" {
+		return "", errors.New("empty token")
+	}
+	return tok, nil
+}
+
+func (p *AWSProvider) fetchDocument(ctx context.Context, token string) (*awsIdentityDocument, error) {
+	body, err := p.imdsGet(ctx, token, awsDocumentPath)
+	if err != nil {
+		return nil, err
+	}
+	var doc awsIdentityDocument
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("parse identity document: %w", err)
+	}
+	return &doc, nil
+}
+
+func (p *AWSProvider) fetchMAC(ctx context.Context, token string) (string, error) {
+	body, err := p.imdsGet(ctx, token, awsMACPath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
+func (p *AWSProvider) fetchVPCID(ctx context.Context, token, mac string) (string, error) {
+	body, err := p.imdsGet(ctx, token, fmt.Sprintf(awsVPCPathFmt, mac))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
+func (p *AWSProvider) imdsGet(ctx context.Context, token, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.base+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(awsHdrToken, token)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("imds %s http %d", path, resp.StatusCode)
+	}
+	return readLimitedN(resp.Body, awsResponseLimit)
+}

--- a/pkg/cloud/aws.go
+++ b/pkg/cloud/aws.go
@@ -102,7 +102,7 @@ func (p *AWSProvider) Fetch(ctx context.Context) (*Metadata, error) {
 
 	doc, docErr := p.fetchDocument(fetchCtx, token)
 	if docErr == nil {
-		meta.InstanceID = doc.InstanceID
+		meta.InstanceID = strings.TrimSpace(doc.InstanceID)
 		meta.Region = doc.Region
 		meta.AvailabilityZone = doc.AvailabilityZone
 		meta.InstanceType = doc.InstanceType
@@ -122,10 +122,16 @@ func (p *AWSProvider) Fetch(ctx context.Context) (*Metadata, error) {
 		}
 	}
 
-	// Only surface document error if it left us with no useful data beyond the
-	// provider tag — gives callers a chance to log Warn but still report cloud:provider=aws.
-	if docErr != nil && meta.InstanceID == "" {
-		return meta, fmt.Errorf("aws identity document: %w", docErr)
+	// instance_id is the deterministic-match key for alpacon-server reconcile.
+	// An "ok" Fetch with empty InstanceID would silently produce a useless tag
+	// set and undermine the feature's whole purpose — surface it as an error
+	// so callers can mark detection as degraded. Partial meta is still
+	// returned so cloud:provider=aws makes it into Server.tags.
+	if meta.InstanceID == "" {
+		if docErr != nil {
+			return meta, fmt.Errorf("aws identity document: %w", docErr)
+		}
+		return meta, errors.New("aws imds returned empty instance id")
 	}
 	return meta, nil
 }

--- a/pkg/cloud/aws.go
+++ b/pkg/cloud/aws.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/rs/zerolog/log"
 )
 
 // AWS IMDSv2 endpoints. Production IMDS lives on the link-local address
@@ -113,19 +111,13 @@ func (p *AWSProvider) Fetch(ctx context.Context) (*Metadata, error) {
 
 	// VPC ID is best-effort: requires two extra hops (mac → vpc-id). If either
 	// fails we leave NetworkID empty. The Server↔CloudInstance match uses
-	// cloud:instance_id, so missing cloud:network_id does not break reconcile —
-	// but we log at debug so field investigators can correlate "why is vpc empty"
-	// with the real IMDS error.
-	mac, macErr := p.fetchMAC(fetchCtx, token)
-	switch {
-	case macErr != nil:
-		log.Debug().Err(macErr).Msg("aws imds mac fetch failed; cloud:network_id will be empty")
-	case mac == "":
-		log.Debug().Msg("aws imds returned empty mac; cloud:network_id will be empty")
-	default:
-		if vpc, vpcErr := p.fetchVPCID(fetchCtx, token, mac); vpcErr != nil {
-			log.Debug().Err(vpcErr).Msg("aws imds vpc-id fetch failed; cloud:network_id will be empty")
-		} else {
+	// cloud:instance_id, so missing cloud:network_id does not break reconcile.
+	// We do not log MAC/VPC failures here: callers (e.g. register CLI) operate
+	// in plain-text mode and library-side zerolog calls would leak JSON into
+	// their output. Operators investigating missing cloud:network_id can curl
+	// IMDS directly; we trade silent partial data for a clean library boundary.
+	if mac, macErr := p.fetchMAC(fetchCtx, token); macErr == nil && mac != "" {
+		if vpc, vpcErr := p.fetchVPCID(fetchCtx, token, mac); vpcErr == nil {
 			meta.NetworkID = vpc
 		}
 	}

--- a/pkg/cloud/aws.go
+++ b/pkg/cloud/aws.go
@@ -87,16 +87,20 @@ func (p *AWSProvider) Probe(ctx context.Context) bool {
 // If Probe-positive but Fetch encounters an error mid-read, we return whatever
 // partial Metadata we managed to populate and let the caller log — we do NOT
 // fall back to a different provider, because the host IS on AWS.
+//
+// On any failure path Fetch returns a non-nil *Metadata with at least
+// Provider=aws set, matching the GCPProvider/AzureProvider contract so callers
+// can call .ToTags() safely without nil-guarding the result.
 func (p *AWSProvider) Fetch(ctx context.Context) (*Metadata, error) {
 	fetchCtx, cancel := context.WithTimeout(ctx, awsFetchTimeout)
 	defer cancel()
 
+	meta := &Metadata{Provider: ProviderAWS}
+
 	token, err := p.fetchToken(fetchCtx)
 	if err != nil {
-		return nil, fmt.Errorf("aws imds token: %w", err)
+		return meta, fmt.Errorf("aws imds token: %w", err)
 	}
-
-	meta := &Metadata{Provider: ProviderAWS}
 
 	doc, docErr := p.fetchDocument(fetchCtx, token)
 	if docErr == nil {

--- a/pkg/cloud/aws.go
+++ b/pkg/cloud/aws.go
@@ -64,10 +64,8 @@ func NewAWS() *AWSProvider {
 // Tests inject an httptest server URL here.
 func NewAWSWithBase(base string) *AWSProvider {
 	return &AWSProvider{
-		base: strings.TrimRight(base, "/"),
-		client: &http.Client{
-			Timeout: awsFetchTimeout + 500*time.Millisecond,
-		},
+		base:   strings.TrimRight(base, "/"),
+		client: newIMDSClient(awsFetchTimeout + 500*time.Millisecond),
 	}
 }
 

--- a/pkg/cloud/aws_test.go
+++ b/pkg/cloud/aws_test.go
@@ -181,9 +181,18 @@ func TestAWS_Fetch_TokenFailure(t *testing.T) {
 	defer server.Close()
 
 	p := NewAWSWithBase(server.URL)
-	_, err := p.Fetch(context.Background())
+	meta, err := p.Fetch(context.Background())
 	if err == nil {
 		t.Error("expected error when token fetch fails")
+	}
+	// Contract: Fetch returns a non-nil *Metadata with Provider=aws on every
+	// failure path, matching GCPProvider/AzureProvider so callers can call
+	// .ToTags() without nil-guarding.
+	if meta == nil {
+		t.Fatal("expected non-nil meta even on token failure")
+	}
+	if meta.Provider != ProviderAWS {
+		t.Errorf("meta.Provider = %q, want %q", meta.Provider, ProviderAWS)
 	}
 }
 

--- a/pkg/cloud/aws_test.go
+++ b/pkg/cloud/aws_test.go
@@ -1,0 +1,282 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// awsTestMAC is the MAC the mock IMDS returns for the primary ENI.
+const awsTestMAC = "06:00:00:00:00:01"
+
+// newAWSMockServer returns an httptest server that mimics the IMDSv2 protocol.
+// Handlers can override individual paths by setting fields on opts.
+type awsMockOpts struct {
+	tokenStatus    int
+	tokenBody      string
+	requireToken   bool
+	documentStatus int
+	documentBody   string
+	macStatus      int
+	macBody        string
+	vpcStatus      int
+	vpcBody        string
+}
+
+func newAWSMockServer(t *testing.T, opts awsMockOpts) *httptest.Server {
+	t.Helper()
+
+	if opts.tokenStatus == 0 {
+		opts.tokenStatus = http.StatusOK
+	}
+	if opts.tokenBody == "" {
+		opts.tokenBody = "TOKEN-xxx"
+	}
+	if opts.documentStatus == 0 {
+		opts.documentStatus = http.StatusOK
+	}
+	if opts.documentBody == "" {
+		doc := awsIdentityDocument{
+			InstanceID:       "i-0123456789abcdef0",
+			Region:           "us-east-1",
+			AvailabilityZone: "us-east-1a",
+			InstanceType:     "t3.micro",
+			AccountID:        "123456789012",
+		}
+		buf, _ := json.Marshal(doc)
+		opts.documentBody = string(buf)
+	}
+	if opts.macStatus == 0 {
+		opts.macStatus = http.StatusOK
+	}
+	if opts.macBody == "" {
+		opts.macBody = awsTestMAC
+	}
+	if opts.vpcStatus == 0 {
+		opts.vpcStatus = http.StatusOK
+	}
+	if opts.vpcBody == "" {
+		opts.vpcBody = "vpc-0abc12345"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/latest/api/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Header.Get(awsHdrTokenTTL) == "" {
+			http.Error(w, "missing ttl header", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(opts.tokenStatus)
+		_, _ = w.Write([]byte(opts.tokenBody))
+	})
+
+	tokenCheck := func(w http.ResponseWriter, r *http.Request) bool {
+		if opts.requireToken && r.Header.Get(awsHdrToken) == "" {
+			http.Error(w, "missing token", http.StatusUnauthorized)
+			return false
+		}
+		return true
+	}
+
+	mux.HandleFunc("/latest/dynamic/instance-identity/document", func(w http.ResponseWriter, r *http.Request) {
+		if !tokenCheck(w, r) {
+			return
+		}
+		w.WriteHeader(opts.documentStatus)
+		_, _ = w.Write([]byte(opts.documentBody))
+	})
+	mux.HandleFunc("/latest/meta-data/mac", func(w http.ResponseWriter, r *http.Request) {
+		if !tokenCheck(w, r) {
+			return
+		}
+		w.WriteHeader(opts.macStatus)
+		_, _ = w.Write([]byte(opts.macBody))
+	})
+	mux.HandleFunc("/latest/meta-data/network/interfaces/macs/", func(w http.ResponseWriter, r *http.Request) {
+		if !tokenCheck(w, r) {
+			return
+		}
+		w.WriteHeader(opts.vpcStatus)
+		_, _ = w.Write([]byte(opts.vpcBody))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestAWS_Fetch_HappyPath(t *testing.T) {
+	server := newAWSMockServer(t, awsMockOpts{requireToken: true})
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	checks := map[string]string{
+		"Provider":         ProviderAWS,
+		"InstanceID":       "i-0123456789abcdef0",
+		"Region":           "us-east-1",
+		"AvailabilityZone": "us-east-1a",
+		"InstanceType":     "t3.micro",
+		"AccountID":        "123456789012",
+		"NetworkID":        "vpc-0abc12345",
+	}
+	got := map[string]string{
+		"Provider":         meta.Provider,
+		"InstanceID":       meta.InstanceID,
+		"Region":           meta.Region,
+		"AvailabilityZone": meta.AvailabilityZone,
+		"InstanceType":     meta.InstanceType,
+		"AccountID":        meta.AccountID,
+		"NetworkID":        meta.NetworkID,
+	}
+	for k, want := range checks {
+		if got[k] != want {
+			t.Errorf("%s = %q, want %q", k, got[k], want)
+		}
+	}
+}
+
+func TestAWS_Probe_TokenSucceeds(t *testing.T) {
+	server := newAWSMockServer(t, awsMockOpts{})
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	if !p.Probe(context.Background()) {
+		t.Error("Probe returned false on healthy IMDS")
+	}
+}
+
+func TestAWS_Probe_Token401(t *testing.T) {
+	server := newAWSMockServer(t, awsMockOpts{tokenStatus: http.StatusUnauthorized})
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	if p.Probe(context.Background()) {
+		t.Error("Probe returned true despite token 401")
+	}
+}
+
+func TestAWS_Probe_Unreachable(t *testing.T) {
+	// 169.254.169.255 is link-local but no listener — connection refused on Linux,
+	// or timeout. Probe must return false either way and respect ctx budget.
+	p := NewAWSWithBase("http://127.0.0.1:1") // port 1 reserved → ECONNREFUSED fast
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	if p.Probe(ctx) {
+		t.Error("Probe returned true when nothing listening")
+	}
+}
+
+func TestAWS_Fetch_TokenFailure(t *testing.T) {
+	server := newAWSMockServer(t, awsMockOpts{tokenStatus: http.StatusUnauthorized})
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	_, err := p.Fetch(context.Background())
+	if err == nil {
+		t.Error("expected error when token fetch fails")
+	}
+}
+
+func TestAWS_Fetch_DocumentError_StillReturnsProvider(t *testing.T) {
+	server := newAWSMockServer(t, awsMockOpts{documentStatus: http.StatusInternalServerError})
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err == nil {
+		t.Error("expected document error to surface")
+	}
+	if meta == nil || meta.Provider != ProviderAWS {
+		t.Errorf("expected partial meta with Provider=aws, got %+v", meta)
+	}
+}
+
+func TestAWS_Fetch_DocumentParseError(t *testing.T) {
+	server := newAWSMockServer(t, awsMockOpts{documentBody: "{ not json"})
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	_, err := p.Fetch(context.Background())
+	if err == nil {
+		t.Error("expected parse error to surface")
+	}
+}
+
+func TestAWS_Fetch_VPCMissing_StillPopulatesDocFields(t *testing.T) {
+	server := newAWSMockServer(t, awsMockOpts{
+		vpcStatus: http.StatusNotFound,
+		vpcBody:   "not found",
+	})
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if meta.InstanceID == "" {
+		t.Error("InstanceID should be populated even without vpc-id")
+	}
+	if meta.NetworkID != "" {
+		t.Errorf("NetworkID should be empty on 404, got %q", meta.NetworkID)
+	}
+}
+
+func TestAWS_Fetch_MACEmpty_NoVPCAttempt(t *testing.T) {
+	var vpcHits atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/latest/api/token", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("TOKEN"))
+	})
+	mux.HandleFunc("/latest/dynamic/instance-identity/document", func(w http.ResponseWriter, _ *http.Request) {
+		doc := awsIdentityDocument{InstanceID: "i-x", Region: "us-east-1"}
+		_ = json.NewEncoder(w).Encode(doc)
+	})
+	mux.HandleFunc("/latest/meta-data/mac", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("")) // empty MAC
+	})
+	mux.HandleFunc("/latest/meta-data/network/interfaces/macs/", func(_ http.ResponseWriter, _ *http.Request) {
+		vpcHits.Add(1)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if meta.NetworkID != "" {
+		t.Errorf("NetworkID should be empty when MAC is empty, got %q", meta.NetworkID)
+	}
+	if vpcHits.Load() != 0 {
+		t.Errorf("expected zero vpc-id hits when MAC empty, got %d", vpcHits.Load())
+	}
+}
+
+func TestAWS_Fetch_RespectsContextCancel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte("TOKEN"))
+	}))
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := p.Fetch(ctx)
+	if err == nil {
+		t.Error("expected ctx-deadline error")
+	}
+}

--- a/pkg/cloud/aws_test.go
+++ b/pkg/cloud/aws_test.go
@@ -210,6 +210,31 @@ func TestAWS_Fetch_DocumentError_StillReturnsProvider(t *testing.T) {
 	}
 }
 
+func TestAWS_Fetch_EmptyInstanceID_ReturnsError(t *testing.T) {
+	// IMDS returns a syntactically-valid identity document with an empty
+	// instanceId. Fetch must surface that as an error since cloud:instance_id
+	// is the deterministic-match key for reconcile.
+	doc := awsIdentityDocument{
+		InstanceID:       "", // empty — the regression we're guarding against
+		Region:           "us-east-1",
+		AvailabilityZone: "us-east-1a",
+		InstanceType:     "t3.micro",
+		AccountID:        "123456789012",
+	}
+	buf, _ := json.Marshal(doc)
+	server := newAWSMockServer(t, awsMockOpts{documentBody: string(buf)})
+	defer server.Close()
+
+	p := NewAWSWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err == nil {
+		t.Error("expected error when instance_id is empty")
+	}
+	if meta == nil || meta.Provider != ProviderAWS {
+		t.Errorf("expected partial Metadata with Provider=aws, got %+v", meta)
+	}
+}
+
 func TestAWS_Fetch_DocumentParseError(t *testing.T) {
 	server := newAWSMockServer(t, awsMockOpts{documentBody: "{ not json"})
 	defer server.Close()

--- a/pkg/cloud/azure.go
+++ b/pkg/cloud/azure.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -103,11 +104,11 @@ func (p *AzureProvider) Fetch(ctx context.Context) (*Metadata, error) {
 		// NetworkID intentionally empty — see function-level comment.
 	}
 	// instance_id is the deterministic-match key. An otherwise-valid IMDS
-	// response with empty vmId would silently undermine reconcile — fail
+	// response with empty vmId would silently undermine reconcile, so fail
 	// explicitly while still returning partial meta (cloud:provider=azure
 	// makes it into Server.tags).
 	if meta.InstanceID == "" {
-		return meta, fmt.Errorf("azure imds returned empty vmId")
+		return meta, errors.New("azure imds returned empty vmId")
 	}
 	return meta, nil
 }

--- a/pkg/cloud/azure.go
+++ b/pkg/cloud/azure.go
@@ -48,14 +48,12 @@ type AzureProvider struct {
 // NewAzure returns an Azure provider pointed at the link-local IMDS endpoint.
 func NewAzure() *AzureProvider { return NewAzureWithBase(azureDefaultBase) }
 
-// NewAzureWithBase builds an Azure provider with an explicit base URL — used
+// NewAzureWithBase builds an Azure provider with an explicit base URL. Used
 // by tests.
 func NewAzureWithBase(base string) *AzureProvider {
 	return &AzureProvider{
-		base: strings.TrimRight(base, "/"),
-		client: &http.Client{
-			Timeout: azureFetchTimeout + 500*time.Millisecond,
-		},
+		base:   strings.TrimRight(base, "/"),
+		client: newIMDSClient(azureFetchTimeout + 500*time.Millisecond),
 	}
 }
 

--- a/pkg/cloud/azure.go
+++ b/pkg/cloud/azure.go
@@ -93,15 +93,23 @@ func (p *AzureProvider) Fetch(ctx context.Context) (*Metadata, error) {
 		return &Metadata{Provider: ProviderAzure}, fmt.Errorf("azure imds parse: %w", err)
 	}
 
-	return &Metadata{
+	meta := &Metadata{
 		Provider:         ProviderAzure,
-		InstanceID:       resp.Compute.VMID,
+		InstanceID:       strings.TrimSpace(resp.Compute.VMID),
 		Region:           resp.Compute.Location,
 		AvailabilityZone: resp.Compute.Zone, // empty for zone-less deployments
 		InstanceType:     resp.Compute.VMSize,
 		AccountID:        resp.Compute.SubscriptionID,
 		// NetworkID intentionally empty — see function-level comment.
-	}, nil
+	}
+	// instance_id is the deterministic-match key. An otherwise-valid IMDS
+	// response with empty vmId would silently undermine reconcile — fail
+	// explicitly while still returning partial meta (cloud:provider=azure
+	// makes it into Server.tags).
+	if meta.InstanceID == "" {
+		return meta, fmt.Errorf("azure imds returned empty vmId")
+	}
+	return meta, nil
 }
 
 func (p *AzureProvider) fetchInstance(ctx context.Context) ([]byte, error) {

--- a/pkg/cloud/azure.go
+++ b/pkg/cloud/azure.go
@@ -60,9 +60,12 @@ func NewAzureWithBase(base string) *AzureProvider {
 // Name implements Provider.
 func (p *AzureProvider) Name() string { return ProviderAzure }
 
-// Probe issues the standard /metadata/instance request. Success confirms
-// Azure IMDS — AWS responds 401 here (no token) and GCP DNS won't resolve, so
-// the discriminator is reliable.
+// Probe issues the standard /metadata/instance request with the required
+// Metadata: true header and api-version query parameter. The combination of
+// path, header, and query param is the discriminator: AWS responds 401 on
+// /metadata/instance without a session token, and GCP responds non-200 on
+// any path that isn't under /computeMetadata/v1 with Metadata-Flavor: Google.
+// A 200 here is therefore a strong positive signal that this is Azure IMDS.
 func (p *AzureProvider) Probe(ctx context.Context) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, azureProbeTimeout)
 	defer cancel()

--- a/pkg/cloud/azure.go
+++ b/pkg/cloud/azure.go
@@ -130,5 +130,5 @@ func (p *AzureProvider) fetchInstance(ctx context.Context) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("instance http %d", resp.StatusCode)
 	}
-	return readLimitedN(resp.Body, azureResponseLimit)
+	return readLimited(resp.Body, azureResponseLimit)
 }

--- a/pkg/cloud/azure.go
+++ b/pkg/cloud/azure.go
@@ -1,0 +1,124 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Azure IMDS endpoint. Note that this lives on the same 169.254.169.254
+// link-local address as AWS but requires the Metadata:true header and an
+// api-version query param; AWS rejects requests with those, so the providers
+// don't accidentally cross-respond.
+const (
+	azureDefaultBase  = "http://169.254.169.254"
+	azureInstancePath = "/metadata/instance"
+	azureAPIVersion   = "2021-02-01"
+
+	azureHdrMetadata = "Metadata"
+	azureHdrValue    = "true"
+
+	azureResponseLimit = 32 * 1024 // Azure responses can be sizeable (full interface list)
+)
+
+const (
+	azureProbeTimeout = 800 * time.Millisecond
+	azureFetchTimeout = 2 * time.Second
+)
+
+type azureInstanceResponse struct {
+	Compute struct {
+		VMID           string `json:"vmId"`
+		Location       string `json:"location"`
+		Zone           string `json:"zone"`
+		VMSize         string `json:"vmSize"`
+		SubscriptionID string `json:"subscriptionId"`
+	} `json:"compute"`
+}
+
+// AzureProvider implements Provider against Azure Instance Metadata Service.
+type AzureProvider struct {
+	base   string
+	client *http.Client
+}
+
+// NewAzure returns an Azure provider pointed at the link-local IMDS endpoint.
+func NewAzure() *AzureProvider { return NewAzureWithBase(azureDefaultBase) }
+
+// NewAzureWithBase builds an Azure provider with an explicit base URL — used
+// by tests.
+func NewAzureWithBase(base string) *AzureProvider {
+	return &AzureProvider{
+		base: strings.TrimRight(base, "/"),
+		client: &http.Client{
+			Timeout: azureFetchTimeout + 500*time.Millisecond,
+		},
+	}
+}
+
+// Name implements Provider.
+func (p *AzureProvider) Name() string { return ProviderAzure }
+
+// Probe issues the standard /metadata/instance request. Success confirms
+// Azure IMDS — AWS responds 401 here (no token) and GCP DNS won't resolve, so
+// the discriminator is reliable.
+func (p *AzureProvider) Probe(ctx context.Context) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, azureProbeTimeout)
+	defer cancel()
+
+	_, err := p.fetchInstance(probeCtx)
+	return err == nil
+}
+
+// Fetch reads /metadata/instance and maps the response into Metadata. Azure
+// IMDS exposes everything in a single JSON document, so one HTTP call covers
+// all fields. NetworkID (VNet) is intentionally left empty: Azure IMDS exposes
+// only subnet prefix, not the VNet name — getting VNet requires ARM API +
+// managed identity, which is out of scope for V1.
+func (p *AzureProvider) Fetch(ctx context.Context) (*Metadata, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, azureFetchTimeout)
+	defer cancel()
+
+	body, err := p.fetchInstance(fetchCtx)
+	if err != nil {
+		return &Metadata{Provider: ProviderAzure}, fmt.Errorf("azure imds instance: %w", err)
+	}
+
+	var resp azureInstanceResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return &Metadata{Provider: ProviderAzure}, fmt.Errorf("azure imds parse: %w", err)
+	}
+
+	return &Metadata{
+		Provider:         ProviderAzure,
+		InstanceID:       resp.Compute.VMID,
+		Region:           resp.Compute.Location,
+		AvailabilityZone: resp.Compute.Zone, // empty for zone-less deployments
+		InstanceType:     resp.Compute.VMSize,
+		AccountID:        resp.Compute.SubscriptionID,
+		// NetworkID intentionally empty — see function-level comment.
+	}, nil
+}
+
+func (p *AzureProvider) fetchInstance(ctx context.Context) ([]byte, error) {
+	url := p.base + azureInstancePath + "?api-version=" + azureAPIVersion
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(azureHdrMetadata, azureHdrValue)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("instance http %d", resp.StatusCode)
+	}
+	return readLimitedN(resp.Body, azureResponseLimit)
+}

--- a/pkg/cloud/azure_test.go
+++ b/pkg/cloud/azure_test.go
@@ -145,6 +145,22 @@ func TestAzure_Fetch_ServerErrorReturnsPartial(t *testing.T) {
 	}
 }
 
+func TestAzure_Fetch_EmptyVMID_ReturnsError(t *testing.T) {
+	// IMDS returns a syntactically-valid response with empty compute.vmId.
+	// Fetch must surface that as an error since cloud:instance_id is the
+	// deterministic-match key for reconcile.
+	server := newAzureMockServer(t, azureMockOpts{vmID: " "})
+	defer server.Close()
+
+	meta, err := NewAzureWithBase(server.URL).Fetch(context.Background())
+	if err == nil {
+		t.Error("expected error when vmId is empty/whitespace")
+	}
+	if meta == nil || meta.Provider != ProviderAzure {
+		t.Errorf("expected partial Metadata with Provider=azure, got %+v", meta)
+	}
+}
+
 func TestAzure_Fetch_BadJSON(t *testing.T) {
 	server := newAzureMockServer(t, azureMockOpts{instanceBody: "{not valid"})
 	defer server.Close()

--- a/pkg/cloud/azure_test.go
+++ b/pkg/cloud/azure_test.go
@@ -120,19 +120,13 @@ func TestAzure_Fetch_ZoneEmpty(t *testing.T) {
 	}
 }
 
-func TestAzure_Probe_RejectsWithoutHeader(t *testing.T) {
-	server := newAzureMockServer(t, azureMockOpts{requireHeader: true})
-	defer server.Close()
-
-	p := NewAzureWithBase(server.URL)
-	if !p.Probe(context.Background()) {
-		t.Error("Probe should succeed when client sends Metadata: true")
-	}
-}
-
 func TestAzure_HeaderEnforcedByServer(t *testing.T) {
 	// If our client failed to send Metadata: true, this server would 400.
 	// We sanity-check that Probe still works.
+	//
+	// (The previously-adjacent TestAzure_Probe_RejectsWithoutHeader had the
+	// same setup and assertion but a misleading negative-sounding name —
+	// removed in favor of this clearly-named duplicate.)
 	server := newAzureMockServer(t, azureMockOpts{requireHeader: true})
 	defer server.Close()
 

--- a/pkg/cloud/azure_test.go
+++ b/pkg/cloud/azure_test.go
@@ -1,0 +1,166 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type azureMockOpts struct {
+	requireHeader  bool
+	requireVersion bool
+	instanceStatus int
+	instanceBody   string
+	zone           string
+	subscription   string
+	vmID           string
+	vmSize         string
+	location       string
+}
+
+func newAzureMockServer(t *testing.T, opts azureMockOpts) *httptest.Server {
+	t.Helper()
+
+	if opts.instanceStatus == 0 {
+		opts.instanceStatus = http.StatusOK
+	}
+	if opts.vmID == "" {
+		opts.vmID = "11111111-2222-3333-4444-555555555555"
+	}
+	if opts.location == "" {
+		opts.location = "eastus"
+	}
+	if opts.vmSize == "" {
+		opts.vmSize = "Standard_D2s_v3"
+	}
+	if opts.subscription == "" {
+		opts.subscription = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	}
+
+	if opts.instanceBody == "" {
+		body := azureInstanceResponse{}
+		body.Compute.VMID = opts.vmID
+		body.Compute.Location = opts.location
+		body.Compute.Zone = opts.zone
+		body.Compute.VMSize = opts.vmSize
+		body.Compute.SubscriptionID = opts.subscription
+		buf, _ := json.Marshal(body)
+		opts.instanceBody = string(buf)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(azureInstancePath, func(w http.ResponseWriter, r *http.Request) {
+		if opts.requireHeader && r.Header.Get(azureHdrMetadata) != azureHdrValue {
+			http.Error(w, "missing Metadata header", http.StatusBadRequest)
+			return
+		}
+		if opts.requireVersion && r.URL.Query().Get("api-version") == "" {
+			http.Error(w, "missing api-version", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(opts.instanceStatus)
+		_, _ = w.Write([]byte(opts.instanceBody))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestAzure_Fetch_HappyPath(t *testing.T) {
+	server := newAzureMockServer(t, azureMockOpts{
+		requireHeader:  true,
+		requireVersion: true,
+		zone:           "2",
+	})
+	defer server.Close()
+
+	p := NewAzureWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	checks := map[string]string{
+		"Provider":         ProviderAzure,
+		"InstanceID":       "11111111-2222-3333-4444-555555555555",
+		"Region":           "eastus",
+		"AvailabilityZone": "2",
+		"InstanceType":     "Standard_D2s_v3",
+		"AccountID":        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	}
+	got := map[string]string{
+		"Provider":         meta.Provider,
+		"InstanceID":       meta.InstanceID,
+		"Region":           meta.Region,
+		"AvailabilityZone": meta.AvailabilityZone,
+		"InstanceType":     meta.InstanceType,
+		"AccountID":        meta.AccountID,
+	}
+	for k, want := range checks {
+		if got[k] != want {
+			t.Errorf("%s = %q, want %q", k, got[k], want)
+		}
+	}
+	if meta.NetworkID != "" {
+		t.Errorf("NetworkID expected empty for Azure V1, got %q", meta.NetworkID)
+	}
+}
+
+func TestAzure_Fetch_ZoneEmpty(t *testing.T) {
+	server := newAzureMockServer(t, azureMockOpts{zone: ""})
+	defer server.Close()
+
+	meta, err := NewAzureWithBase(server.URL).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if meta.AvailabilityZone != "" {
+		t.Errorf("AZ should be empty for zone-less VM, got %q", meta.AvailabilityZone)
+	}
+}
+
+func TestAzure_Probe_RejectsWithoutHeader(t *testing.T) {
+	server := newAzureMockServer(t, azureMockOpts{requireHeader: true})
+	defer server.Close()
+
+	p := NewAzureWithBase(server.URL)
+	if !p.Probe(context.Background()) {
+		t.Error("Probe should succeed when client sends Metadata: true")
+	}
+}
+
+func TestAzure_HeaderEnforcedByServer(t *testing.T) {
+	// If our client failed to send Metadata: true, this server would 400.
+	// We sanity-check that Probe still works.
+	server := newAzureMockServer(t, azureMockOpts{requireHeader: true})
+	defer server.Close()
+
+	if !NewAzureWithBase(server.URL).Probe(context.Background()) {
+		t.Error("Probe failed: header not being sent?")
+	}
+}
+
+func TestAzure_Fetch_ServerErrorReturnsPartial(t *testing.T) {
+	server := newAzureMockServer(t, azureMockOpts{instanceStatus: http.StatusServiceUnavailable})
+	defer server.Close()
+
+	p := NewAzureWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err == nil {
+		t.Error("expected error on 503")
+	}
+	if meta == nil || meta.Provider != ProviderAzure {
+		t.Errorf("expected partial Metadata with Provider=azure, got %+v", meta)
+	}
+}
+
+func TestAzure_Fetch_BadJSON(t *testing.T) {
+	server := newAzureMockServer(t, azureMockOpts{instanceBody: "{not valid"})
+	defer server.Close()
+
+	_, err := NewAzureWithBase(server.URL).Fetch(context.Background())
+	if err == nil {
+		t.Error("expected parse error")
+	}
+}

--- a/pkg/cloud/azure_test.go
+++ b/pkg/cloud/azure_test.go
@@ -123,10 +123,6 @@ func TestAzure_Fetch_ZoneEmpty(t *testing.T) {
 func TestAzure_HeaderEnforcedByServer(t *testing.T) {
 	// If our client failed to send Metadata: true, this server would 400.
 	// We sanity-check that Probe still works.
-	//
-	// (The previously-adjacent TestAzure_Probe_RejectsWithoutHeader had the
-	// same setup and assertion but a misleading negative-sounding name —
-	// removed in favor of this clearly-named duplicate.)
 	server := newAzureMockServer(t, azureMockOpts{requireHeader: true})
 	defer server.Close()
 

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -1,0 +1,92 @@
+// Package cloud detects the host's cloud provider (AWS, GCP, Azure) via the
+// provider-specific instance metadata service (IMDS) and exposes the result
+// as a tag map prefixed cloud:* that alpacon-server matches against
+// CloudInstance records during reconcile.
+package cloud
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrNoCloudProvider is returned by Detect when no provider responds on the
+// link-local IMDS endpoint. This is the normal on-prem / dev-laptop / non-cloud
+// VM path — callers should treat it as a graceful degrade, not a failure.
+var ErrNoCloudProvider = errors.New("no cloud provider detected")
+
+// Provider names.
+const (
+	ProviderAWS   = "aws"
+	ProviderGCP   = "gcp"
+	ProviderAzure = "azure"
+)
+
+// Tag keys reported to alpacon-server. These match alpacon-server's
+// _build_cloud_tags schema (cloud_plan/tasks/PHASE3D).
+const (
+	TagProvider         = "cloud:provider"
+	TagInstanceID       = "cloud:instance_id"
+	TagRegion           = "cloud:region"
+	TagAvailabilityZone = "cloud:availability_zone"
+	TagInstanceType     = "cloud:instance_type"
+	TagNetworkID        = "cloud:network_id"
+	TagAccountID        = "cloud:account_id"
+)
+
+// Metadata is the provider-agnostic snapshot of cloud-instance attributes
+// that reconcile uses. Fields are best-effort: providers that cannot fetch
+// a particular field leave it empty, and ToTags omits empty values.
+type Metadata struct {
+	Provider         string
+	InstanceID       string
+	Region           string
+	AvailabilityZone string
+	InstanceType     string
+	NetworkID        string
+	AccountID        string
+}
+
+// ToTags converts Metadata to the cloud:* tag map. Empty fields are omitted so
+// they do not pollute Server.tags with blank values.
+func (m *Metadata) ToTags() map[string]string {
+	if m == nil {
+		return nil
+	}
+	tags := make(map[string]string, 7)
+	if m.Provider != "" {
+		tags[TagProvider] = m.Provider
+	}
+	if m.InstanceID != "" {
+		tags[TagInstanceID] = m.InstanceID
+	}
+	if m.Region != "" {
+		tags[TagRegion] = m.Region
+	}
+	if m.AvailabilityZone != "" {
+		tags[TagAvailabilityZone] = m.AvailabilityZone
+	}
+	if m.InstanceType != "" {
+		tags[TagInstanceType] = m.InstanceType
+	}
+	if m.NetworkID != "" {
+		tags[TagNetworkID] = m.NetworkID
+	}
+	if m.AccountID != "" {
+		tags[TagAccountID] = m.AccountID
+	}
+	return tags
+}
+
+// Provider is the cloud-specific IMDS client.
+//
+// Probe is a short-timeout reachability check (typically the cheapest GET that
+// proves the IMDS endpoint is the right provider). Fetch follows up with the
+// full metadata read. Once Probe returns true, the host is treated as being
+// on that provider — Detect never falls back to a different provider on Fetch
+// failure, because IMDS endpoints are provider-specific and partial data is
+// strictly better than wrong-provider data.
+type Provider interface {
+	Name() string
+	Probe(ctx context.Context) bool
+	Fetch(ctx context.Context) (*Metadata, error)
+}

--- a/pkg/cloud/detect.go
+++ b/pkg/cloud/detect.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-
-	"github.com/rs/zerolog/log"
 )
 
 // dmiPaths lists the sysfs DMI files queried for a cloud-provider hint on
@@ -25,8 +23,13 @@ var dmiPaths = []string{
 // hosts have a strong identifying string in sys_vendor / chassis_asset_tag).
 //
 // Return contract:
-//   - all probes fail: returns (nil, nil, ErrNoCloudProvider). Callers must
-//     treat this as a normal on-prem / dev path, not a failure.
+//   - all probes fail and ctx is healthy: returns
+//     (nil, nil, ErrNoCloudProvider). Callers must treat this as a normal
+//     on-prem / dev path, not a failure.
+//   - ctx is canceled or times out at any point: returns (nil, nil, ctx.Err()).
+//     This is distinct from ErrNoCloudProvider so callers can tell "no provider"
+//     apart from "detection aborted by timeout/cancel" — including the edge
+//     case where ctx expires during the last provider's Probe.
 //   - probe succeeds and Fetch succeeds: returns (provider, fullMeta, nil).
 //   - probe succeeds but Fetch errors mid-read: returns
 //     (provider, partialMeta, fetchErr). Caller gets to decide how to surface
@@ -34,9 +37,9 @@ var dmiPaths = []string{
 //     probe is positive — IMDS responses are provider-specific, so partial
 //     data is strictly better than wrong-provider data.
 //
-// Returning the Fetch error (rather than swallowing it) lets register surface
-// partial-detection diagnostics to the operator instead of silently shipping
-// an incomplete tag set.
+// Detect is a pure library function: it does not log. Callers that need to
+// surface failures (e.g. the register CLI) should inspect the returned error
+// and format it in their own output style.
 func Detect(ctx context.Context, providers []Provider) (Provider, *Metadata, error) {
 	if len(providers) == 0 {
 		return nil, nil, ErrNoCloudProvider
@@ -45,21 +48,24 @@ func Detect(ctx context.Context, providers []Provider) (Provider, *Metadata, err
 	ordered := reorderByDMI(providers, readDMIHint())
 
 	for _, p := range ordered {
-		if ctx.Err() != nil {
-			return nil, nil, ctx.Err()
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
 		}
 		if !p.Probe(ctx) {
 			continue
 		}
 
 		meta, err := p.Fetch(ctx)
-		if err != nil {
-			log.Warn().Err(err).Str("provider", p.Name()).Msg("cloud metadata fetch returned partial data")
-		}
 		if meta == nil {
 			meta = &Metadata{Provider: p.Name()}
 		}
 		return p, meta, err
+	}
+	// ctx may have expired during the last Probe; surface that rather than
+	// the generic ErrNoCloudProvider so callers can distinguish timeout from
+	// "host is not on any of the known clouds".
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
 	}
 	return nil, nil, ErrNoCloudProvider
 }

--- a/pkg/cloud/detect.go
+++ b/pkg/cloud/detect.go
@@ -1,0 +1,123 @@
+package cloud
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// dmiPaths lists the sysfs DMI files queried for a cloud-provider hint on
+// Linux. Order matters only as a tie-breaker — the first file whose contents
+// classify cleanly via classifyDMI wins.
+var dmiPaths = []string{
+	"/sys/class/dmi/id/sys_vendor",
+	"/sys/class/dmi/id/chassis_asset_tag",
+	"/sys/class/dmi/id/board_vendor",
+	"/sys/class/dmi/id/bios_vendor",
+}
+
+// Detect probes the supplied providers in order and returns the first one that
+// responds on its IMDS endpoint. On Linux, a DMI hint is consulted first so we
+// don't burn 800 ms probing the wrong provider on the common case (single-cloud
+// hosts have a strong identifying string in sys_vendor / chassis_asset_tag).
+//
+// Returns ErrNoCloudProvider when no provider responds. Callers must treat that
+// as a normal on-prem / dev path, not an error.
+//
+// If a provider's Probe succeeds but Fetch fails, we still return that provider
+// with whatever partial Metadata it produced. We never try a different provider
+// after a successful Probe — IMDS responses are provider-specific, so partial
+// data is better than wrong-provider data.
+func Detect(ctx context.Context, providers []Provider) (Provider, *Metadata, error) {
+	if len(providers) == 0 {
+		return nil, nil, ErrNoCloudProvider
+	}
+
+	ordered := reorderByDMI(providers, readDMIHint())
+
+	for _, p := range ordered {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+		if !p.Probe(ctx) {
+			continue
+		}
+
+		meta, err := p.Fetch(ctx)
+		if err != nil {
+			log.Warn().Err(err).Str("provider", p.Name()).Msg("cloud metadata fetch returned partial data")
+		}
+		if meta == nil {
+			meta = &Metadata{Provider: p.Name()}
+		}
+		return p, meta, nil
+	}
+	return nil, nil, ErrNoCloudProvider
+}
+
+// reorderByDMI moves the provider matching the DMI hint to the front. If the
+// hint is empty or doesn't match any provider, the original order is preserved.
+// This is a pure optimization — Detect's correctness does not depend on it.
+func reorderByDMI(providers []Provider, hint string) []Provider {
+	if hint == "" {
+		return providers
+	}
+	idx := -1
+	for i, p := range providers {
+		if p.Name() == hint {
+			idx = i
+			break
+		}
+	}
+	if idx <= 0 {
+		return providers
+	}
+	out := make([]Provider, 0, len(providers))
+	out = append(out, providers[idx])
+	out = append(out, providers[:idx]...)
+	out = append(out, providers[idx+1:]...)
+	return out
+}
+
+// readDMIHint returns a provider name ("aws"/"gcp"/"azure") if a DMI field
+// gives a strong signal, otherwise "". Linux-only — macOS and Windows skip
+// this and rely on Probe ordering.
+func readDMIHint() string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+	for _, path := range dmiPaths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if name := classifyDMI(string(data)); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+// classifyDMI examines a DMI field value and reports the matching provider.
+// Match patterns are conservative — we'd rather return "" (fall back to
+// sequential probing) than incorrectly skip a provider.
+func classifyDMI(value string) string {
+	v := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case strings.Contains(v, "amazon"), strings.Contains(v, "aws"):
+		return ProviderAWS
+	case strings.Contains(v, "google"):
+		return ProviderGCP
+	case strings.Contains(v, "microsoft corporation"):
+		return ProviderAzure
+	}
+	return ""
+}
+
+// DefaultProviders returns the production provider list in detect priority.
+func DefaultProviders() []Provider {
+	return []Provider{NewAWS(), NewGCP(), NewAzure()}
+}

--- a/pkg/cloud/detect.go
+++ b/pkg/cloud/detect.go
@@ -24,13 +24,19 @@ var dmiPaths = []string{
 // don't burn 800 ms probing the wrong provider on the common case (single-cloud
 // hosts have a strong identifying string in sys_vendor / chassis_asset_tag).
 //
-// Returns ErrNoCloudProvider when no provider responds. Callers must treat that
-// as a normal on-prem / dev path, not an error.
+// Return contract:
+//   - all probes fail: returns (nil, nil, ErrNoCloudProvider). Callers must
+//     treat this as a normal on-prem / dev path, not a failure.
+//   - probe succeeds and Fetch succeeds: returns (provider, fullMeta, nil).
+//   - probe succeeds but Fetch errors mid-read: returns
+//     (provider, partialMeta, fetchErr). Caller gets to decide how to surface
+//     the partial result. We never fall through to another provider once a
+//     probe is positive — IMDS responses are provider-specific, so partial
+//     data is strictly better than wrong-provider data.
 //
-// If a provider's Probe succeeds but Fetch fails, we still return that provider
-// with whatever partial Metadata it produced. We never try a different provider
-// after a successful Probe — IMDS responses are provider-specific, so partial
-// data is better than wrong-provider data.
+// Returning the Fetch error (rather than swallowing it) lets register surface
+// partial-detection diagnostics to the operator instead of silently shipping
+// an incomplete tag set.
 func Detect(ctx context.Context, providers []Provider) (Provider, *Metadata, error) {
 	if len(providers) == 0 {
 		return nil, nil, ErrNoCloudProvider
@@ -53,7 +59,7 @@ func Detect(ctx context.Context, providers []Provider) (Provider, *Metadata, err
 		if meta == nil {
 			meta = &Metadata{Provider: p.Name()}
 		}
-		return p, meta, nil
+		return p, meta, err
 	}
 	return nil, nil, ErrNoCloudProvider
 }

--- a/pkg/cloud/detect_test.go
+++ b/pkg/cloud/detect_test.go
@@ -1,0 +1,208 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// fakeProvider is a configurable in-memory Provider for testing Detect.
+type fakeProvider struct {
+	name       string
+	probeOK    bool
+	fetchMeta  *Metadata
+	fetchErr   error
+	probeCalls int
+	fetchCalls int
+}
+
+func (f *fakeProvider) Name() string { return f.name }
+func (f *fakeProvider) Probe(_ context.Context) bool {
+	f.probeCalls++
+	return f.probeOK
+}
+func (f *fakeProvider) Fetch(_ context.Context) (*Metadata, error) {
+	f.fetchCalls++
+	return f.fetchMeta, f.fetchErr
+}
+
+func TestDetect_FirstProbeWinsAndReturnsMetadata(t *testing.T) {
+	expected := &Metadata{Provider: ProviderAWS, InstanceID: "i-x"}
+	aws := &fakeProvider{name: ProviderAWS, probeOK: true, fetchMeta: expected}
+	gcp := &fakeProvider{name: ProviderGCP, probeOK: false}
+
+	p, meta, err := Detect(context.Background(), []Provider{aws, gcp})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if p.Name() != ProviderAWS {
+		t.Errorf("provider = %q, want aws", p.Name())
+	}
+	if meta != expected {
+		t.Errorf("meta = %+v, want %+v", meta, expected)
+	}
+	if gcp.probeCalls != 0 {
+		t.Errorf("GCP should not be probed after AWS succeeds, got %d", gcp.probeCalls)
+	}
+}
+
+func TestDetect_AllProbesFail_ReturnsErr(t *testing.T) {
+	aws := &fakeProvider{name: ProviderAWS}
+	gcp := &fakeProvider{name: ProviderGCP}
+	azure := &fakeProvider{name: ProviderAzure}
+
+	_, _, err := Detect(context.Background(), []Provider{aws, gcp, azure})
+	if !errors.Is(err, ErrNoCloudProvider) {
+		t.Errorf("err = %v, want ErrNoCloudProvider", err)
+	}
+}
+
+func TestDetect_FetchError_StillReturnsProvider(t *testing.T) {
+	// Probe succeeds, Fetch returns partial Metadata + error. Detect must NOT
+	// fall through to another provider — host IS on AWS.
+	partial := &Metadata{Provider: ProviderAWS}
+	aws := &fakeProvider{name: ProviderAWS, probeOK: true, fetchMeta: partial, fetchErr: errors.New("partial fetch")}
+	gcp := &fakeProvider{name: ProviderGCP, probeOK: true, fetchMeta: &Metadata{Provider: ProviderGCP}}
+
+	p, meta, err := Detect(context.Background(), []Provider{aws, gcp})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if p.Name() != ProviderAWS {
+		t.Errorf("Detect fell through to %q; should stick with AWS", p.Name())
+	}
+	if meta.Provider != ProviderAWS {
+		t.Errorf("meta.Provider = %q, want aws", meta.Provider)
+	}
+	if gcp.fetchCalls != 0 {
+		t.Error("GCP must not be fetched after AWS probe succeeded")
+	}
+}
+
+func TestDetect_NilMetaFromFetch_ReturnsProviderOnlyMeta(t *testing.T) {
+	// If a provider returns nil metadata + error, Detect must still surface
+	// a non-nil Metadata so callers can call .ToTags() safely.
+	aws := &fakeProvider{name: ProviderAWS, probeOK: true, fetchMeta: nil, fetchErr: errors.New("nil")}
+
+	_, meta, err := Detect(context.Background(), []Provider{aws})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if meta == nil || meta.Provider != ProviderAWS {
+		t.Errorf("expected non-nil meta with Provider=aws, got %+v", meta)
+	}
+}
+
+func TestDetect_EmptyProviders(t *testing.T) {
+	_, _, err := Detect(context.Background(), nil)
+	if !errors.Is(err, ErrNoCloudProvider) {
+		t.Errorf("err = %v, want ErrNoCloudProvider", err)
+	}
+}
+
+func TestDetect_ContextCancelled(t *testing.T) {
+	aws := &fakeProvider{name: ProviderAWS}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := Detect(ctx, []Provider{aws})
+	if err == nil {
+		t.Error("expected ctx err when context cancelled before probe")
+	}
+}
+
+func TestDetect_ContextDeadlineRespectedBetweenProbes(t *testing.T) {
+	slow := &fakeProvider{name: ProviderAWS, probeOK: false}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	// Add a synthetic delay between probes by sleeping in Probe. We can't easily
+	// embed a sleep in the fake, but the failing-probe case still validates the
+	// ctx.Err short-circuit inside the loop.
+	_, _, err := Detect(ctx, []Provider{slow, slow, slow})
+	// Either the ctx error or ErrNoCloudProvider is acceptable here; we just
+	// don't want it to hang.
+	if err == nil {
+		t.Error("expected an error")
+	}
+}
+
+func TestReorderByDMI_NoHint(t *testing.T) {
+	aws := &fakeProvider{name: ProviderAWS}
+	gcp := &fakeProvider{name: ProviderGCP}
+	azure := &fakeProvider{name: ProviderAzure}
+
+	out := reorderByDMI([]Provider{aws, gcp, azure}, "")
+	if len(out) != 3 || out[0] != aws || out[1] != gcp || out[2] != azure {
+		t.Errorf("reorder with empty hint should preserve order, got %v", out)
+	}
+}
+
+func TestReorderByDMI_HintMovesProviderToFront(t *testing.T) {
+	aws := &fakeProvider{name: ProviderAWS}
+	gcp := &fakeProvider{name: ProviderGCP}
+	azure := &fakeProvider{name: ProviderAzure}
+
+	out := reorderByDMI([]Provider{aws, gcp, azure}, ProviderAzure)
+	if out[0].Name() != ProviderAzure {
+		t.Errorf("hint=azure should put azure first; got %q", out[0].Name())
+	}
+	// Other providers stay in relative order
+	if out[1].Name() != ProviderAWS || out[2].Name() != ProviderGCP {
+		t.Errorf("remaining order wrong: got %q, %q", out[1].Name(), out[2].Name())
+	}
+}
+
+func TestReorderByDMI_HintAlreadyFirst(t *testing.T) {
+	aws := &fakeProvider{name: ProviderAWS}
+	gcp := &fakeProvider{name: ProviderGCP}
+
+	out := reorderByDMI([]Provider{aws, gcp}, ProviderAWS)
+	if out[0] != aws || out[1] != gcp {
+		t.Errorf("hint already first should preserve order")
+	}
+}
+
+func TestReorderByDMI_HintNotMatched(t *testing.T) {
+	aws := &fakeProvider{name: ProviderAWS}
+	gcp := &fakeProvider{name: ProviderGCP}
+
+	out := reorderByDMI([]Provider{aws, gcp}, "unknown-provider")
+	if out[0] != aws || out[1] != gcp {
+		t.Errorf("unmatched hint should preserve order")
+	}
+}
+
+func TestClassifyDMI(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Amazon EC2", ProviderAWS},
+		{"amazon", ProviderAWS},
+		{"AWS Nitro", ProviderAWS},
+		{"Google", ProviderGCP},
+		{"Google Compute Engine", ProviderGCP},
+		{"Microsoft Corporation", ProviderAzure},
+		{"  microsoft corporation\n", ProviderAzure},
+		{"VMware, Inc.", ""},
+		{"QEMU", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := classifyDMI(c.in); got != c.want {
+			t.Errorf("classifyDMI(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestReadDMIHint_NonLinuxReturnsEmpty(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("skipping non-Linux path on Linux")
+	}
+	if got := readDMIHint(); got != "" {
+		t.Errorf("non-Linux readDMIHint should return \"\", got %q", got)
+	}
+}

--- a/pkg/cloud/detect_test.go
+++ b/pkg/cloud/detect_test.go
@@ -156,6 +156,29 @@ func TestDetect_ContextDeadlineRespectedBetweenProbes(t *testing.T) {
 	}
 }
 
+func TestDetect_ContextExpiresDuringLastProbe_ReturnsCtxErr(t *testing.T) {
+	// Regression: if ctx expires DURING the final provider's Probe (not before
+	// the next iteration's top-of-loop check), Detect previously fell out and
+	// returned ErrNoCloudProvider — losing the real ctx error. The fix is a
+	// final ctx.Err() check before returning ErrNoCloudProvider.
+	//
+	// Setup: ctx deadline 30ms; single slow probe that sleeps 60ms. The probe
+	// returns false (via its own ctx.Done case) AFTER ctx expires. Without the
+	// post-loop ctx.Err() check, Detect would return ErrNoCloudProvider; with
+	// the check it returns context.DeadlineExceeded.
+	slow := &fakeProvider{name: ProviderAWS, probeOK: false, probeDelay: 60 * time.Millisecond}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, _, err := Detect(ctx, []Provider{slow})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded, got %v", err)
+	}
+	if errors.Is(err, ErrNoCloudProvider) {
+		t.Error("must not collapse ctx deadline into ErrNoCloudProvider")
+	}
+}
+
 func TestReorderByDMI_NoHint(t *testing.T) {
 	aws := &fakeProvider{name: ProviderAWS}
 	gcp := &fakeProvider{name: ProviderGCP}

--- a/pkg/cloud/detect_test.go
+++ b/pkg/cloud/detect_test.go
@@ -126,11 +126,15 @@ func TestDetect_ContextCancelled(t *testing.T) {
 }
 
 func TestDetect_ContextDeadlineRespectedBetweenProbes(t *testing.T) {
-	// Each fake probe sleeps 30ms; ctx deadline is 50ms so 1st probe completes
-	// (fails) then ctx.Err short-circuit fires before the 2nd probe sleeps.
-	// Without the in-loop ctx.Err check, this test would still hang for 90ms+
-	// because each probe respects ctx but Detect would keep iterating; with the
-	// short-circuit Detect returns the ctx error promptly after 1-2 probes.
+	// Each fake probe sleeps 30ms; ctx deadline is 50ms. With the in-loop
+	// ctx.Err short-circuit working correctly, Detect returns
+	// context.DeadlineExceeded after 1-2 probes — not ErrNoCloudProvider.
+	//
+	// If the short-circuit regresses (e.g. the ctx.Err check is removed),
+	// each probe still returns quickly via its own ctx.Done case, the loop
+	// drains all providers, and Detect falls out with ErrNoCloudProvider.
+	// Tolerating ErrNoCloudProvider here would silently accept that
+	// regression, so the assertion requires DeadlineExceeded strictly.
 	slow := func() *fakeProvider {
 		return &fakeProvider{name: ProviderAWS, probeOK: false, probeDelay: 30 * time.Millisecond}
 	}
@@ -141,13 +145,12 @@ func TestDetect_ContextDeadlineRespectedBetweenProbes(t *testing.T) {
 	_, _, err := Detect(ctx, []Provider{slow(), slow(), slow()})
 	elapsed := time.Since(start)
 
-	// ctx error (deadline) is the expected signal here, not ErrNoCloudProvider.
-	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, ErrNoCloudProvider) {
-		t.Errorf("expected DeadlineExceeded or ErrNoCloudProvider, got %v", err)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded, got %v", err)
 	}
-	// Loose upper bound: with the short-circuit Detect should return well
-	// before all 3 probes complete (3 * 30ms = 90ms). Allow generous slack for
-	// CI scheduling jitter.
+	// Upper bound guards against the regression where Detect ignores the
+	// deadline and serializes all probes (3 * 30ms = 90ms). Generous slack
+	// for CI scheduling jitter.
 	if elapsed > 200*time.Millisecond {
 		t.Errorf("Detect ran for %v; ctx short-circuit appears broken", elapsed)
 	}

--- a/pkg/cloud/detect_test.go
+++ b/pkg/cloud/detect_test.go
@@ -12,6 +12,7 @@ import (
 type fakeProvider struct {
 	name       string
 	probeOK    bool
+	probeDelay time.Duration // sleep inside Probe to exercise ctx cancellation paths
 	fetchMeta  *Metadata
 	fetchErr   error
 	probeCalls int
@@ -19,8 +20,15 @@ type fakeProvider struct {
 }
 
 func (f *fakeProvider) Name() string { return f.name }
-func (f *fakeProvider) Probe(_ context.Context) bool {
+func (f *fakeProvider) Probe(ctx context.Context) bool {
 	f.probeCalls++
+	if f.probeDelay > 0 {
+		select {
+		case <-time.After(f.probeDelay):
+		case <-ctx.Done():
+			return false
+		}
+	}
 	return f.probeOK
 }
 func (f *fakeProvider) Fetch(_ context.Context) (*Metadata, error) {
@@ -60,15 +68,17 @@ func TestDetect_AllProbesFail_ReturnsErr(t *testing.T) {
 }
 
 func TestDetect_FetchError_StillReturnsProvider(t *testing.T) {
-	// Probe succeeds, Fetch returns partial Metadata + error. Detect must NOT
+	// Probe succeeds, Fetch returns partial Metadata + error. Detect surfaces
+	// the error to the caller alongside the partial Metadata, and must NOT
 	// fall through to another provider — host IS on AWS.
 	partial := &Metadata{Provider: ProviderAWS}
-	aws := &fakeProvider{name: ProviderAWS, probeOK: true, fetchMeta: partial, fetchErr: errors.New("partial fetch")}
+	fetchErr := errors.New("partial fetch")
+	aws := &fakeProvider{name: ProviderAWS, probeOK: true, fetchMeta: partial, fetchErr: fetchErr}
 	gcp := &fakeProvider{name: ProviderGCP, probeOK: true, fetchMeta: &Metadata{Provider: ProviderGCP}}
 
 	p, meta, err := Detect(context.Background(), []Provider{aws, gcp})
-	if err != nil {
-		t.Fatalf("Detect: %v", err)
+	if !errors.Is(err, fetchErr) {
+		t.Errorf("expected Detect to surface fetch error, got %v", err)
 	}
 	if p.Name() != ProviderAWS {
 		t.Errorf("Detect fell through to %q; should stick with AWS", p.Name())
@@ -83,12 +93,14 @@ func TestDetect_FetchError_StillReturnsProvider(t *testing.T) {
 
 func TestDetect_NilMetaFromFetch_ReturnsProviderOnlyMeta(t *testing.T) {
 	// If a provider returns nil metadata + error, Detect must still surface
-	// a non-nil Metadata so callers can call .ToTags() safely.
-	aws := &fakeProvider{name: ProviderAWS, probeOK: true, fetchMeta: nil, fetchErr: errors.New("nil")}
+	// a non-nil Metadata so callers can call .ToTags() safely, and surface
+	// the error so callers know detection was partial.
+	fetchErr := errors.New("nil")
+	aws := &fakeProvider{name: ProviderAWS, probeOK: true, fetchMeta: nil, fetchErr: fetchErr}
 
 	_, meta, err := Detect(context.Background(), []Provider{aws})
-	if err != nil {
-		t.Fatalf("Detect: %v", err)
+	if !errors.Is(err, fetchErr) {
+		t.Errorf("expected Detect to surface fetch error, got %v", err)
 	}
 	if meta == nil || meta.Provider != ProviderAWS {
 		t.Errorf("expected non-nil meta with Provider=aws, got %+v", meta)
@@ -114,18 +126,30 @@ func TestDetect_ContextCancelled(t *testing.T) {
 }
 
 func TestDetect_ContextDeadlineRespectedBetweenProbes(t *testing.T) {
-	slow := &fakeProvider{name: ProviderAWS, probeOK: false}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	// Each fake probe sleeps 30ms; ctx deadline is 50ms so 1st probe completes
+	// (fails) then ctx.Err short-circuit fires before the 2nd probe sleeps.
+	// Without the in-loop ctx.Err check, this test would still hang for 90ms+
+	// because each probe respects ctx but Detect would keep iterating; with the
+	// short-circuit Detect returns the ctx error promptly after 1-2 probes.
+	slow := func() *fakeProvider {
+		return &fakeProvider{name: ProviderAWS, probeOK: false, probeDelay: 30 * time.Millisecond}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	// Add a synthetic delay between probes by sleeping in Probe. We can't easily
-	// embed a sleep in the fake, but the failing-probe case still validates the
-	// ctx.Err short-circuit inside the loop.
-	_, _, err := Detect(ctx, []Provider{slow, slow, slow})
-	// Either the ctx error or ErrNoCloudProvider is acceptable here; we just
-	// don't want it to hang.
-	if err == nil {
-		t.Error("expected an error")
+	start := time.Now()
+	_, _, err := Detect(ctx, []Provider{slow(), slow(), slow()})
+	elapsed := time.Since(start)
+
+	// ctx error (deadline) is the expected signal here, not ErrNoCloudProvider.
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, ErrNoCloudProvider) {
+		t.Errorf("expected DeadlineExceeded or ErrNoCloudProvider, got %v", err)
+	}
+	// Loose upper bound: with the short-circuit Detect should return well
+	// before all 3 probes complete (3 * 30ms = 90ms). Allow generous slack for
+	// CI scheduling jitter.
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("Detect ran for %v; ctx short-circuit appears broken", elapsed)
 	}
 }
 

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -21,7 +21,7 @@ import (
 //   - Provider discrimination: cross-fire on the shared 169.254.169.254 with
 //     AWS and Azure is prevented by the Metadata-Flavor: Google REQUEST header
 //     (which AWS/Azure won't echo) and the response-header validation in
-//     get() (added in iteration 1).
+//     get() that requires Metadata-Flavor: Google in the response.
 //
 // GCE listens on both 169.254.169.254 (IPv4) and fd00:ec2::254 (IPv6). We use
 // IPv4 to match AWS/Azure; IPv6-only GCE hosts are rare and can be supported

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -99,9 +100,9 @@ func (p *GCPProvider) Fetch(ctx context.Context) (*Metadata, error) {
 	meta.InstanceID = strings.TrimSpace(string(id))
 	// instance_id is the deterministic-match key. A misbehaving IMDS that
 	// returns 200 with an empty body would otherwise produce a useless tag
-	// set with no cloud:instance_id — fail explicitly instead.
+	// set with no cloud:instance_id, so fail explicitly instead.
 	if meta.InstanceID == "" {
-		return meta, fmt.Errorf("gcp imds returned empty instance id")
+		return meta, errors.New("gcp imds returned empty instance id")
 	}
 
 	if zone, err := p.get(fetchCtx, gcpZonePath); err == nil {

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -137,11 +137,20 @@ func basename(s string) string {
 }
 
 // zoneToRegion strips the trailing zone suffix from a GCE zone name.
-// "us-central1-a" → "us-central1". A zone without a trailing "-X" is returned
-// unchanged (defensive — should not happen in practice).
+// "us-central1-a" → "us-central1". GCE zones are always region-letter where
+// letter is exactly one character (a/b/c/...). If the final segment after the
+// last "-" is anything other than one character, the input is treated as
+// already a region (or otherwise malformed) and returned unchanged. This
+// guards against inputs like "us-central1" being incorrectly chopped to "us".
 func zoneToRegion(zone string) string {
-	if idx := strings.LastIndex(zone, "-"); idx > 0 {
-		return zone[:idx]
+	idx := strings.LastIndex(zone, "-")
+	if idx <= 0 {
+		return zone
 	}
-	return zone
+	if len(zone)-idx-1 != 1 {
+		// suffix is not a single zone letter — input is already a region or
+		// is otherwise non-zone-shaped (defensive).
+		return zone
+	}
+	return zone[:idx]
 }

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -8,11 +8,26 @@ import (
 	"time"
 )
 
-// GCE metadata server endpoints. The hostname metadata.google.internal resolves
-// to 169.254.169.254 (and to fd00:ec2::254 on IPv6 GCE), but we use the
-// hostname so the request fails fast on non-GCP hosts where DNS won't resolve.
+// GCE metadata server endpoints. We target the link-local IP directly rather
+// than the canonical hostname metadata.google.internal. Reasoning:
+//
+//   - DNS dependency: a hostname lookup can resolve to a non-link-local
+//     address on hosts with split-horizon DNS, custom search domains, or a
+//     compromised resolver, allowing off-host HTTP requests that may spoof
+//     GCE responses and produce wrong cloud:* tags. The IP cannot be
+//     redirected by DNS.
+//   - Defense in depth: AWS and Azure already use link-local IPs. Using the
+//     same approach for GCP gives us a uniform untrustworthy-network policy.
+//   - Provider discrimination: cross-fire on the shared 169.254.169.254 with
+//     AWS and Azure is prevented by the Metadata-Flavor: Google REQUEST header
+//     (which AWS/Azure won't echo) and the response-header validation in
+//     get() (added in iteration 1).
+//
+// GCE listens on both 169.254.169.254 (IPv4) and fd00:ec2::254 (IPv6). We use
+// IPv4 to match AWS/Azure; IPv6-only GCE hosts are rare and can be supported
+// by future override via NewGCPWithBase.
 const (
-	gcpDefaultBase = "http://metadata.google.internal"
+	gcpDefaultBase = "http://169.254.169.254"
 
 	gcpInstanceIDPath  = "/computeMetadata/v1/instance/id"
 	gcpZonePath        = "/computeMetadata/v1/instance/zone"

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -42,22 +42,22 @@ type GCPProvider struct {
 // NewGCP returns a GCP provider pointed at metadata.google.internal.
 func NewGCP() *GCPProvider { return NewGCPWithBase(gcpDefaultBase) }
 
-// NewGCPWithBase constructs a GCP provider against an arbitrary base URL — used
+// NewGCPWithBase constructs a GCP provider against an arbitrary base URL. Used
 // by tests.
 func NewGCPWithBase(base string) *GCPProvider {
 	return &GCPProvider{
-		base: strings.TrimRight(base, "/"),
-		client: &http.Client{
-			Timeout: gcpFetchTimeout + 500*time.Millisecond,
-		},
+		base:   strings.TrimRight(base, "/"),
+		client: newIMDSClient(gcpFetchTimeout + 500*time.Millisecond),
 	}
 }
 
 // Name implements Provider.
 func (p *GCPProvider) Name() string { return ProviderGCP }
 
-// Probe reads the instance-id endpoint. A successful 200 with the right
-// Metadata-Flavor header echoed back is the strongest signal that this is GCE.
+// Probe reads the instance-id endpoint. A successful 200 with the
+// Metadata-Flavor: Google response header (validated inside get) is the
+// strongest signal that this is GCE — bare 200s without the header are
+// rejected as not-GCP (e.g. a captive portal returning a generic 200).
 func (p *GCPProvider) Probe(ctx context.Context) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, gcpProbeTimeout)
 	defer cancel()
@@ -114,6 +114,13 @@ func (p *GCPProvider) get(ctx context.Context, path string) ([]byte, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("gcp %s http %d", path, resp.StatusCode)
+	}
+	// GCE metadata server always echoes Metadata-Flavor: Google in responses.
+	// Absence rules out a real GCE responder (a captive portal or spoofed
+	// 169.254.169.254 listener could return 200 to anything), so we treat the
+	// header as authoritative provider discrimination, not just a hint.
+	if got := resp.Header.Get(gcpFlavorHeader); got != gcpFlavorValue {
+		return nil, fmt.Errorf("gcp %s missing Metadata-Flavor response header (got %q)", path, got)
 	}
 	return readLimitedN(resp.Body, gcpResponseLimit)
 }

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -97,6 +97,12 @@ func (p *GCPProvider) Fetch(ctx context.Context) (*Metadata, error) {
 		return meta, fmt.Errorf("gcp instance-id: %w", err)
 	}
 	meta.InstanceID = strings.TrimSpace(string(id))
+	// instance_id is the deterministic-match key. A misbehaving IMDS that
+	// returns 200 with an empty body would otherwise produce a useless tag
+	// set with no cloud:instance_id — fail explicitly instead.
+	if meta.InstanceID == "" {
+		return meta, fmt.Errorf("gcp imds returned empty instance id")
+	}
 
 	if zone, err := p.get(fetchCtx, gcpZonePath); err == nil {
 		az := basename(string(zone))

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -54,7 +54,9 @@ type GCPProvider struct {
 	client *http.Client
 }
 
-// NewGCP returns a GCP provider pointed at metadata.google.internal.
+// NewGCP returns a GCP provider pointed at the link-local IP 169.254.169.254
+// (see gcpDefaultBase for why we use the IP directly rather than the canonical
+// metadata.google.internal hostname).
 func NewGCP() *GCPProvider { return NewGCPWithBase(gcpDefaultBase) }
 
 // NewGCPWithBase constructs a GCP provider against an arbitrary base URL. Used

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -1,0 +1,140 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// GCE metadata server endpoints. The hostname metadata.google.internal resolves
+// to 169.254.169.254 (and to fd00:ec2::254 on IPv6 GCE), but we use the
+// hostname so the request fails fast on non-GCP hosts where DNS won't resolve.
+const (
+	gcpDefaultBase = "http://metadata.google.internal"
+
+	gcpInstanceIDPath  = "/computeMetadata/v1/instance/id"
+	gcpZonePath        = "/computeMetadata/v1/instance/zone"
+	gcpMachineTypePath = "/computeMetadata/v1/instance/machine-type"
+	gcpNetworkPath     = "/computeMetadata/v1/instance/network-interfaces/0/network"
+	gcpProjectIDPath   = "/computeMetadata/v1/project/project-id"
+
+	// gcpFlavorHeader prevents accidental cross-origin reads — GCE rejects
+	// requests without this exact header.
+	gcpFlavorHeader = "Metadata-Flavor"
+	gcpFlavorValue  = "Google"
+
+	gcpResponseLimit = 4 * 1024
+)
+
+const (
+	gcpProbeTimeout = 800 * time.Millisecond
+	gcpFetchTimeout = 2 * time.Second
+)
+
+// GCPProvider implements Provider against the GCE metadata server.
+type GCPProvider struct {
+	base   string
+	client *http.Client
+}
+
+// NewGCP returns a GCP provider pointed at metadata.google.internal.
+func NewGCP() *GCPProvider { return NewGCPWithBase(gcpDefaultBase) }
+
+// NewGCPWithBase constructs a GCP provider against an arbitrary base URL — used
+// by tests.
+func NewGCPWithBase(base string) *GCPProvider {
+	return &GCPProvider{
+		base: strings.TrimRight(base, "/"),
+		client: &http.Client{
+			Timeout: gcpFetchTimeout + 500*time.Millisecond,
+		},
+	}
+}
+
+// Name implements Provider.
+func (p *GCPProvider) Name() string { return ProviderGCP }
+
+// Probe reads the instance-id endpoint. A successful 200 with the right
+// Metadata-Flavor header echoed back is the strongest signal that this is GCE.
+func (p *GCPProvider) Probe(ctx context.Context) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, gcpProbeTimeout)
+	defer cancel()
+
+	_, err := p.get(probeCtx, gcpInstanceIDPath)
+	return err == nil
+}
+
+// Fetch retrieves the full metadata snapshot. Each sub-fetch is best-effort —
+// failures leave the corresponding Metadata field empty rather than aborting
+// the whole call, since GCE returns 404 (not 500) for genuinely-missing fields.
+func (p *GCPProvider) Fetch(ctx context.Context) (*Metadata, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, gcpFetchTimeout)
+	defer cancel()
+
+	meta := &Metadata{Provider: ProviderGCP}
+
+	id, err := p.get(fetchCtx, gcpInstanceIDPath)
+	if err != nil {
+		return meta, fmt.Errorf("gcp instance-id: %w", err)
+	}
+	meta.InstanceID = strings.TrimSpace(string(id))
+
+	if zone, err := p.get(fetchCtx, gcpZonePath); err == nil {
+		az := basename(string(zone))
+		meta.AvailabilityZone = az
+		meta.Region = zoneToRegion(az)
+	}
+	if mt, err := p.get(fetchCtx, gcpMachineTypePath); err == nil {
+		meta.InstanceType = basename(string(mt))
+	}
+	if net, err := p.get(fetchCtx, gcpNetworkPath); err == nil {
+		meta.NetworkID = basename(string(net))
+	}
+	if proj, err := p.get(fetchCtx, gcpProjectIDPath); err == nil {
+		meta.AccountID = strings.TrimSpace(string(proj))
+	}
+
+	return meta, nil
+}
+
+func (p *GCPProvider) get(ctx context.Context, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.base+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(gcpFlavorHeader, gcpFlavorValue)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gcp %s http %d", path, resp.StatusCode)
+	}
+	return readLimitedN(resp.Body, gcpResponseLimit)
+}
+
+// basename returns the final path segment of a slash-separated string.
+// GCE metadata returns full resource paths like "projects/123/zones/us-central1-a";
+// we only care about the leaf.
+func basename(s string) string {
+	s = strings.TrimSpace(s)
+	if idx := strings.LastIndex(s, "/"); idx >= 0 {
+		return s[idx+1:]
+	}
+	return s
+}
+
+// zoneToRegion strips the trailing zone suffix from a GCE zone name.
+// "us-central1-a" → "us-central1". A zone without a trailing "-X" is returned
+// unchanged (defensive — should not happen in practice).
+func zoneToRegion(zone string) string {
+	if idx := strings.LastIndex(zone, "-"); idx > 0 {
+		return zone[:idx]
+	}
+	return zone
+}

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -146,7 +146,7 @@ func (p *GCPProvider) get(ctx context.Context, path string) ([]byte, error) {
 	if got := resp.Header.Get(gcpFlavorHeader); got != gcpFlavorValue {
 		return nil, fmt.Errorf("gcp %s missing Metadata-Flavor response header (got %q)", path, got)
 	}
-	return readLimitedN(resp.Body, gcpResponseLimit)
+	return readLimited(resp.Body, gcpResponseLimit)
 }
 
 // basename returns the final path segment of a slash-separated string.

--- a/pkg/cloud/gcp_test.go
+++ b/pkg/cloud/gcp_test.go
@@ -1,0 +1,237 @@
+package cloud
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+type gcpMockOpts struct {
+	requireFlavor    bool
+	instanceIDStatus int
+	instanceIDBody   string
+	zoneStatus       int
+	zoneBody         string
+	machineStatus    int
+	machineBody      string
+	networkStatus    int
+	networkBody      string
+	projectStatus    int
+	projectBody      string
+}
+
+func newGCPMockServer(t *testing.T, opts gcpMockOpts) *httptest.Server {
+	t.Helper()
+
+	if opts.instanceIDStatus == 0 {
+		opts.instanceIDStatus = http.StatusOK
+	}
+	if opts.instanceIDBody == "" {
+		opts.instanceIDBody = "1234567890123456789"
+	}
+	if opts.zoneStatus == 0 {
+		opts.zoneStatus = http.StatusOK
+	}
+	if opts.zoneBody == "" {
+		opts.zoneBody = "projects/123/zones/us-central1-a"
+	}
+	if opts.machineStatus == 0 {
+		opts.machineStatus = http.StatusOK
+	}
+	if opts.machineBody == "" {
+		opts.machineBody = "projects/123/machineTypes/e2-medium"
+	}
+	if opts.networkStatus == 0 {
+		opts.networkStatus = http.StatusOK
+	}
+	if opts.networkBody == "" {
+		opts.networkBody = "projects/123/networks/default"
+	}
+	if opts.projectStatus == 0 {
+		opts.projectStatus = http.StatusOK
+	}
+	if opts.projectBody == "" {
+		opts.projectBody = "my-project"
+	}
+
+	mux := http.NewServeMux()
+	guard := func(w http.ResponseWriter, r *http.Request) bool {
+		if opts.requireFlavor && r.Header.Get(gcpFlavorHeader) != gcpFlavorValue {
+			http.Error(w, "missing Metadata-Flavor", http.StatusForbidden)
+			return false
+		}
+		return true
+	}
+
+	mux.HandleFunc(gcpInstanceIDPath, func(w http.ResponseWriter, r *http.Request) {
+		if !guard(w, r) {
+			return
+		}
+		w.WriteHeader(opts.instanceIDStatus)
+		_, _ = w.Write([]byte(opts.instanceIDBody))
+	})
+	mux.HandleFunc(gcpZonePath, func(w http.ResponseWriter, r *http.Request) {
+		if !guard(w, r) {
+			return
+		}
+		w.WriteHeader(opts.zoneStatus)
+		_, _ = w.Write([]byte(opts.zoneBody))
+	})
+	mux.HandleFunc(gcpMachineTypePath, func(w http.ResponseWriter, r *http.Request) {
+		if !guard(w, r) {
+			return
+		}
+		w.WriteHeader(opts.machineStatus)
+		_, _ = w.Write([]byte(opts.machineBody))
+	})
+	mux.HandleFunc(gcpNetworkPath, func(w http.ResponseWriter, r *http.Request) {
+		if !guard(w, r) {
+			return
+		}
+		w.WriteHeader(opts.networkStatus)
+		_, _ = w.Write([]byte(opts.networkBody))
+	})
+	mux.HandleFunc(gcpProjectIDPath, func(w http.ResponseWriter, r *http.Request) {
+		if !guard(w, r) {
+			return
+		}
+		w.WriteHeader(opts.projectStatus)
+		_, _ = w.Write([]byte(opts.projectBody))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestGCP_Fetch_HappyPath(t *testing.T) {
+	server := newGCPMockServer(t, gcpMockOpts{requireFlavor: true})
+	defer server.Close()
+
+	p := NewGCPWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	checks := map[string]string{
+		"Provider":         ProviderGCP,
+		"InstanceID":       "1234567890123456789",
+		"Region":           "us-central1",
+		"AvailabilityZone": "us-central1-a",
+		"InstanceType":     "e2-medium",
+		"NetworkID":        "default",
+		"AccountID":        "my-project",
+	}
+	got := map[string]string{
+		"Provider":         meta.Provider,
+		"InstanceID":       meta.InstanceID,
+		"Region":           meta.Region,
+		"AvailabilityZone": meta.AvailabilityZone,
+		"InstanceType":     meta.InstanceType,
+		"NetworkID":        meta.NetworkID,
+		"AccountID":        meta.AccountID,
+	}
+	for k, want := range checks {
+		if got[k] != want {
+			t.Errorf("%s = %q, want %q", k, got[k], want)
+		}
+	}
+}
+
+func TestGCP_Probe_RejectsWithoutFlavorHeader(t *testing.T) {
+	// Server requires Metadata-Flavor header — if we sent the right one, Probe succeeds.
+	server := newGCPMockServer(t, gcpMockOpts{requireFlavor: true})
+	defer server.Close()
+
+	p := NewGCPWithBase(server.URL)
+	if !p.Probe(context.Background()) {
+		t.Error("Probe should pass when Metadata-Flavor is sent")
+	}
+}
+
+func TestGCP_Probe_FlavorEnforcementBreaksOnAWS(t *testing.T) {
+	// Simulate hitting AWS IMDS by mistake: it returns 401 on this path.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	p := NewGCPWithBase(server.URL)
+	if p.Probe(context.Background()) {
+		t.Error("Probe should fail when server doesn't recognize GCP paths")
+	}
+}
+
+func TestGCP_Fetch_ProjectIDFailure_OtherFieldsStillReturned(t *testing.T) {
+	server := newGCPMockServer(t, gcpMockOpts{projectStatus: http.StatusNotFound})
+	defer server.Close()
+
+	p := NewGCPWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if meta.InstanceID == "" {
+		t.Error("InstanceID should be populated even when project-id 404s")
+	}
+	if meta.AccountID != "" {
+		t.Errorf("AccountID should be empty on project-id 404, got %q", meta.AccountID)
+	}
+}
+
+func TestGCP_Fetch_InstanceIDFailureAbortsWithError(t *testing.T) {
+	server := newGCPMockServer(t, gcpMockOpts{instanceIDStatus: http.StatusInternalServerError})
+	defer server.Close()
+
+	p := NewGCPWithBase(server.URL)
+	_, err := p.Fetch(context.Background())
+	if err == nil {
+		t.Error("expected error when instance-id endpoint 500s")
+	}
+}
+
+func TestGCP_Fetch_ZoneEdgeCases(t *testing.T) {
+	cases := []struct {
+		body       string
+		wantRegion string
+		wantZone   string
+	}{
+		{"projects/123/zones/us-central1-a", "us-central1", "us-central1-a"},
+		{"projects/999/zones/asia-northeast1-b", "asia-northeast1", "asia-northeast1-b"},
+		{"us-east4-c", "us-east4", "us-east4-c"}, // already a basename
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.body, func(t *testing.T) {
+			server := newGCPMockServer(t, gcpMockOpts{zoneBody: tc.body})
+			defer server.Close()
+
+			meta, err := NewGCPWithBase(server.URL).Fetch(context.Background())
+			if err != nil {
+				t.Fatalf("Fetch: %v", err)
+			}
+			if meta.AvailabilityZone != tc.wantZone {
+				t.Errorf("zone = %q, want %q", meta.AvailabilityZone, tc.wantZone)
+			}
+			if meta.Region != tc.wantRegion {
+				t.Errorf("region = %q, want %q", meta.Region, tc.wantRegion)
+			}
+		})
+	}
+}
+
+func TestGCP_FlavorHeader_AlwaysSent(t *testing.T) {
+	var seenHeader atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHeader.Store(r.Header.Get(gcpFlavorHeader))
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	p := NewGCPWithBase(server.URL)
+	_ = p.Probe(context.Background())
+	if got := seenHeader.Load(); got != gcpFlavorValue {
+		t.Errorf("Metadata-Flavor header = %q, want %q", got, gcpFlavorValue)
+	}
+}

--- a/pkg/cloud/gcp_test.go
+++ b/pkg/cloud/gcp_test.go
@@ -169,6 +169,32 @@ func TestGCP_Probe_FlavorEnforcementBreaksOnAWS(t *testing.T) {
 	}
 }
 
+func TestZoneToRegion(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// real GCE zones — strip trailing single-letter suffix
+		{"us-central1-a", "us-central1"},
+		{"asia-northeast1-b", "asia-northeast1"},
+		{"us-east4-c", "us-east4"},
+		// region-only inputs must NOT be stripped (the previous implementation
+		// chopped "us-central1" to "us")
+		{"us-central1", "us-central1"},
+		{"asia-northeast1", "asia-northeast1"},
+		// edge cases
+		{"region", "region"}, // no dash
+		{"", ""},             // empty
+		// multi-character trailing segment is treated as not-a-zone
+		{"us-central1-ab", "us-central1-ab"},
+	}
+	for _, c := range cases {
+		if got := zoneToRegion(c.in); got != c.want {
+			t.Errorf("zoneToRegion(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestGCP_Probe_RejectsResponseWithoutFlavorHeader(t *testing.T) {
 	// A captive portal / spoofed listener can return 200 + body without the
 	// Metadata-Flavor: Google response header. Probe must reject this so we

--- a/pkg/cloud/gcp_test.go
+++ b/pkg/cloud/gcp_test.go
@@ -226,6 +226,23 @@ func TestGCP_Fetch_ProjectIDFailure_OtherFieldsStillReturned(t *testing.T) {
 	}
 }
 
+func TestGCP_Fetch_EmptyInstanceID_ReturnsError(t *testing.T) {
+	// IMDS returns 200 with empty body for instance-id. Fetch must surface
+	// that as an error since cloud:instance_id is the deterministic-match
+	// key for reconcile.
+	server := newGCPMockServer(t, gcpMockOpts{instanceIDBody: "   "})
+	defer server.Close()
+
+	p := NewGCPWithBase(server.URL)
+	meta, err := p.Fetch(context.Background())
+	if err == nil {
+		t.Error("expected error when instance_id is empty/whitespace")
+	}
+	if meta == nil || meta.Provider != ProviderGCP {
+		t.Errorf("expected partial Metadata with Provider=gcp, got %+v", meta)
+	}
+}
+
 func TestGCP_Fetch_InstanceIDFailureAbortsWithError(t *testing.T) {
 	server := newGCPMockServer(t, gcpMockOpts{instanceIDStatus: http.StatusInternalServerError})
 	defer server.Close()

--- a/pkg/cloud/gcp_test.go
+++ b/pkg/cloud/gcp_test.go
@@ -147,9 +147,7 @@ func TestGCP_Fetch_HappyPath(t *testing.T) {
 
 func TestGCP_Probe_SucceedsAgainstFlavorEnforcingServer(t *testing.T) {
 	// Integration sanity: a server that requires Metadata-Flavor: Google
-	// (mimicking real GCE) accepts our request, so Probe succeeds. Renamed
-	// from RejectsWithoutFlavorHeader — that name suggested a negative test
-	// but the assertion is positive (our client sends the header).
+	// (mimicking real GCE) accepts our request, so Probe succeeds.
 	server := newGCPMockServer(t, gcpMockOpts{requireFlavor: true})
 	defer server.Close()
 

--- a/pkg/cloud/gcp_test.go
+++ b/pkg/cloud/gcp_test.go
@@ -9,17 +9,18 @@ import (
 )
 
 type gcpMockOpts struct {
-	requireFlavor    bool
-	instanceIDStatus int
-	instanceIDBody   string
-	zoneStatus       int
-	zoneBody         string
-	machineStatus    int
-	machineBody      string
-	networkStatus    int
-	networkBody      string
-	projectStatus    int
-	projectBody      string
+	requireFlavor      bool // server enforces request Metadata-Flavor header
+	omitFlavorResponse bool // server does NOT echo Metadata-Flavor in responses (simulates non-GCE 200)
+	instanceIDStatus   int
+	instanceIDBody     string
+	zoneStatus         int
+	zoneBody           string
+	machineStatus      int
+	machineBody        string
+	networkStatus      int
+	networkBody        string
+	projectStatus      int
+	projectBody        string
 }
 
 func newGCPMockServer(t *testing.T, opts gcpMockOpts) *httptest.Server {
@@ -61,6 +62,11 @@ func newGCPMockServer(t *testing.T, opts gcpMockOpts) *httptest.Server {
 		if opts.requireFlavor && r.Header.Get(gcpFlavorHeader) != gcpFlavorValue {
 			http.Error(w, "missing Metadata-Flavor", http.StatusForbidden)
 			return false
+		}
+		// Real GCE echoes Metadata-Flavor: Google in successful responses; mimic
+		// unless the test explicitly opts out to verify client-side rejection.
+		if !opts.omitFlavorResponse {
+			w.Header().Set(gcpFlavorHeader, gcpFlavorValue)
 		}
 		return true
 	}
@@ -160,6 +166,19 @@ func TestGCP_Probe_FlavorEnforcementBreaksOnAWS(t *testing.T) {
 	p := NewGCPWithBase(server.URL)
 	if p.Probe(context.Background()) {
 		t.Error("Probe should fail when server doesn't recognize GCP paths")
+	}
+}
+
+func TestGCP_Probe_RejectsResponseWithoutFlavorHeader(t *testing.T) {
+	// A captive portal / spoofed listener can return 200 + body without the
+	// Metadata-Flavor: Google response header. Probe must reject this so we
+	// don't false-positive non-GCE hosts.
+	server := newGCPMockServer(t, gcpMockOpts{omitFlavorResponse: true})
+	defer server.Close()
+
+	p := NewGCPWithBase(server.URL)
+	if p.Probe(context.Background()) {
+		t.Error("Probe should fail when response is missing Metadata-Flavor: Google header")
 	}
 }
 

--- a/pkg/cloud/gcp_test.go
+++ b/pkg/cloud/gcp_test.go
@@ -145,14 +145,17 @@ func TestGCP_Fetch_HappyPath(t *testing.T) {
 	}
 }
 
-func TestGCP_Probe_RejectsWithoutFlavorHeader(t *testing.T) {
-	// Server requires Metadata-Flavor header — if we sent the right one, Probe succeeds.
+func TestGCP_Probe_SucceedsAgainstFlavorEnforcingServer(t *testing.T) {
+	// Integration sanity: a server that requires Metadata-Flavor: Google
+	// (mimicking real GCE) accepts our request, so Probe succeeds. Renamed
+	// from RejectsWithoutFlavorHeader — that name suggested a negative test
+	// but the assertion is positive (our client sends the header).
 	server := newGCPMockServer(t, gcpMockOpts{requireFlavor: true})
 	defer server.Close()
 
 	p := NewGCPWithBase(server.URL)
 	if !p.Probe(context.Background()) {
-		t.Error("Probe should pass when Metadata-Flavor is sent")
+		t.Error("Probe should pass against a flavor-enforcing server when our client sends the header")
 	}
 }
 

--- a/pkg/cloud/util.go
+++ b/pkg/cloud/util.go
@@ -1,0 +1,20 @@
+package cloud
+
+import (
+	"fmt"
+	"io"
+)
+
+// readLimitedN reads up to max bytes from r and errors out if the payload
+// exceeds the cap. Defends against a misbehaving / spoofed metadata responder
+// filling memory with garbage — real IMDS responses are tiny (well under 8 KB).
+func readLimitedN(r io.Reader, max int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > max {
+		return nil, fmt.Errorf("response exceeds %d bytes", max)
+	}
+	return body, nil
+}

--- a/pkg/cloud/util.go
+++ b/pkg/cloud/util.go
@@ -7,10 +7,10 @@ import (
 	"time"
 )
 
-// readLimitedN reads up to max bytes from r and errors out if the payload
+// readLimited reads up to max bytes from r and errors out if the payload
 // exceeds the cap. Defends against a misbehaving / spoofed metadata responder
 // filling memory with garbage. Real IMDS responses are tiny (well under 8 KB).
-func readLimitedN(r io.Reader, max int64) ([]byte, error) {
+func readLimited(r io.Reader, max int64) ([]byte, error) {
 	body, err := io.ReadAll(io.LimitReader(r, max+1))
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/util.go
+++ b/pkg/cloud/util.go
@@ -3,11 +3,13 @@ package cloud
 import (
 	"fmt"
 	"io"
+	"net/http"
+	"time"
 )
 
 // readLimitedN reads up to max bytes from r and errors out if the payload
 // exceeds the cap. Defends against a misbehaving / spoofed metadata responder
-// filling memory with garbage — real IMDS responses are tiny (well under 8 KB).
+// filling memory with garbage. Real IMDS responses are tiny (well under 8 KB).
 func readLimitedN(r io.Reader, max int64) ([]byte, error) {
 	body, err := io.ReadAll(io.LimitReader(r, max+1))
 	if err != nil {
@@ -17,4 +19,28 @@ func readLimitedN(r io.Reader, max int64) ([]byte, error) {
 		return nil, fmt.Errorf("response exceeds %d bytes", max)
 	}
 	return body, nil
+}
+
+// newIMDSClient returns an *http.Client configured for link-local IMDS reads.
+// Two security hardenings beyond http.DefaultClient:
+//
+//  1. Proxy is explicitly disabled. IMDS lives on link-local addresses
+//     (169.254.169.254 / metadata.google.internal) that must never traverse a
+//     proxy. Honoring HTTP_PROXY/HTTPS_PROXY env vars would leak host metadata
+//     to whatever the operator's shell configured.
+//  2. Redirects are disabled. A spoofed or compromised metadata responder
+//     issuing a 30x could otherwise direct the client to an off-host URL and
+//     exfiltrate request headers (notably the IMDSv2 session token for AWS).
+//     CheckRedirect returns http.ErrUseLastResponse so callers see the 30x
+//     status as a non-200 and fail closed.
+func newIMDSClient(timeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 }

--- a/pkg/cloud/util.go
+++ b/pkg/cloud/util.go
@@ -34,7 +34,17 @@ func readLimitedN(r io.Reader, max int64) ([]byte, error) {
 //     CheckRedirect returns http.ErrUseLastResponse so callers see the 30x
 //     status as a non-200 and fail closed.
 func newIMDSClient(timeout time.Duration) *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Safe assertion: tests or instrumentation packages (e.g. OpenTelemetry,
+	// runtime fault injection) may swap http.DefaultTransport for a different
+	// RoundTripper. An unchecked type assertion would panic in those cases and
+	// crash the agent at register time. Fall back to a fresh *http.Transport
+	// so IMDS probing degrades gracefully instead.
+	var transport *http.Transport
+	if base, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = base.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
 	transport.Proxy = nil
 	return &http.Client{
 		Timeout:   timeout,


### PR DESCRIPTION
## Summary

- New `pkg/cloud/` package detects AWS / GCP / Azure via the provider-specific IMDS at `alpamon register` time and ships `cloud:*` tags in the registration payload.
- Closes the deterministic-matching gap for self-installed alpamon (operators running register over SSH, outside the SSM `install_script.sh` path). Every install route now lands `cloud:instance_id` in `Server.tags` so PHASE3B reconcile strategy 1 (tag match) hits, not only the SSM route.
- `--no-cloud-probe` CLI flag for environments where IMDS access is blocked by policy.
- No alpacon-server changes required. The register `tags` field is already accepted.

---

## Background — the matching gap

alpacon-server Phase 3-B reconcile (PR `alpacax/alpacon-server#2013`) auto-matches `CloudInstance` ↔ `Server` using 4 fallback strategies in priority order:

| Priority | Strategy | Limitation |
|---|---|---|
| 1 | tag (`Server.tags['cloud:instance_id']`) | Requires something to plant the tag |
| 2 | MAC (`CloudInstance.mac_addresses` ↔ `Interface.mac`) | alpamon's `VirtualIfacePattern` drops the MAC too |
| 3 | IP (`InterfaceAddress.address` ↔ `CloudInstance.private_ip`) | Same NIC filter + IPv4-only |
| 4 | hostname slugify | Operator-supplied names break it |

**Strategy 1** is the only 100%-deterministic option, but until now only the SSM install path injected the tag via `install_script.sh --tag cloud:instance_id=...`. **Self-installed alpamon** (operator SSH installs, custom cloud-init, etc.) had no tag, fell through to strategy 2/3/4, and broke in real environments:

- AWS Nitro instances — `enp0sN` naming caught by `VirtualIfacePattern` (`pkg/utils/metrics.go:54`); both MAC and IP are dropped from sync
- ECS bridge mode — `veth*` filter
- WireGuard / Tailscale-only hosts
- IPv6-only VPC (`pkg/runner/commit.go:639` is IPv4-only)

In these cases reconcile fell to strategy 4 (`hostname` slug), the most fragile option.

## Background — the fix

alpamon now self-detects its cloud-provider environment at register time and writes the `cloud:*` tag schema that alpacon-server's `_build_cloud_tags` already understands. The agent stops being passive about the install-path heterogeneity — every install route lands the same tag.

| Tag key | AWS source | GCP source | Azure source |
|---|---|---|---|
| `cloud:provider` | `aws` | `gcp` | `azure` |
| `cloud:instance_id` | `…instance-identity/document.instanceId` | `…/instance/id` | `…/compute/vmId` |
| `cloud:region` | `…document.region` | `…/instance/zone` (strip `-X`) | `…/compute/location` |
| `cloud:availability_zone` | `…document.availabilityZone` | `…/instance/zone` | `…/compute/zone` (omit if empty) |
| `cloud:instance_type` | `…document.instanceType` | `…/instance/machine-type` (basename) | `…/compute/vmSize` |
| `cloud:network_id` | primary MAC → `…/macs/<mac>/vpc-id` | `…/network-interfaces/0/network` (basename) | (V1: not collected) |
| `cloud:account_id` | `…document.accountId` | `…/project/project-id` | `…/compute/subscriptionId` |

`cloud:instance_id` alone is sufficient for reconcile to hit 100%; the other fields are populated for observability in alpacon-server's admin UI.

---

## Design decisions

### Why register-only, no daemon-side sync?

The PHASE3D design doc originally proposed a `Cache` with 1-hour background refresh and `[cloud] sync_tags` config so drift (e.g. `instance_type` resize) would auto-heal on the next sync.

We removed this entirely after analyzing field immutability:

| Field | Variable during instance lifetime? |
|---|---|
| `cloud:instance_id` | **Immutable**. If it changes, it is a different instance (new register required) |
| `cloud:provider` | **Immutable** |
| `cloud:region` | **Immutable**. Region migration is impossible without recreation |
| `cloud:availability_zone` | **Immutable** |
| `cloud:instance_type` | Mutable via Stop→Resize→Start, but the OS reboot it requires triggers alpamon restart anyway |
| `cloud:network_id` | Effectively immutable (primary NIC's VPC/Network is fixed) |
| `cloud:account_id` | **Immutable** |

The one mutable field (`instance_type`) is not used for matching, and its change forces an OS reboot which re-runs alpamon. So periodic refresh exists to solve a problem that does not exist. Removing it saves:

- `pkg/cloud/cache.go` + tests (~300 LoC)
- `pkg/runner/cloud.go` + tests (~110 LoC)
- `ServerData.Tags` wire-protocol extension
- `[cloud] sync_tags` config flag
- An alpacon-server PR to extend the `/sync/` serializer
- The operator-surprise of alpamon overwriting admin-UI edits every hour

### Why all three providers when alpacon-server only supports AWS today?

alpacon-server's `CloudInstance`/`CloudAccount` schema is AWS-only at the moment. GCP and Azure support is on the alpacon-server roadmap. We ship all three providers in alpamon now so that **when alpacon-server adds GCP/Azure schema later, every already-deployed alpamon agent immediately starts contributing matched data** without any agent-side change. Until then:

- GCP/Azure hosts: `cloud:*` tags persist in `Server.tags`, visible in admin UI, reconcile strategy 1 skipped (no matching `CloudInstance`), naturally falls back to strategies 2/3/4 — exactly the pre-PR behavior plus extra observability tags.

### Why no fallback after positive probe?

If AWS probe returns true but Fetch errors mid-read, we do **not** try GCP or Azure next. IMDS endpoints are provider-specific, so partial AWS data is strictly better than wrong-provider data. Detect logs a warning and returns the partial Metadata.

### Why DMI-hint optimization?

On Linux, `/sys/class/dmi/id/{sys_vendor,chassis_asset_tag,...}` typically contains a strong provider signature ("Amazon EC2", "Google", "Microsoft Corporation") at near-zero cost (~50µs sysfs read). Reading it lets Detect reorder the probe list, skipping up to 1.6s of wasted timeouts on the common case where the host is GCP or Azure (default order is AWS-first). DMI is a hint, not authority: spoofed or absent strings still fall back to sequential probes.

### Why context-based timeouts instead of leveraging `pkg/agent/ContextManager` / `internal/pool.Pool`?

Register is a one-shot CLI bootstrap step. The agent daemon (and therefore `ContextManager`) has not been instantiated yet. Detect spawns **zero goroutines** and dispatches **zero concurrent tasks**, so `pool.Pool` does not apply either. Each provider uses `context.WithTimeout` to bound individual probe/fetch HTTP calls; Detect uses `context.WithTimeout(context.Background(), 5*time.Second)` as the umbrella. Forcing the existing daemon infra into a CLI command would be over-engineering.

---

## What changed

### New package `pkg/cloud/`

```
pkg/cloud/
├── cloud.go            Provider interface, Metadata struct, ToTags, ErrNoCloudProvider, tag keys
├── aws.go              AWS IMDSv2 client (PUT token + GET document/mac/vpc-id)
├── aws_test.go
├── gcp.go              GCE metadata server client (Metadata-Flavor: Google)
├── gcp_test.go
├── azure.go            Azure IMDS client (Metadata: true, api-version)
├── azure_test.go
├── detect.go           Sequential probe + Linux DMI hint + DefaultProviders
├── detect_test.go
└── util.go             readLimitedN helper (response size cap)
```

### Modified files

| File | Change |
|---|---|
| `cmd/alpamon/command/register/register.go` | `--no-cloud-probe` flag, register-time auto-detection, `mergeCloudAndUserTags` (user `--tag` wins on conflict) |
| `cmd/alpamon/command/register/register_test.go` | Merge precedence, graceful detect failure, `--no-cloud-probe` short-circuit |

`pkg/config/`, `pkg/runner/`, and `cmd/alpamon/command/root.go` are unchanged in this PR.

---

## Commits walkthrough

The PR is broken into 6 cherry-pickable commits, each independently buildable and testable:

| # | Subject | Files |
|---|---|---|
| 1 | `feat(cloud): add Provider interface and Metadata schema` | `cloud.go`, `util.go` |
| 2 | `feat(cloud): implement AWS IMDSv2 provider` | `aws.go`, `aws_test.go` |
| 3 | `feat(cloud): implement GCP metadata server provider` | `gcp.go`, `gcp_test.go` |
| 4 | `feat(cloud): implement Azure IMDS provider` | `azure.go`, `azure_test.go` |
| 5 | `feat(cloud): add Detect with Linux DMI hint optimization` | `detect.go`, `detect_test.go` |
| 6 | `feat(register): auto-detect cloud metadata and merge into tags` | `register.go`, `register_test.go` |

Each provider commit is independent of the others — reviewer can read AWS thoroughly without rebuilding context for GCP/Azure.

---

## Operator UX

```
$ sudo alpamon register --url https://alpacon.example.com --token <T>
Server name auto-detected: my-host
Platform auto-detected: debian
Cloud detected: aws (instance=i-0abc...)
Registering server: https://alpacon.example.com

==========================================
Server registered successfully!
==========================================
  Name: my-host
  ID:   ...
  Config: /etc/alpamon/alpamon.conf
==========================================
```

On non-cloud hosts:
```
$ sudo alpamon register --url ... --token ...
...
No cloud provider detected; registering as plain server.
Registering server: ...
```

To skip detection (e.g. IMDS blocked by policy):
```
$ sudo alpamon register --url ... --token ... --no-cloud-probe
...
Cloud detection skipped (--no-cloud-probe).
```

---

## Security

- **IMDSv2 token TTL**: 21600s (AWS-documented maximum). Token lives only in `fetchCtx` scope; never logged.
- **Response size caps**: AWS 8 KB, GCP 4 KB, Azure 32 KB via `readLimitedN`. Defends against runaway/spoofed link-local responders.
- **No raw body logging**: only provider name + tag count appear in structured logs.
- **Provider isolation**: AWS requires `X-aws-ec2-metadata-token`; GCP rejects requests without `Metadata-Flavor: Google`; Azure rejects requests without `Metadata: true`. The three IMDS protocols cannot cross-fire even though AWS and Azure share `169.254.169.254`.

---

## Verification

### Local
- `go vet ./...` — clean
- `go build -v ./cmd/alpamon` — success
- `go test ./... -p 1 -count=1` — 40 packages pass, 0 failures
- `go test ./pkg/cloud/ ./cmd/alpamon/command/register/ -race -count=1` — no races
- `gofmt -l <touched files>` — zero drift

### Test coverage (per package)

| Package | Test cases |
|---|---|
| `pkg/cloud/aws_test.go` | happy path, token 401, probe unreachable, document 500 → partial, parse error, vpc-id 404, MAC empty → no vpc call, ctx cancel |
| `pkg/cloud/gcp_test.go` | happy path, Metadata-Flavor header enforced, missing header → 403, project-id 404 → other fields preserved, instance-id 500 → abort, zone format variants, header always sent |
| `pkg/cloud/azure_test.go` | happy path, zone empty (zone-less VM), header/api-version enforced, 503 → partial, bad JSON |
| `pkg/cloud/detect_test.go` | first probe wins, all fail → `ErrNoCloudProvider`, fetch error preserves provider, nil-meta defensive path, ctx cancel, DMI hint reorder 4 cases, `classifyDMI` 10 cases |
| `cmd/alpamon/command/register/register_test.go` (extensions) | merge precedence (user wins), no-provider → user tags only, `--no-cloud-probe` skips detection, generic error → empty result |

---

## Test plan

- [ ] CI green on `go vet`, `go build`, `go test -p 1`
- [ ] AWS EC2 (Nitro instance, e.g. `t3.micro`): `sudo alpamon register --url … --token …` → verify register payload `tags` contains `cloud:provider=aws`, `cloud:instance_id=i-…`, `cloud:region=…`, `cloud:availability_zone=…`, `cloud:instance_type=t3.micro`, `cloud:network_id=vpc-…`, `cloud:account_id=…`. Confirm Phase 3-B reconcile matches strategy 1 in alpacon-server admin UI.
- [ ] On-prem laptop (no IMDS): register prints "No cloud provider detected"; succeeds; `tags` does not contain `cloud:*` keys.
- [ ] `--no-cloud-probe`: zero IMDS traffic verified via `tcpdump -i lo`; register still succeeds.
- [ ] Operator override: `--tag cloud:provider=manual-aws --tag env=prod` → operator's value wins on `cloud:provider`; `env=prod` added; other auto-detected `cloud:*` keys preserved.
- [ ] GCP / Azure dev VM (when alpacon-server roadmap delivers schema): verify tags are stored in `Server.tags` and admin UI displays them even before reconcile picks them up.

---

## Out of scope (future work)

- `pkg/utils/metrics.go:54` `VirtualIfacePattern` regex tightening (`enp0sN` / `tailscale*`) — separate PR.
- `pkg/runner/commit.go:639` IPv4-only filter widening — separate PR.
- alpacon-server `CloudInstance` / `CloudAccount` schema + reconcile for GCP and Azure — separate roadmap item. alpamon side is ready; activation is server-side schema work only.
- Multi-NIC ENI metadata (V1 reports primary ENI only).
- Azure `cloud:network_id` (VNet name) — requires ARM API + managed identity, separate security review.
- Secondary IMDS metadata (IAM role ARN, user-data).
- IMDS hop-limit auto-detection (containers default hop=1).

---

## References

- alpacon-server PHASE3B reconcile PR: `alpacax/alpacon-server#2013`
- AWS IMDSv2: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
- GCP metadata server: https://cloud.google.com/compute/docs/metadata/overview
- Azure IMDS: https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service
- alpamon `pkg/utils/metrics.go:54` — virtual NIC filter (root cause of MAC/IP fallback failure)
- alpamon `pkg/runner/commit.go:639` — IPv4-only address sync
- alpamon `cmd/alpamon/command/register/register.go:107` — `--no-cloud-probe` flag definition

---

## Follow-ups (post-merge, alpacon-server side)

After this PR lands, the alpacon-server PHASE3B reconcile expected-vs-actual hit rates should be re-measured:

- [ ] Confirm strategy-1 (tag) hit rate climbs to ~100% for AWS hosts on the next 24 h window.
- [ ] Confirm strategy 2/3/4 fallback rates drop accordingly.
- [ ] (Roadmap) When GCP / Azure `CloudInstance` schema lands on alpacon-server, the `cloud:provider=gcp` / `azure` tags already deployed by alpamon will retroactively unlock strategy-1 matching for those providers with zero alpamon redeploy.
