### PR TITLE
chore(security): bump Go toolchain to 1.25.10

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.7'
+  GO_VERSION: '1.25.10'
   ENT_VERSION: 'v0.14.5'
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.7'
+  GO_VERSION: '1.25.10'
   ENT_VERSION: 'v0.14.5'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: '1.25.7'
+  GO_VERSION: '1.25.10'
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ go build -o alpamon ./cmd/alpamon         # native
 GOOS=windows GOARCH=amd64 go build ./cmd/alpamon   # Windows cross-compile
 ```
 
-Go 1.25.7+ is required. `GOPATH/bin` should be on `PATH`.
+Go 1.25.10+ is required. `GOPATH/bin` should be on `PATH`.
 
 ### Generate Ent schema code
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alpacax/alpamon
 
-go 1.25.7
+go 1.25.10
 
 require (
 	entgo.io/ent v0.14.5


### PR DESCRIPTION
## Summary

Bumps the `go` directive in `go.mod` from `1.25.7` to `1.25.10` to resolve 6 stdlib security vulnerabilities. No code changes — `go.sum` is unchanged (stdlib is bundled in the toolchain). CI workflows and README updated to reference `1.25.10`.

## Vulnerabilities resolved

| GO ID | CVE | Package | Fixed in | Impact |
|-------|-----|---------|----------|--------|
| GO-2026-4870 | CVE-2026-32283 | `crypto/tls` | go1.25.9 | TLS 1.3 deadlock DoS |
| GO-2026-4918 | CVE-2026-33814 | `net/http` | go1.25.10 | HTTP/2 infinite loop DoS |
| GO-2026-4946 | CVE-2026-32281 | `crypto/x509` | go1.25.9 | Certificate policy CPU exhaustion |
| GO-2026-4947 | CVE-2026-32280 | `crypto/x509` | go1.25.9 | Intermediate cert CPU exhaustion |
| GO-2026-4971 | CVE-2026-39836 | `net` | go1.25.10 | NUL byte panic (Windows) |
| GO-2026-4601 | CVE-2026-25679 | `net/url` | go1.25.8 | Host/authority validation bypass |

## Changes

- `go.mod`: `go 1.25.7` → `go 1.25.10`
- `.github/workflows/build-and-test.yml`: `GO_VERSION: '1.25.7'` → `'1.25.10'`
- `.github/workflows/lint.yml`: `GO_VERSION: '1.25.7'` → `'1.25.10'`
- `.github/workflows/release.yml`: `GO_VERSION: '1.25.7'` → `'1.25.10'`
- `README.md`: updated minimum version reference

## Scope

- **No third-party dependency changes** — patch release guarantees no API changes per Go compatibility policy
- **No `go.sum` changes** — stdlib is bundled in the toolchain, not recorded in go.sum
- **No Dockerfile changes needed** — `golang:1.25` floating tag automatically picks up the latest patch

## Checklist

- [x] Self-reviewed the code
- [x] `go build ./cmd/alpamon` passes
- [x] `go mod tidy` — no go.sum changes
- [x] `go vet ./...` — no warnings
- [x] `go test ./... -p 1` — all packages pass