### PR TITLE
fix(scripts): make install.ps1 work under PowerShell 7.x (pwsh)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -157,9 +157,10 @@ jobs:
       # PowerShell 7.x to catch future syntax-compatibility drift.
       # This is a parse-only regression guard, not a behavior test:
       # the install.ps1 PS-7.x fix gates ServicePointManager assignments
-      # on $PSVersionTable.PSVersion.Major, which both shells parse
-      # cleanly. Actual fix behavior is verified manually on hosts with
-      # degraded OS TLS (see docs/windows.md > PowerShell compatibility).
+      # on $PSVersionTable.PSEdition (only the Desktop edition takes the
+      # legacy shim), which both shells parse cleanly. Actual fix
+      # behavior is verified manually on hosts with degraded OS TLS
+      # (see docs/windows.md > PowerShell compatibility).
       - name: Parse install.ps1 under Windows PowerShell 5.1
         shell: powershell
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -153,6 +153,49 @@ jobs:
         run: go build -v .
         working-directory: ./cmd/alpamon
 
+      # Parse install.ps1 under both Windows PowerShell 5.1 and
+      # PowerShell 7.x to catch future syntax-compatibility drift.
+      # This is a parse-only regression guard, not a behavior test:
+      # the install.ps1 PS-7.x fix gates ServicePointManager assignments
+      # on $PSVersionTable.PSVersion.Major, which both shells parse
+      # cleanly. Actual fix behavior is verified manually on hosts with
+      # degraded OS TLS (see docs/windows.md > PowerShell compatibility).
+      - name: Parse install.ps1 under Windows PowerShell 5.1
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $script = Join-Path $PWD 'scripts\install.ps1'
+          if (-not (Test-Path $script)) { throw "install.ps1 not found at $script" }
+          $tokens = $null
+          $parseErrors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+              $script, [ref]$tokens, [ref]$parseErrors) | Out-Null
+          if ($parseErrors.Count -gt 0) {
+              foreach ($e in $parseErrors) {
+                  Write-Host "::error file=scripts/install.ps1,line=$($e.Extent.StartLineNumber)::$($e.Message)"
+              }
+              throw "install.ps1 has $($parseErrors.Count) parse error(s) under Windows PowerShell 5.1."
+          }
+          Write-Host "install.ps1 parsed cleanly under Windows PowerShell $($PSVersionTable.PSVersion)."
+
+      - name: Parse install.ps1 under PowerShell 7.x
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $script = Join-Path $PWD 'scripts/install.ps1'
+          if (-not (Test-Path $script)) { throw "install.ps1 not found at $script" }
+          $tokens = $null
+          $parseErrors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+              $script, [ref]$tokens, [ref]$parseErrors) | Out-Null
+          if ($parseErrors.Count -gt 0) {
+              foreach ($e in $parseErrors) {
+                  Write-Host "::error file=scripts/install.ps1,line=$($e.Extent.StartLineNumber)::$($e.Message)"
+              }
+              throw "install.ps1 has $($parseErrors.Count) parse error(s) under PowerShell 7.x."
+          }
+          Write-Host "install.ps1 parsed cleanly under PowerShell $($PSVersionTable.PSVersion)."
+
       - name: Vet
         run: go vet ./...
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -111,7 +111,7 @@ build shipped via the Microsoft Store and `winget`).
 
 | Shell | Invocation | TLS path |
 |---|---|---|
-| Windows PowerShell 5.1 | `powershell -ExecutionPolicy Bypass -File install.ps1` | `Invoke-WebRequest` routes through `[Net.ServicePointManager]`; the script forces TLS 1.2/1.3 there before any network call |
+| Windows PowerShell 5.1 | `powershell -ExecutionPolicy Bypass -File install.ps1` | `Invoke-WebRequest` routes through `[Net.ServicePointManager]`; the script forces TLS 1.2 (and TLS 1.3 when the `Tls13` enum is present, which requires .NET Framework 4.8+) before any network call |
 | PowerShell 7.x | `pwsh -File install.ps1` | `Invoke-WebRequest` is reimplemented on `HttpClient`, which ignores `ServicePointManager.SecurityProtocol`; the script relies on the HttpClient/OS defaults (TLS 1.2, plus TLS 1.3 when the runtime and SChannel/OpenSSL support it—on Windows that means Server 2022 / Windows 11 or newer) |
 
 The version check uses `$PSVersionTable.PSEdition -eq 'Desktop'` so

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -114,12 +114,16 @@ build shipped via the Microsoft Store and `winget`).
 | Windows PowerShell 5.1 | `powershell -ExecutionPolicy Bypass -File install.ps1` | `Invoke-WebRequest` routes through `[Net.ServicePointManager]`; the script forces TLS 1.2/1.3 there before any network call |
 | PowerShell 7.x | `pwsh -File install.ps1` | `Invoke-WebRequest` is reimplemented on `HttpClient`, which ignores `ServicePointManager.SecurityProtocol`; the script relies on the .NET 7+ defaults (TLS 1.2/1.3) |
 
-The version check uses `$PSVersionTable.PSVersion.Major -lt 7`, so the
-5.1 code path also runs under the (end-of-life) PowerShell 6.x line if
-it is somehow still in use. PowerShell 4.x and earlier are rejected by
-a `#requires -Version 5.1` directive at the top of the script, which
-fails fast with a clear error instead of producing a confusing mid-run
-cmdlet failure.
+The version check uses `$PSVersionTable.PSEdition -eq 'Desktop'` so
+only Windows PowerShell (the `Desktop` edition built on .NET
+Framework) takes the legacy `ServicePointManager` TLS path.
+PowerShell 6.x and 7.x both report `Core` edition and use the
+HttpClient-based web cmdlets, so they fall through to the HttpClient
+defaults; treating either as 5.1 would emit a misleading verbose
+message and a TLS assignment the HTTP stack ignores. PowerShell 4.x
+and earlier are rejected by a `#requires -Version 5.1` directive at
+the top of the script, which fails fast with a clear error instead
+of producing a confusing mid-run cmdlet failure.
 
 If a host running PowerShell 7.x has OS-level TLS configured below 1.2
 (very old Windows 10 baselines with disabled TLS 1.2, custom Group

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -85,9 +85,12 @@ upgrade an already-registered host, use `alpamon upgrade` or the
 If the install fails after the service was stopped, the script
 best-effort restarts the previously-running service before exiting
 non-zero, so a transient network or checksum failure does not leave
-the host with a downed agent. TLS 1.2 is forced before any network
-call, so stock Server 2019 images do not need a manual
-`[Net.ServicePointManager]::SecurityProtocol` shim.
+the host with a downed agent. On Windows PowerShell 5.1 the script
+forces TLS 1.2+ at the .NET `ServicePointManager` level, so stock
+Server 2019 images do not need a manual TLS shim. On PowerShell 7.x
+the installer relies on the .NET HttpClient defaults instead—see
+[PowerShell compatibility](#powershell-compatibility) for the full
+matrix.
 
 A terser pipe-to-`iex` form is also supported; it still performs the
 checksum verification inside the script, but trades local-audit
@@ -97,6 +100,39 @@ friendliness for brevity:
 $env:ALPAMON_URL   = "https://<workspace>"
 $env:ALPAMON_TOKEN = "<TOKEN>"
 iwr https://raw.githubusercontent.com/alpacax/alpamon/main/scripts/install.ps1 -UseB | iex
+```
+
+### PowerShell compatibility
+
+`install.ps1` is verified against both Windows PowerShell 5.1
+(`powershell.exe`, the in-box shell on Windows Server 2019/2022 and
+Windows 10/11) and PowerShell 7.x (`pwsh.exe`, the cross-platform
+build shipped via the Microsoft Store and `winget`).
+
+| Shell | Invocation | TLS path |
+|---|---|---|
+| Windows PowerShell 5.1 | `powershell -ExecutionPolicy Bypass -File install.ps1` | `Invoke-WebRequest` routes through `[Net.ServicePointManager]`; the script forces TLS 1.2/1.3 there before any network call |
+| PowerShell 7.x | `pwsh -File install.ps1` | `Invoke-WebRequest` is reimplemented on `HttpClient`, which ignores `ServicePointManager.SecurityProtocol`; the script relies on the .NET 7+ defaults (TLS 1.2/1.3) |
+
+The version check uses `$PSVersionTable.PSVersion.Major -lt 7`, so the
+5.1 code path also runs under the (end-of-life) PowerShell 6.x line if
+it is somehow still in use. PowerShell 4.x and earlier are rejected by
+a `#requires -Version 5.1` directive at the top of the script, which
+fails fast with a clear error instead of producing a confusing mid-run
+cmdlet failure.
+
+If a host running PowerShell 7.x has OS-level TLS configured below 1.2
+(very old Windows 10 baselines with disabled TLS 1.2, custom Group
+Policy lockdowns), `install.ps1` cannot work around it—the HttpClient
+is bound by `SChannel`. Re-enable TLS 1.2 at the OS level before
+running the installer; the same fix applies to every other HTTPS
+client on that host.
+
+Pass `-Verbose` to either shell to see which TLS path the installer
+selected:
+
+```powershell
+& pwsh -File .\install.ps1 -Verbose
 ```
 
 ### Option B: manual extract + `alpamon register`

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -112,7 +112,7 @@ build shipped via the Microsoft Store and `winget`).
 | Shell | Invocation | TLS path |
 |---|---|---|
 | Windows PowerShell 5.1 | `powershell -ExecutionPolicy Bypass -File install.ps1` | `Invoke-WebRequest` routes through `[Net.ServicePointManager]`; the script forces TLS 1.2/1.3 there before any network call |
-| PowerShell 7.x | `pwsh -File install.ps1` | `Invoke-WebRequest` is reimplemented on `HttpClient`, which ignores `ServicePointManager.SecurityProtocol`; the script relies on the .NET 7+ defaults (TLS 1.2/1.3) |
+| PowerShell 7.x | `pwsh -File install.ps1` | `Invoke-WebRequest` is reimplemented on `HttpClient`, which ignores `ServicePointManager.SecurityProtocol`; the script relies on the HttpClient/OS defaults (TLS 1.2, plus TLS 1.3 when the runtime and SChannel/OpenSSL support it—on Windows that means Server 2022 / Windows 11 or newer) |
 
 The version check uses `$PSVersionTable.PSEdition -eq 'Desktop'` so
 only Windows PowerShell (the `Desktop` edition built on .NET

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,3 +1,4 @@
+#requires -Version 5.1
 <#
 .SYNOPSIS
     Install the Alpamon agent on Windows.
@@ -82,7 +83,22 @@ $tempDir = $null
 # would persist in a caller that invoked the installer via `iwr | iex`.
 # Capture the prior value and restore it in the finally block for the
 # same reason $ProgressPreference is saved and restored above.
-$previousSecurityProtocol = [Net.ServicePointManager]::SecurityProtocol
+#
+# Only meaningful on Windows PowerShell 5.1, which routes
+# Invoke-WebRequest / Invoke-RestMethod through ServicePointManager.
+# PowerShell 7.x reimplements those cmdlets on HttpClient and ignores
+# ServicePointManager.SecurityProtocol entirely, so there is nothing
+# to save or restore there. Pre-initialize to $null so the finally
+# block always has a defined read target even under
+# Set-StrictMode -Version Latest.
+$previousSecurityProtocol = $null
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    Write-Verbose "PowerShell $($PSVersionTable.PSVersion); saving previous SecurityProtocol for restore."
+    $previousSecurityProtocol = [Net.ServicePointManager]::SecurityProtocol
+}
+else {
+    Write-Verbose "PowerShell $($PSVersionTable.PSVersion); skipping SecurityProtocol save (HttpClient ignores it)."
+}
 
 try {
     if (-not $Url -or -not $Token) {
@@ -99,11 +115,25 @@ try {
     # Older Server 2019 base images default to SSL3/TLS1.0, which fails
     # the GitHub API handshake. TLS 1.3 only exists on .NET Framework 4.8+,
     # so probe for the enum value rather than referencing the literal.
-    $tls = [Net.SecurityProtocolType]::Tls12
-    if ([Enum]::IsDefined([Net.SecurityProtocolType], 'Tls13')) {
-        $tls = $tls -bor [Net.SecurityProtocolType]'Tls13'
+    #
+    # PowerShell 7.x reimplements Invoke-WebRequest / Invoke-RestMethod
+    # on top of HttpClient; ServicePointManager.SecurityProtocol still
+    # exists for source compatibility but has no effect on TLS
+    # negotiation there. Skip the assignment on 7.x and rely on the
+    # .NET 7+ HttpClient defaults (TLS 1.2 / 1.3). If OS-level TLS is
+    # degraded below 1.2 on a PS 7.x host, fix it at the OS level; the
+    # installer is not the right place to paper over that.
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+        $tls = [Net.SecurityProtocolType]::Tls12
+        if ([Enum]::IsDefined([Net.SecurityProtocolType], 'Tls13')) {
+            $tls = $tls -bor [Net.SecurityProtocolType]'Tls13'
+        }
+        [Net.ServicePointManager]::SecurityProtocol = $tls
+        Write-Verbose "Forced ServicePointManager.SecurityProtocol = $tls (Windows PowerShell 5.x path)."
     }
-    [Net.ServicePointManager]::SecurityProtocol = $tls
+    else {
+        Write-Verbose "Skipping ServicePointManager.SecurityProtocol assignment on PowerShell $($PSVersionTable.PSVersion); HttpClient ignores it."
+    }
 
     # If an alpamon service already exists, stop it so `alpamon register`
     # can replace %ProgramFiles%\alpamon\alpamon.exe without hitting
@@ -226,6 +256,14 @@ finally {
     if ($tempDir -and (Test-Path $tempDir)) {
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
-    [Net.ServicePointManager]::SecurityProtocol = $previousSecurityProtocol
+    # Symmetric with the save/set guards above: only restore on the
+    # PowerShell version that actually changed the value. On 7.x the
+    # value was never saved ($previousSecurityProtocol is $null) and
+    # writing $null into a [Net.SecurityProtocolType] property is
+    # confusing at best.
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+        [Net.ServicePointManager]::SecurityProtocol = $previousSecurityProtocol
+        Write-Verbose "Restored ServicePointManager.SecurityProtocol = $previousSecurityProtocol."
+    }
     $ProgressPreference = $previousProgressPreference
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -122,10 +122,12 @@ try {
     # ServicePointManager.SecurityProtocol still exists for source
     # compatibility but has no effect on TLS negotiation there.
     # Skip the assignment on those editions and rely on the
-    # HttpClient defaults (TLS 1.2 / 1.3 on .NET 7+). If OS-level
-    # TLS is degraded below 1.2 on such a host, fix it at the OS
-    # level; the installer is not the right place to paper over
-    # that.
+    # HttpClient/OS defaults (TLS 1.2, plus TLS 1.3 when the
+    # runtime and OS support it — on Windows that requires
+    # Server 2022 / Windows 11 SChannel or newer; older Windows
+    # gets TLS 1.2 only). If OS-level TLS is degraded below 1.2
+    # on such a host, fix it at the OS level; the installer is
+    # not the right place to paper over that.
     if ($PSVersionTable.PSEdition -eq 'Desktop') {
         $tls = [Net.SecurityProtocolType]::Tls12
         if ([Enum]::IsDefined([Net.SecurityProtocolType], 'Tls13')) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -84,15 +84,16 @@ $tempDir = $null
 # Capture the prior value and restore it in the finally block for the
 # same reason $ProgressPreference is saved and restored above.
 #
-# Only meaningful on Windows PowerShell 5.1, which routes
-# Invoke-WebRequest / Invoke-RestMethod through ServicePointManager.
-# PowerShell 7.x reimplements those cmdlets on HttpClient and ignores
-# ServicePointManager.SecurityProtocol entirely, so there is nothing
-# to save or restore there. Pre-initialize to $null so the finally
-# block always has a defined read target even under
-# Set-StrictMode -Version Latest.
+# Only meaningful on Windows PowerShell (the `Desktop` edition,
+# built on .NET Framework), which routes Invoke-WebRequest /
+# Invoke-RestMethod through ServicePointManager. PowerShell Core
+# editions (6.x and 7.x) reimplement those cmdlets on HttpClient
+# and ignore ServicePointManager.SecurityProtocol entirely, so
+# there is nothing to save or restore there. Pre-initialize to
+# $null so the finally block always has a defined read target
+# even under Set-StrictMode -Version Latest.
 $previousSecurityProtocol = $null
-if ($PSVersionTable.PSVersion.Major -lt 7) {
+if ($PSVersionTable.PSEdition -eq 'Desktop') {
     Write-Verbose "PowerShell $($PSVersionTable.PSVersion); saving previous SecurityProtocol for restore."
     $previousSecurityProtocol = [Net.ServicePointManager]::SecurityProtocol
 }
@@ -116,14 +117,16 @@ try {
     # the GitHub API handshake. TLS 1.3 only exists on .NET Framework 4.8+,
     # so probe for the enum value rather than referencing the literal.
     #
-    # PowerShell 7.x reimplements Invoke-WebRequest / Invoke-RestMethod
-    # on top of HttpClient; ServicePointManager.SecurityProtocol still
-    # exists for source compatibility but has no effect on TLS
-    # negotiation there. Skip the assignment on 7.x and rely on the
-    # .NET 7+ HttpClient defaults (TLS 1.2 / 1.3). If OS-level TLS is
-    # degraded below 1.2 on a PS 7.x host, fix it at the OS level; the
-    # installer is not the right place to paper over that.
-    if ($PSVersionTable.PSVersion.Major -lt 7) {
+    # PowerShell Core editions (6.x and 7.x) reimplement
+    # Invoke-WebRequest / Invoke-RestMethod on top of HttpClient;
+    # ServicePointManager.SecurityProtocol still exists for source
+    # compatibility but has no effect on TLS negotiation there.
+    # Skip the assignment on those editions and rely on the
+    # HttpClient defaults (TLS 1.2 / 1.3 on .NET 7+). If OS-level
+    # TLS is degraded below 1.2 on such a host, fix it at the OS
+    # level; the installer is not the right place to paper over
+    # that.
+    if ($PSVersionTable.PSEdition -eq 'Desktop') {
         $tls = [Net.SecurityProtocolType]::Tls12
         if ([Enum]::IsDefined([Net.SecurityProtocolType], 'Tls13')) {
             $tls = $tls -bor [Net.SecurityProtocolType]'Tls13'
@@ -257,11 +260,11 @@ finally {
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
     # Symmetric with the save/set guards above: only restore on the
-    # PowerShell version that actually changed the value. On 7.x the
-    # value was never saved ($previousSecurityProtocol is $null) and
-    # writing $null into a [Net.SecurityProtocolType] property is
-    # confusing at best.
-    if ($PSVersionTable.PSVersion.Major -lt 7) {
+    # PowerShell edition that actually changed the value. On Core
+    # editions the value was never saved ($previousSecurityProtocol
+    # is $null) and writing $null into a [Net.SecurityProtocolType]
+    # property is confusing at best.
+    if ($PSVersionTable.PSEdition -eq 'Desktop') {
         [Net.ServicePointManager]::SecurityProtocol = $previousSecurityProtocol
         Write-Verbose "Restored ServicePointManager.SecurityProtocol = $previousSecurityProtocol."
     }


### PR DESCRIPTION
## Summary

- `scripts/install.ps1` forces TLS 1.2+ via `[Net.ServicePointManager]::SecurityProtocol = $tls` so older Server 2019 images (TLS 1.0 / SSL 3 defaults) can complete the `api.github.com` handshake. Under PowerShell 7.x this silently no-ops because `Invoke-WebRequest` / `Invoke-RestMethod` are reimplemented on `HttpClient`, which ignores `ServicePointManager`. On hosts with degraded OS-level TLS, pwsh-launched installs fail with an opaque handshake error against `api.github.com`.
- Gate the entire save/set/restore triple on `$PSVersionTable.PSEdition -eq 'Desktop'` and rely on the HttpClient defaults under PS 7.x (TLS 1.2, plus TLS 1.3 when runtime and OS support it). Add `#requires -Version 5.1` so PS 3.x/4.x fail fast with a clear error. Add `Write-Verbose` markers on both branches for `-Verbose` diagnostics.
- Update `docs/windows.md` to differentiate the PS 5.1 (ServicePointManager shim) and PS 7.x (HttpClient defaults) paths and add a "PowerShell compatibility" subsection.
- Add two AST-parse-only CI steps under `shell: powershell` (5.1) and `shell: pwsh` (7.x) as a forward-looking regression guard for syntax compatibility.

Closes #310.

## Implementation details

### `scripts/install.ps1` (4 edits, all sharing the guard `$PSVersionTable.PSEdition -eq 'Desktop'`)

1. **L1** — new `#requires -Version 5.1` directive at the top of the file.
2. **L82-101** — guard the **save**. Pre-initialize `$previousSecurityProtocol = $null` so the finally block has a defined read target under `Set-StrictMode -Version Latest`, then save the actual value only on PS 5.x.
3. **L114-138** — guard the **set**. Only run the TLS configuration block on PS 5.x; on PS 7.x emit a `Write-Verbose` saying we are deferring to `HttpClient` defaults.
4. **L255-269** — guard the **restore**. Symmetric with the save: only restore on PS 5.x so we never write `$null` (or anything else) into the `[Net.SecurityProtocolType]` property on PS 7.x.

Same guard expression is used in three places to keep `grep "PSEdition -eq 'Desktop'" scripts/install.ps1` returning exactly 3 hits — easy to audit for drift in future edits.

### `docs/windows.md` (2 edits)

1. **L85-93** — rewrite the now-stale prose `"TLS 1.2 is forced before any network call ..."` to differentiate PS 5.1 (ServicePointManager shim) from PS 7.x (HttpClient defaults), with a cross-link to the new section.
2. **L105-137** — new `### PowerShell compatibility` subsection (peer to `### Option A` / `### Option B`), with a 2-row matrix table, OS-TLS-degraded fallback guidance ("fix it at the OS level — installer is not the right place"), and a `-Verbose` diagnostic snippet.

### `.github/workflows/build-and-test.yml` (1 addition)

- Two new steps inside `build-and-test-windows`, between Build and Vet:
  - `shell: powershell` (5.1) → `Parser::ParseFile scripts\install.ps1`
  - `shell: pwsh` (7.x) → `Parser::ParseFile scripts/install.ps1`
- Failures emit `::error file=scripts/install.ps1,line=N::<message>` so the PR diff annotates the offending line directly.
- Since `release.yml` calls this workflow via `workflow_call`, the guards run on every release tag automatically too.

## Corrections to the source issue draft

While reviewing the draft (`GITHUB_ISSUE_ALPAMON_INSTALL_PS1_PWSH7.md`) against the actual code, five gaps were found and fixed in this PR:

1. **Issue missed guarding the SAVE at L85.** Without guarding it, `$previousSecurityProtocol` would be undefined under StrictMode or hold a meaningless value on PS 7.x. All three sites (save, set, restore) are now gated symmetrically.
2. **Issue claim that CI already invokes `install.ps1` under 5.1 is wrong.** Neither `build-and-test.yml` (only ran `--version` smoke on the built binary) nor `release.yml` (downloaded the release ZIP directly via `Invoke-WebRequest`) ever invoked `install.ps1`. The CI steps in this PR are net-new, not "a second invocation".
3. **Issue's docs change was purely additive but did not correct stale prose.** `docs/windows.md` L87-90 said `"TLS 1.2 is forced before any network call"` — true for 5.1, false for 7.x. The docs edit rewrites that sentence in addition to adding the new subsection.
4. **DEBUG doc mentioned `Write-Verbose` diagnostic lines; the issue draft omitted them.** Added — operators running `-Verbose` see which TLS path the installer took without any cost in normal runs.
5. **Issue's line range "L98-106" mixed 4 comment lines and 5 code lines.** Working precision matters; final commit references the executable code only.

## What this PR is honest about

- **CI proves syntax-compatibility regression only.** The AST parse step does not (and cannot, on GitHub-hosted `windows-latest` runners with healthy OS TLS) exercise the actual bug fix. Anyone claiming the new CI steps "prove the bug is fixed" is overselling.
- **The fix's correctness is established by manual V2 verification** on a host with degraded OS-level TLS — see Test plan below.

## Test plan

### Manual verification (required before merge)

- [ ] **V1 — PS 5.1 baseline (regression)**
  On Windows Server 2019 with default `powershell.exe` 5.1:
  ```powershell
  $env:ALPAMON_URL = "https://<workspace>"; $env:ALPAMON_TOKEN = "<valid-token>"
  powershell -ExecutionPolicy Bypass -File .\install.ps1 -Verbose
  ```
  Verbose output contains `Forced ServicePointManager.SecurityProtocol = ...` and `Restored ServicePointManager.SecurityProtocol = ...`. Exit 0; `Get-Service alpamon` reports `Running`.

- [ ] **V2 — PS 7.x on a degraded-TLS host (THE actual bug reproducer)**
  Same Server 2019 VM with `pwsh` 7.6.x and TLS 1.2 disabled at the OS level (older AMI).
  - Pre-fix sanity: on `git checkout main`, `pwsh -File .\install.ps1` should fail at the GitHub API handshake. If it succeeds, host is not in degraded state — pick a different AMI.
  - Fix branch: `pwsh -File .\install.ps1 -Verbose`. Expect: verbose output contains `Skipping ServicePointManager.SecurityProtocol assignment on PowerShell 7.x.x; HttpClient ignores it.` Exit 0; service `Running`.

- [ ] **V3 — `iwr | iex` cloud-init path on PS 7.x**
  Run the terser docs recipe at `docs/windows.md` `iwr ... | iex`. Expect success. The `$previousSecurityProtocol = $null` pre-init guards against state leak from the caller's scope.

- [ ] **V4 — `#requires` rejection**
  Realistic PS 4.0 test is not possible. Substitute: edit a scratch copy to `#requires -Version 99.0`, run, confirm friendly error message.

- [ ] **V5 — Docs render on GitHub**
  Cross-link `[PowerShell compatibility](#powershell-compatibility)` resolves, the new table renders, em-dashes have no spaces per project style.

### CI verification (automatic)

- [ ] **V6** — push triggers `Parse install.ps1 under Windows PowerShell 5.1` and `Parse install.ps1 under PowerShell 7.x` steps; both green. Linux container matrix and macOS jobs unaffected.

## Out of scope

Tracked elsewhere; not touched in this PR:

- Privilege demotion on Windows (alpamon `parsePaths` home guard / Issue 5 epic).
- `-DryRun` / `-DownloadOnly` flag for `install.ps1` to enable deeper CI smoke testing.
- End-to-end CI run against a real Alpacon endpoint (needs secrets + test workspace).
- Replacing `Invoke-RestMethod` with a manually constructed `HttpClient` to force `SslProtocols` under PS 7.x — modern HttpClient defaults already negotiate TLS 1.2 (and TLS 1.3 when available).
- Inspecting and configuring OS-level TLS from the installer.
- `Invoke-WebRequest -UseBasicParsing` deprecation under PS 7.x (currently a no-op, accepted without warning).
- Authenticode signing of `install.ps1`.

## Files changed

```
.github/workflows/build-and-test.yml | +43 / -0
docs/windows.md                      | +39 / -3
scripts/install.ps1                  | +44 / -6
3 files changed, 126 insertions(+), 9 deletions(-)
```

## References

- Issue #310 — source spec (this PR includes 5 corrections; see section above).
- Companion alpamon issue: Windows file download home-guard (DEBUG doc Issue 1) — separate ticket.
- `docs/windows.md` > [PowerShell compatibility](docs/windows.md#powershell-compatibility) — operator-facing docs.


