### PR TITLE
fix(file): wrap upload src with io.NopCloser to prevent double-close (#315)

### DIFF
--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -396,10 +396,12 @@ func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, rec
 //   - Pre-handoff failures: closes src directly so it never leaks.
 func (h *FileHandler) fileUpload(args *common.CommandArgs, src io.ReadCloser, size int64, fileName string, recursive bool) (int, error) {
 	if args.UseBlob {
-		_, code, err := utils.Put(args.Content, src, size, 0)
-		// Surface src.Close() errors when the PUT itself succeeded so a
-		// non-zero `cat` exit (cmdReadCloser EACCES/ENOENT) is not silently
-		// reported as a successful upload.
+		// Strip Closer so http.Client.Do can't close src before us—we own
+		// the close so the demoted-cat reader's non-zero exit (EACCES/ENOENT)
+		// surfaces via Close(), and *os.File on Windows is not double-closed
+		// (returns os.ErrClosed on the second Close, which would otherwise be
+		// reported as a failed upload even though the PUT succeeded).
+		_, code, err := utils.Put(args.Content, io.NopCloser(src), size, 0)
 		if cerr := src.Close(); err == nil && cerr != nil {
 			return code, cerr
 		}

--- a/pkg/executor/handlers/file/file_test.go
+++ b/pkg/executor/handlers/file/file_test.go
@@ -2,7 +2,14 @@ package file
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
@@ -176,6 +183,99 @@ func TestFileExists(t *testing.T) {
 	}
 }
 
+// TestFileUpload_UseBlob_OsFile_NoDoubleClose locks in the v2.1.6 regression
+// where http.Client.Do auto-closes req.Body and fileUpload then calls
+// src.Close() a second time. On *os.File the second Close returns
+// os.ErrClosed, which fileUpload propagated as a failed upload. After the
+// io.NopCloser wrap, http.Client.Do can no longer close src and our
+// explicit Close is the single real close.
+func TestFileUpload_UseBlob_OsFile_NoDoubleClose(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tmpPath := filepath.Join(t.TempDir(), "blob.bin")
+	if err := os.WriteFile(tmpPath, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	f, err := os.Open(tmpPath)
+	if err != nil {
+		t.Fatalf("open temp: %v", err)
+	}
+
+	h := NewFileHandler(common.NewMockCommandExecutor(t), nil)
+	args := &common.CommandArgs{UseBlob: true, Content: srv.URL}
+
+	code, err := h.fileUpload(args, f, 5, "blob.bin", false)
+	if err != nil {
+		t.Fatalf("fileUpload returned err=%v, want nil (regression of v2.1.6 double-close)", err)
+	}
+	if code != http.StatusOK {
+		t.Errorf("fileUpload code=%d, want %d", code, http.StatusOK)
+	}
+}
+
+// TestFileUpload_UseBlob_CloseErrorPropagates verifies the original intent
+// of commit b9ba9712: when the underlying reader's Close() returns an
+// error (e.g. demoted cat EACCES/ENOENT via cmdReadCloser), fileUpload
+// must propagate it instead of reporting the upload as successful.
+// closeCnt==1 also guards against a future regression that brings the
+// double-close back.
+func TestFileUpload_UseBlob_CloseErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	closeSentinel := errors.New("synthetic close failure")
+	er := &errReader{
+		r:        strings.NewReader("hello"),
+		failAt:   1 << 30,
+		closeErr: closeSentinel,
+	}
+
+	h := NewFileHandler(common.NewMockCommandExecutor(t), nil)
+	args := &common.CommandArgs{UseBlob: true, Content: srv.URL}
+
+	_, err := h.fileUpload(args, er, 5, "blob.bin", false)
+	if !errors.Is(err, closeSentinel) {
+		t.Fatalf("fileUpload err=%v, want chain containing %v", err, closeSentinel)
+	}
+	if er.closeCnt != 1 {
+		t.Errorf("errReader.Close was called %d time(s), want exactly 1 (double-close regression)", er.closeCnt)
+	}
+}
+
+// TestFileUpload_UseBlob_PutErrorTakesPrecedence verifies the `err == nil &&`
+// guard: when utils.Put itself fails (transport-level error), that error is
+// returned instead of the src.Close() error. Without this guard a Close()
+// failure would mask the real PUT failure.
+func TestFileUpload_UseBlob_PutErrorTakesPrecedence(t *testing.T) {
+	closeSentinel := errors.New("synthetic close failure")
+	er := &errReader{
+		r:        strings.NewReader("hello"),
+		failAt:   1 << 30,
+		closeErr: closeSentinel,
+	}
+
+	h := NewFileHandler(common.NewMockCommandExecutor(t), nil)
+	// 127.0.0.1:1 is the reserved tcpmux port; on all common platforms a
+	// connection here is refused immediately, producing a transport-level
+	// error from utils.Put without depending on DNS or external network.
+	args := &common.CommandArgs{UseBlob: true, Content: "http://127.0.0.1:1/blob"}
+
+	_, err := h.fileUpload(args, er, 5, "blob.bin", false)
+	if err == nil {
+		t.Fatal("fileUpload returned nil err, want PUT transport error")
+	}
+	if errors.Is(err, closeSentinel) {
+		t.Errorf("fileUpload returned close error %v; PUT transport error should take precedence", err)
+	}
+}
+
 func TestFileHandler_parsePaths(t *testing.T) {
 	// This test uses Unix-style absolute paths ("/home/user", "/tmp/...").
 	// On Windows those paths join with the supplied home into shapes
@@ -230,4 +330,3 @@ func TestFileHandler_parsePaths(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/executor/handlers/file/file_test.go
+++ b/pkg/executor/handlers/file/file_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -263,19 +262,14 @@ func TestFileUpload_UseBlob_PutErrorTakesPrecedence(t *testing.T) {
 	}
 
 	h := NewFileHandler(common.NewMockCommandExecutor(t), nil)
-	// Bind to 127.0.0.1:0 to claim a free port, then close the listener so
-	// any subsequent connection to that address is deterministically refused.
-	// This avoids depending on a specific port (e.g. tcpmux/1) being closed
-	// in CI/container environments.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	closedAddr := ln.Addr().String()
-	_ = ln.Close()
-	args := &common.CommandArgs{UseBlob: true, Content: "http://" + closedAddr + "/blob"}
+	// Port 0 is reserved and cannot be dialed; net.Dial fails immediately
+	// with "can't assign requested address" / "invalid argument", giving a
+	// deterministic transport-level error without depending on any port
+	// being closed or claiming an ephemeral port that could be re-bound
+	// in the window between listener close and the PUT attempt.
+	args := &common.CommandArgs{UseBlob: true, Content: "http://127.0.0.1:0/blob"}
 
-	_, err = h.fileUpload(args, er, 5, "blob.bin", false)
+	_, err := h.fileUpload(args, er, 5, "blob.bin", false)
 	if err == nil {
 		t.Fatal("fileUpload returned nil err, want PUT transport error")
 	}

--- a/pkg/executor/handlers/file/file_test.go
+++ b/pkg/executor/handlers/file/file_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -262,12 +263,19 @@ func TestFileUpload_UseBlob_PutErrorTakesPrecedence(t *testing.T) {
 	}
 
 	h := NewFileHandler(common.NewMockCommandExecutor(t), nil)
-	// 127.0.0.1:1 is the reserved tcpmux port; on all common platforms a
-	// connection here is refused immediately, producing a transport-level
-	// error from utils.Put without depending on DNS or external network.
-	args := &common.CommandArgs{UseBlob: true, Content: "http://127.0.0.1:1/blob"}
+	// Bind to 127.0.0.1:0 to claim a free port, then close the listener so
+	// any subsequent connection to that address is deterministically refused.
+	// This avoids depending on a specific port (e.g. tcpmux/1) being closed
+	// in CI/container environments.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	closedAddr := ln.Addr().String()
+	_ = ln.Close()
+	args := &common.CommandArgs{UseBlob: true, Content: "http://" + closedAddr + "/blob"}
 
-	_, err := h.fileUpload(args, er, 5, "blob.bin", false)
+	_, err = h.fileUpload(args, er, 5, "blob.bin", false)
 	if err == nil {
 		t.Fatal("fileUpload returned nil err, want PUT transport error")
 	}


### PR DESCRIPTION
## Summary
- Fixes #315: on Windows, WebFTP blob uploads were reported as failed even though the PUT succeeded, because `http.Client.Do` auto-closed `req.Body` and `fileUpload` then called `src.Close()` a second time. On raw `*os.File` the second `Close()` returns `os.ErrClosed`, which masked a successful upload as a failure.
- Wrap `src` in `io.NopCloser` so `http.Client.Do` cannot close it; `fileUpload` remains the single owner of `Close()`. The demoted-cat reader's non-zero exit (EACCES/ENOENT via `cmdReadCloser`) still surfaces through the explicit `Close()`.
- Adds three regression tests in `file_test.go`:
  - `TestFileUpload_UseBlob_OsFile_NoDoubleClose`: locks in the #315 path (no double-close on `*os.File`).
  - `TestFileUpload_UseBlob_CloseErrorPropagates`: verifies cat-exit propagation still works and asserts `closeCnt == 1`.
  - `TestFileUpload_UseBlob_PutErrorTakesPrecedence`: PUT transport error wins over close error.

## Cross-OS impact
- Windows: fixes the double-close on `*os.File` (the bug).
- Linux/macOS: unchanged behavior. `src` is typically `cmdReadCloser` (demoted `cat`); previously closed once by `http.Client` then again by the handler, now closed exactly once by the handler. The cat exit code still propagates.
- HTTP connection reuse is unaffected: the transport returns the connection to the pool once the body is fully read; calling `Close` on the request body is not required for reuse.

## Test plan
- [ ] `go test -v ./pkg/executor/handlers/file/... -p 1`
- [ ] Manual WebFTP upload on Windows: confirm UI shows success and file lands on disk.
- [ ] Manual WebFTP upload on Linux: confirm permission-denied case still surfaces as a failed upload (cat EACCES propagates via `Close`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)