### PR TITLE
ci: replace GORELEASER_GITHUB_TOKEN PAT with alpacax-release-publisher App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,11 @@ jobs:
           repositories: |
             alpamon
             homebrew-alpacon
+          # Pin the minted installation token to the single permission
+          # GoReleaser actually needs. If the App's installation
+          # permissions are expanded in the future for another use case,
+          # this step continues to issue a contents-only token.
+          permission-contents: write
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,24 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      # GoReleaser needs write access to two repositories with a single
+      # token: this repo (to attach release assets) and homebrew-alpacon
+      # (to push the updated Formula commit into the tap). The built-in
+      # `secrets.GITHUB_TOKEN` is scoped to this repo only, so we mint a
+      # cross-repo installation token from the alpacax-release-publisher
+      # GitHub App instead. The same token is reused by the later
+      # "Publish stable-alias checksums file" step.
+      - name: Generate App token
+        id: release-publisher-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PUBLISHER_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            alpamon
+            homebrew-alpacon
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -67,7 +85,7 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-publisher-token.outputs.token }}
           # Pin the tag goreleaser treats as "current" to the tag that
           # actually triggered this workflow. Without this, goreleaser
           # falls back to `git describe --tags`, which picks the
@@ -108,7 +126,7 @@ jobs:
       # upload`.
       - name: Publish stable-alias checksums file
         env:
-          GH_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release-publisher-token.outputs.token }}
         run: |
           set -e
           versioned="dist/alpamon-${{ steps.channel.outputs.tag }}-checksums.sha256"


### PR DESCRIPTION
## Summary

Replaces the `alpacax-gh-bot` PAT (`secrets.GORELEASER_GITHUB_TOKEN`) used by GoReleaser with an installation token minted from the new `alpacax-release-publisher` GitHub App. Part of the org-wide effort to retire the shared `alpacax-gh-bot` account in favour of purpose-scoped GitHub Apps.

## Why an App (and why a single token covering two repos)

GoReleaser publishes the GitHub Release for `alpamon` **and** pushes a Formula update commit into `alpacax/homebrew-alpacon` (configured in `.goreleaser.yaml` under `brews.repository`). Both operations run inside the same GoReleaser invocation and share one `GITHUB_TOKEN`, so the token must have write access to both repositories. The same token is also reused by the subsequent `Publish stable-alias checksums file` step, which uploads an additional asset to this repo's release.

The built-in `secrets.GITHUB_TOKEN` only has access to the current repo, which is why this workflow previously relied on a personal access token from the shared `alpacax-gh-bot` account. The new App provides the same cross-repo reach with:

- least-privilege scope (`contents:write` + `metadata:read` only; no PR/issue write)
- short-lived, auto-rotated installation tokens
- a per-purpose identity (`app/alpacax-release-publisher[bot]`) instead of a shared user account, so audit logs and SOC2 access review can attribute every release/Formula push correctly

App is installed on three repos: `alpacon-cli`, `alpamon`, `homebrew-alpacon`. Org-level secrets `RELEASE_PUBLISHER_APP_ID` and `RELEASE_PUBLISHER_PRIVATE_KEY` are already configured with `selected` visibility scoped to those three repos.

## Changes

### `.github/workflows/release.yml`
- Add `Generate App token` step (uses `actions/create-github-app-token@v1`) in the `goreleaser` job, scoped to `alpamon` + `homebrew-alpacon`.
- Switch the `Run GoReleaser` step's `GITHUB_TOKEN` env from `secrets.GORELEASER_GITHUB_TOKEN` to `steps.release-publisher-token.outputs.token`.
- Switch the `Publish stable-alias checksums file` step's `GH_TOKEN` env to the same App token output.
- No change to permissions block, job structure, smoke tests, or PackageCloud upload steps.

## Compatibility notes

- **GoReleaser config (`.goreleaser.yaml`) is untouched.** `brews.commit_author` (`alpacaxbot` / `support@alpacax.com`) is a static string in the config, unrelated to the GitHub authentication identity — Formula commits will continue to be authored as `alpacaxbot` exactly as before. Only the underlying git push authentication changes.
- **PackageCloud uploads are unchanged** — they use `PACKAGECLOUD_TOKEN`, not the GitHub token, and are untouched by this PR.
- **`brews.skip_upload: auto`** semantics are unchanged (pre-release tags still skip the Formula push); this PR only swaps the authentication mechanism for the push when it does happen.
- **Existing releases are unaffected.** GitHub Releases and Formula files already published continue to serve `gh release download` / `brew install` normally. Failure mode of this PR (if any) is scoped to *future* tag pushes — no impact on users pulling already-published versions.

## Test plan

End-to-end validation is only possible during a real release (GoReleaser fires on `git push` of a `vX.Y.Z` tag). After merge:

- [ ] On the next release tag, verify the `goreleaser` job completes successfully and the resulting GitHub Release shows artifacts published as expected.
- [ ] Verify `Publish stable-alias checksums file` step uploads `alpamon-checksums.sha256` successfully (this exercises the App token path independently from GoReleaser's own use of it).
- [ ] For stable tags, verify `alpacax/homebrew-alpacon` receives a Formula update commit (commit author still `alpacaxbot`, push attributed to `app/alpacax-release-publisher[bot]`).
- [ ] After the next successful release, the org will delete the `GORELEASER_GITHUB_TOKEN` org secret and revoke the underlying fine-grained PAT.

Until that release runs, the legacy `GORELEASER_GITHUB_TOKEN` secret remains intact as a fallback — re-pointing the workflow to it via revert is a one-line rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)