### PR TITLE
feat(command): include exit_code in fin payload

### DIFF
--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -33,6 +33,7 @@ type CommandResponse struct {
 	Success     bool    `json:"success"`
 	Result      string  `json:"result"`
 	ElapsedTime float64 `json:"elapsed_time"`
+	ExitCode    int     `json:"exit_code"`
 }
 
 // PingResponse represents a ping response
@@ -50,11 +51,12 @@ func NewPingResponse() *PingResponse {
 }
 
 // NewCommandResponse creates a new command response
-func NewCommandResponse(success bool, result string, elapsed float64) *CommandResponse {
+func NewCommandResponse(success bool, result string, elapsed float64, exitCode int) *CommandResponse {
 	return &CommandResponse{
 		Success:     success,
 		Result:      result,
 		ElapsedTime: elapsed,
+		ExitCode:    exitCode,
 	}
 }
 

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -124,11 +124,12 @@ func TestCommand_AllowSh(t *testing.T) {
 }
 
 func TestNewCommandResponse(t *testing.T) {
-	resp := NewCommandResponse(true, "success output", 1.5)
+	resp := NewCommandResponse(true, "success output", 1.5, 0)
 
 	assert.True(t, resp.Success)
 	assert.Equal(t, "success output", resp.Result)
 	assert.Equal(t, 1.5, resp.ElapsedTime)
+	assert.Equal(t, 0, resp.ExitCode)
 }
 
 func TestNewPingResponse(t *testing.T) {
@@ -139,10 +140,12 @@ func TestNewPingResponse(t *testing.T) {
 }
 
 func TestCommandResponse_JSON(t *testing.T) {
-	resp := NewCommandResponse(true, "done", 2.5)
+	resp := NewCommandResponse(false, "command failed", 2.5, 7)
 
 	data, err := json.Marshal(resp)
 	require.NoError(t, err)
+
+	assert.Contains(t, string(data), `"exit_code":7`)
 
 	var decoded CommandResponse
 	err = json.Unmarshal(data, &decoded)
@@ -151,4 +154,5 @@ func TestCommandResponse_JSON(t *testing.T) {
 	assert.Equal(t, resp.Success, decoded.Success)
 	assert.Equal(t, resp.Result, decoded.Result)
 	assert.Equal(t, resp.ElapsedTime, decoded.ElapsedTime)
+	assert.Equal(t, resp.ExitCode, decoded.ExitCode)
 }

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -291,7 +291,7 @@ func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
 		} else {
 			log.Error().Msg("Dispatcher not initialized")
 			// Send failure notification
-			payload := protocol.NewCommandResponse(false, "Internal error: dispatcher not initialized", 0)
+			payload := protocol.NewCommandResponse(false, "Internal error: dispatcher not initialized", 0, 1)
 			scheduler.Rqueue.Post(fmt.Sprintf(eventCommandFinURL, msg.Command.ID),
 				payload,
 				10,
@@ -346,7 +346,7 @@ func (wc *WebsocketClient) handleCommand(command protocol.Command, data protocol
 		log.Error().Err(err).Msgf("Failed to submit command %s to pool", command.ID)
 		// Send failure notification
 		start := time.Now()
-		payload := protocol.NewCommandResponse(false, fmt.Sprintf("Failed to submit command: %v", err), time.Since(start).Seconds())
+		payload := protocol.NewCommandResponse(false, fmt.Sprintf("Failed to submit command: %v", err), time.Since(start).Seconds(), 1)
 		scheduler.Rqueue.Post(fmt.Sprintf(eventCommandFinURL, command.ID),
 			payload,
 			10,

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -52,7 +52,7 @@ func (cr *CommandRunner) Run(ctx context.Context) error {
 	defer func() {
 		if cr.command.ID != "" {
 			finURL := fmt.Sprintf(eventCommandFinURL, cr.command.ID)
-			payload := protocol.NewCommandResponse(exitCode == 0, result, time.Since(start).Seconds())
+			payload := protocol.NewCommandResponse(exitCode == 0, result, time.Since(start).Seconds(), exitCode)
 			scheduler.Rqueue.Post(finURL, payload, 10, time.Time{})
 		}
 	}()


### PR DESCRIPTION
## Summary

- Add `ExitCode int` field to `CommandResponse` with JSON key `exit_code`
- Pass the real process exit code captured in `executor.go` to the `/fin` endpoint
- Internal error paths (`dispatcher not initialized`, `pool submit failure`) report `exit_code=1`

## Background

Closes #307, refs alpacon-server#2019

alpamon already captures the real exit code in `executor.go`:
```go
exitCode = exitError.ExitCode()
```

But it was discarded when building the fin payload:
```go
// before
payload := protocol.NewCommandResponse(exitCode == 0, result, elapsed)
// after
payload := protocol.NewCommandResponse(exitCode == 0, result, elapsed, exitCode)
```

## Changes

| File | Change |
|---|---|
| `internal/protocol/message.go` | Add `ExitCode int` to `CommandResponse`; update `NewCommandResponse` signature |
| `pkg/runner/command.go` | Pass actual `exitCode` to `NewCommandResponse` |
| `pkg/runner/client.go` | Pass `exit_code=1` for internal error paths |
| `internal/protocol/message_test.go` | Update tests; assert `exit_code` in JSON output |

## Dependency

- alpacon-server must expose `exit_code` in the fin serializer and GET response: alpacax/alpacon-server#2050
- alpacon-cli propagates exit code to process exit: alpacax/alpacon-cli#175