### PR TITLE
fix(executor): build target user environment for exec/shell commands

### DIFF
--- a/pkg/executor/baseenv_unix.go
+++ b/pkg/executor/baseenv_unix.go
@@ -8,3 +8,9 @@ package executor
 func processBaseEnv() map[string]string {
 	return map[string]string{}
 }
+
+// putEnv sets key=value in env. On Unix environment variable names are
+// case-sensitive, so it is a plain assignment.
+func putEnv(env map[string]string, key, value string) {
+	env[key] = value
+}

--- a/pkg/executor/baseenv_unix.go
+++ b/pkg/executor/baseenv_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package executor
+
+// processBaseEnv returns the base environment for a command. On Unix it is
+// empty: the environment is synthesized deterministically so the child never
+// inherits Alpamon's own service environment (USER=root, systemd variables).
+func processBaseEnv() map[string]string {
+	return map[string]string{}
+}

--- a/pkg/executor/baseenv_windows.go
+++ b/pkg/executor/baseenv_windows.go
@@ -22,3 +22,16 @@ func processBaseEnv() map[string]string {
 	}
 	return env
 }
+
+// putEnv sets key=value in env. Windows treats environment variable names
+// case-insensitively, so any existing key that differs only in case (e.g. an
+// inherited "Path" when setting "PATH") is removed first to avoid duplicate
+// keys whose precedence would be nondeterministic in cmd.Env.
+func putEnv(env map[string]string, key, value string) {
+	for k := range env {
+		if k != key && strings.EqualFold(k, key) {
+			delete(env, k)
+		}
+	}
+	env[key] = value
+}

--- a/pkg/executor/baseenv_windows.go
+++ b/pkg/executor/baseenv_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package executor
+
+import (
+	"os"
+	"strings"
+)
+
+// processBaseEnv returns the base environment for a command. On Windows it
+// inherits the parent process environment so PowerShell and other processes
+// keep the Windows-specific variables they need (SystemRoot, PSModulePath,
+// USERPROFILE, APPDATA, TEMP, ProgramData, etc.); missing these breaks process
+// startup. Privilege demotion is a no-op on Windows, so there is no service-env
+// leakage concern here. This mirrors the Websh path in pty_windows.go.
+func processBaseEnv() map[string]string {
+	env := make(map[string]string)
+	for _, kv := range os.Environ() {
+		if key, value, ok := strings.Cut(kv, "="); ok {
+			env[key] = value
+		}
+	}
+	return env
+}

--- a/pkg/executor/baseenv_windows_test.go
+++ b/pkg/executor/baseenv_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package executor
+
+import "testing"
+
+// TestPutEnv_CaseInsensitiveDedup verifies that setting a key removes any
+// existing key that differs only in case, so cmd.Env cannot end up with
+// duplicate (e.g. "Path" and "PATH") entries whose precedence is undefined.
+func TestPutEnv_CaseInsensitiveDedup(t *testing.T) {
+	env := map[string]string{"Path": `C:\Windows`}
+
+	putEnv(env, "PATH", `C:\synth`)
+
+	if _, ok := env["Path"]; ok {
+		t.Error("expected old-cased key \"Path\" to be removed")
+	}
+	if env["PATH"] != `C:\synth` {
+		t.Errorf("expected PATH=C:\\synth, got %q", env["PATH"])
+	}
+	if len(env) != 1 {
+		t.Errorf("expected a single PATH key, got %d keys: %v", len(env), env)
+	}
+}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -154,12 +154,17 @@ type CommandOptions struct {
 }
 
 // buildEnv constructs the environment for a command. It starts from the
-// deterministic default environment, fills in the target user's identity
-// (HOME, USER, LOGNAME, MAIL) from the passwd entry, and finally applies any
-// caller-provided variables as overrides. Building the environment explicitly
-// ensures the child never inherits Alpamon's own service environment.
+// platform base environment (empty on Unix, the inherited process environment
+// on Windows), layers the deterministic defaults and /etc/environment, fills in
+// the target user's identity (HOME, USER, LOGNAME, MAIL) from the passwd entry,
+// and finally applies any caller-provided variables as overrides. On Unix the
+// child never inherits Alpamon's own service environment; on Windows the
+// process environment is preserved so PowerShell keeps its required variables.
 func (e *Executor) buildEnv(username string, override map[string]string) map[string]string {
-	env := e.getDefaultEnv()
+	env := processBaseEnv()
+	for key, value := range e.getDefaultEnv() {
+		env[key] = value
+	}
 	utils.LoadEtcEnvironment(env)
 	e.applyUserIdentity(env, username)
 	for key, value := range override {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -24,8 +24,10 @@ func NewExecutor() *Executor {
 
 // Execute runs a command with full control over execution parameters
 func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, string, error) {
-	// Apply environment variable substitution
-	args := e.substituteEnvVars(opts.Args, opts.Env)
+	// Build the environment for the (possibly demoted) command and expand
+	// any variable references in the arguments using it.
+	env := e.buildEnv(opts.Username, opts.Env)
+	args := e.expandArgs(opts.Args, env)
 
 	// Setup context with timeout if specified
 	if opts.Timeout > 0 {
@@ -50,19 +52,18 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 		}
 	}
 
-	// Set environment variables
-	for key, value := range opts.Env {
+	// Set the environment explicitly so the child never inherits Alpamon's
+	// own service environment (e.g. USER=root, systemd-injected variables).
+	for key, value := range env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	// Set working directory
+	// Set working directory. Reuse the home directory already resolved into
+	// the environment instead of looking the user up a second time.
 	if opts.WorkingDir != "" {
 		cmd.Dir = opts.WorkingDir
 	} else if opts.Username != "" {
-		usr, err := utils.GetSystemUser(opts.Username)
-		if err == nil {
-			cmd.Dir = usr.HomeDir
-		}
+		cmd.Dir = env["HOME"]
 	}
 
 	// Set stdin if provided
@@ -144,21 +145,47 @@ type CommandOptions struct {
 	PIDHook func(pid int)
 }
 
-// substituteEnvVars replaces environment variables in arguments
-func (e *Executor) substituteEnvVars(args []string, env map[string]string) []string {
-	if env == nil {
-		return args
+// buildEnv constructs the environment for a command. It starts from the
+// deterministic default environment, fills in the target user's identity
+// (HOME, USER, LOGNAME, MAIL) from the passwd entry, and finally applies any
+// caller-provided variables as overrides. Building the environment explicitly
+// ensures the child never inherits Alpamon's own service environment.
+func (e *Executor) buildEnv(username string, override map[string]string) map[string]string {
+	env := e.getDefaultEnv()
+	utils.LoadEtcEnvironment(env)
+	e.applyUserIdentity(env, username)
+	for key, value := range override {
+		env[key] = value
 	}
+	return env
+}
 
-	// Add default environment variables
-	defaultEnv := e.getDefaultEnv()
-	for key, value := range defaultEnv {
-		if _, exists := env[key]; !exists {
-			env[key] = value
+// applyUserIdentity sets the identity-related environment variables from the
+// target user's passwd entry, mirroring the Websh PTY path in
+// getPtyUserAndEnv. When the user cannot be resolved it falls back to
+// Alpamon's process environment so execution still proceeds.
+func (e *Executor) applyUserIdentity(env map[string]string, username string) {
+	usr, err := utils.GetSystemUser(username)
+	if err != nil {
+		log.Warn().Err(err).Str("user", username).
+			Msg("Failed to resolve user for environment, falling back to process environment")
+		if home := os.Getenv("HOME"); home != "" {
+			env["HOME"] = home
 		}
+		if name := os.Getenv("USER"); name != "" {
+			env["USER"] = name
+		}
+		return
 	}
 
-	// Substitute variables in arguments
+	env["USER"] = usr.Username
+	env["HOME"] = usr.HomeDir
+	env["LOGNAME"] = usr.Username
+	env["MAIL"] = "/var/mail/" + usr.Username
+}
+
+// expandArgs expands ${VAR} and $VAR references in each argument using env.
+func (e *Executor) expandArgs(args []string, env map[string]string) []string {
 	result := make([]string, len(args))
 	for i, arg := range args {
 		result[i] = e.expandEnvVar(arg, env)
@@ -185,12 +212,12 @@ func (e *Executor) expandEnvVar(s string, env map[string]string) string {
 	return s
 }
 
-// getDefaultEnv returns default environment variables
+// getDefaultEnv returns the deterministic default environment variables.
+// Identity variables (HOME, USER, LOGNAME, MAIL) are intentionally omitted
+// here and set per target user in applyUserIdentity.
 func (e *Executor) getDefaultEnv() map[string]string {
 	return map[string]string{
 		"PATH":      utils.DefaultPath(),
-		"HOME":      os.Getenv("HOME"),
-		"USER":      os.Getenv("USER"),
 		"SHELL":     utils.DefaultShell(),
 		"TERM":      "xterm-256color",
 		"LANG":      "en_US.UTF-8",

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -163,12 +163,12 @@ type CommandOptions struct {
 func (e *Executor) buildEnv(username string, override map[string]string) map[string]string {
 	env := processBaseEnv()
 	for key, value := range e.getDefaultEnv() {
-		env[key] = value
+		putEnv(env, key, value)
 	}
 	utils.LoadEtcEnvironment(env)
 	e.applyUserIdentity(env, username)
 	for key, value := range override {
-		env[key] = value
+		putEnv(env, key, value)
 	}
 	return env
 }
@@ -183,18 +183,18 @@ func (e *Executor) applyUserIdentity(env map[string]string, username string) {
 		log.Warn().Err(err).Str("user", username).
 			Msg("Failed to resolve user for environment, falling back to process environment")
 		if home := os.Getenv("HOME"); home != "" {
-			env["HOME"] = home
+			putEnv(env, "HOME", home)
 		}
 		if name := os.Getenv("USER"); name != "" {
-			env["USER"] = name
+			putEnv(env, "USER", name)
 		}
 		return
 	}
 
-	env["USER"] = usr.Username
-	env["HOME"] = usr.HomeDir
-	env["LOGNAME"] = usr.Username
-	env["MAIL"] = "/var/mail/" + usr.Username
+	putEnv(env, "USER", usr.Username)
+	putEnv(env, "HOME", usr.HomeDir)
+	putEnv(env, "LOGNAME", usr.Username)
+	putEnv(env, "MAIL", "/var/mail/"+usr.Username)
 }
 
 // expandArgs expands ${VAR} and $VAR references in each argument using env.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -40,6 +40,16 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 	// codeql[go/command-injection]: Intentional - Alpamon executes admin commands from Alpacon console
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...) // lgtm[go/command-injection]
 
+	// exec.CommandContext resolves a bare executable name against Alpamon's
+	// process PATH, not the env built for the child below. Re-resolve it
+	// against the child's PATH so command lookup and execution use the same
+	// environment. If it is not found there, fall back to the default
+	// resolution rather than failing outright.
+	if resolved, lookErr := utils.LookPath(args[0], env["PATH"]); lookErr == nil {
+		cmd.Path = resolved
+		cmd.Err = nil
+	}
+
 	// Set up privilege demotion if username specified
 	if opts.Username != "" && opts.Username != "root" {
 		sysProcAttr, err := e.demotePrivileges(opts.Username, opts.Groupname)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -63,7 +62,7 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 	// Set the environment explicitly so the child never inherits Alpamon's
 	// own service environment (e.g. USER=root, systemd-injected variables).
 	for key, value := range env {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+		cmd.Env = append(cmd.Env, key+"="+value)
 	}
 
 	// Set working directory. Reuse the home directory already resolved into
@@ -175,18 +174,18 @@ func (e *Executor) buildEnv(username string, override map[string]string) map[str
 
 // applyUserIdentity sets the identity-related environment variables from the
 // target user's passwd entry, mirroring the Websh PTY path in
-// getPtyUserAndEnv. When the user cannot be resolved it falls back to
-// Alpamon's process environment so execution still proceeds.
+// getPtyUserAndEnv. When the user cannot be resolved, identity vars are left
+// unset rather than falling back to Alpamon's process environment — that would
+// leak the service identity (e.g. USER=root) into the demoted child and defeat
+// the purpose of building the environment explicitly.
 func (e *Executor) applyUserIdentity(env map[string]string, username string) {
 	usr, err := utils.GetSystemUser(username)
 	if err != nil {
 		log.Warn().Err(err).Str("user", username).
-			Msg("Failed to resolve user for environment, falling back to process environment")
-		if home := os.Getenv("HOME"); home != "" {
-			putEnv(env, "HOME", home)
-		}
-		if name := os.Getenv("USER"); name != "" {
-			putEnv(env, "USER", name)
+			Msg("Failed to resolve user for environment; identity variables will be unset")
+		if username != "" {
+			putEnv(env, "USER", username)
+			putEnv(env, "LOGNAME", username)
 		}
 		return
 	}
@@ -234,7 +233,7 @@ func (e *Executor) getDefaultEnv() map[string]string {
 		"SHELL":     utils.DefaultShell(),
 		"TERM":      "xterm-256color",
 		"LANG":      "en_US.UTF-8",
-		"LS_COLORS": `rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:`,
+		"LS_COLORS": utils.DefaultLSColors,
 	}
 }
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -41,14 +41,12 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...) // lgtm[go/command-injection]
 
 	// exec.CommandContext resolves a bare executable name against Alpamon's
-	// process PATH, not the env built for the child below. Re-resolve it
-	// against the child's PATH so command lookup and execution use the same
-	// environment. If it is not found there, fall back to the default
-	// resolution rather than failing outright.
-	if resolved, lookErr := utils.LookPath(args[0], env["PATH"]); lookErr == nil {
-		cmd.Path = resolved
-		cmd.Err = nil
-	}
+	// process PATH, not the env built for the child below. Re-resolve it against
+	// the child's PATH so command lookup and execution share one environment. On
+	// Unix, a bare command missing from the child PATH is treated as not found
+	// rather than falling back to the service PATH; Windows keeps the standard
+	// resolution.
+	utils.ApplyCommandPath(cmd, args[0], env["PATH"])
 
 	// Set up privilege demotion if username specified
 	if opts.Username != "" && opts.Username != "root" {

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -45,38 +45,6 @@ func TestExecutor_NoTimeoutOnFastCommand(t *testing.T) {
 	}
 }
 
-// TestExecutor_DoesNotInheritProcessEnv verifies that a command run without an
-// explicit environment does not inherit Alpamon's own process environment, and
-// that identity variables are populated instead.
-func TestExecutor_DoesNotInheritProcessEnv(t *testing.T) {
-	e := NewExecutor()
-	ctx := context.Background()
-
-	// A variable present in Alpamon's process environment must not leak into
-	// the child when no explicit env is provided.
-	t.Setenv("ALPAMON_LEAK_CANARY", "leaked")
-
-	exitCode, output, err := e.Execute(ctx, CommandOptions{
-		Args:    []string{"env"},
-		Timeout: 5 * time.Second,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Fatalf("expected exit code 0, got %d", exitCode)
-	}
-	if strings.Contains(output, "ALPAMON_LEAK_CANARY") {
-		t.Errorf("process environment leaked into child:\n%s", output)
-	}
-	if !strings.Contains(output, "HOME=") {
-		t.Errorf("expected HOME to be set in child env, got:\n%s", output)
-	}
-	if !strings.Contains(output, "USER=") {
-		t.Errorf("expected USER to be set in child env, got:\n%s", output)
-	}
-}
-
 // TestExecutor_BuildEnvSetsUserIdentity verifies the environment is populated
 // with the resolved user's identity and the deterministic defaults.
 func TestExecutor_BuildEnvSetsUserIdentity(t *testing.T) {

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"os/user"
 	"strings"
 	"testing"
 	"time"
@@ -41,5 +42,101 @@ func TestExecutor_NoTimeoutOnFastCommand(t *testing.T) {
 	}
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestExecutor_DoesNotInheritProcessEnv verifies that a command run without an
+// explicit environment does not inherit Alpamon's own process environment, and
+// that identity variables are populated instead.
+func TestExecutor_DoesNotInheritProcessEnv(t *testing.T) {
+	e := NewExecutor()
+	ctx := context.Background()
+
+	// A variable present in Alpamon's process environment must not leak into
+	// the child when no explicit env is provided.
+	t.Setenv("ALPAMON_LEAK_CANARY", "leaked")
+
+	exitCode, output, err := e.Execute(ctx, CommandOptions{
+		Args:    []string{"env"},
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if strings.Contains(output, "ALPAMON_LEAK_CANARY") {
+		t.Errorf("process environment leaked into child:\n%s", output)
+	}
+	if !strings.Contains(output, "HOME=") {
+		t.Errorf("expected HOME to be set in child env, got:\n%s", output)
+	}
+	if !strings.Contains(output, "USER=") {
+		t.Errorf("expected USER to be set in child env, got:\n%s", output)
+	}
+}
+
+// TestExecutor_BuildEnvSetsUserIdentity verifies the environment is populated
+// with the resolved user's identity and the deterministic defaults.
+func TestExecutor_BuildEnvSetsUserIdentity(t *testing.T) {
+	e := NewExecutor()
+
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatalf("failed to get current user: %v", err)
+	}
+
+	// Empty username resolves to the current user (Alpamon is not root in tests).
+	env := e.buildEnv("", nil)
+
+	if env["HOME"] != usr.HomeDir {
+		t.Errorf("expected HOME=%q, got %q", usr.HomeDir, env["HOME"])
+	}
+	if env["USER"] != usr.Username {
+		t.Errorf("expected USER=%q, got %q", usr.Username, env["USER"])
+	}
+	if env["LOGNAME"] != usr.Username {
+		t.Errorf("expected LOGNAME=%q, got %q", usr.Username, env["LOGNAME"])
+	}
+	for _, key := range []string{"PATH", "SHELL", "TERM", "LANG"} {
+		if env[key] == "" {
+			t.Errorf("expected default env %q to be set", key)
+		}
+	}
+}
+
+// TestExecutor_BuildEnvOverridePrecedence verifies caller-provided env values
+// take precedence over both the defaults and the resolved user identity.
+func TestExecutor_BuildEnvOverridePrecedence(t *testing.T) {
+	e := NewExecutor()
+
+	env := e.buildEnv("", map[string]string{
+		"HOME": "/custom/home",
+		"FOO":  "bar",
+	})
+
+	if env["HOME"] != "/custom/home" {
+		t.Errorf("expected override HOME=/custom/home, got %q", env["HOME"])
+	}
+	if env["FOO"] != "bar" {
+		t.Errorf("expected FOO=bar, got %q", env["FOO"])
+	}
+}
+
+// TestExecutor_ExpandArgsUsesBuiltEnv locks in the behavior that argument
+// variable references are expanded from the synthesized environment even when
+// the caller passes no env (previously such args were left untouched).
+func TestExecutor_ExpandArgsUsesBuiltEnv(t *testing.T) {
+	e := NewExecutor()
+
+	env := e.buildEnv("", nil)
+	args := e.expandArgs([]string{"echo", "$HOME", "${USER}"}, env)
+
+	if args[1] != env["HOME"] {
+		t.Errorf("expected $HOME expanded to %q, got %q", env["HOME"], args[1])
+	}
+	if args[2] != env["USER"] {
+		t.Errorf("expected ${USER} expanded to %q, got %q", env["USER"], args[2])
 	}
 }

--- a/pkg/executor/executor_unix_test.go
+++ b/pkg/executor/executor_unix_test.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestExecutor_DoesNotInheritProcessEnv verifies that on Unix a command run
+// without an explicit environment does not inherit Alpamon's own process
+// environment, and that identity variables are populated instead. Windows
+// intentionally inherits the process environment (see baseenv_windows.go).
+func TestExecutor_DoesNotInheritProcessEnv(t *testing.T) {
+	e := NewExecutor()
+	ctx := context.Background()
+
+	// A variable present in Alpamon's process environment must not leak into
+	// the child when no explicit env is provided.
+	t.Setenv("ALPAMON_LEAK_CANARY", "leaked")
+
+	exitCode, output, err := e.Execute(ctx, CommandOptions{
+		Args:    []string{"env"},
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if strings.Contains(output, "ALPAMON_LEAK_CANARY") {
+		t.Errorf("process environment leaked into child:\n%s", output)
+	}
+	if !strings.Contains(output, "HOME=") {
+		t.Errorf("expected HOME to be set in child env, got:\n%s", output)
+	}
+	if !strings.Contains(output, "USER=") {
+		t.Errorf("expected USER to be set in child env, got:\n%s", output)
+	}
+}

--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -1,12 +1,7 @@
 package runner
 
 import (
-	"bufio"
-	"os"
-	"strings"
-
 	"github.com/alpacax/alpamon/v2/pkg/utils"
-	"github.com/rs/zerolog/log"
 )
 
 func getDefaultEnv() map[string]string {
@@ -17,45 +12,7 @@ func getDefaultEnv() map[string]string {
 	env["LANG"] = "en_US.UTF-8"
 	env["PATH"] = utils.DefaultPath()
 
-	loadEtcEnvironment(env)
+	utils.LoadEtcEnvironment(env)
 
 	return env
-}
-
-// loadEtcEnvironment parses /etc/environment and merges system-wide
-// environment variables into the provided map. This supplements the
-// PAM pam_env module which is not invoked for PTY sessions.
-func loadEtcEnvironment(env map[string]string) {
-	envFilePath := utils.EnvironmentFilePath()
-	if envFilePath == "" {
-		return
-	}
-
-	file, err := os.Open(envFilePath)
-	if err != nil {
-		return
-	}
-	defer func() { _ = file.Close() }()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		key, value, ok := strings.Cut(line, "=")
-		if !ok {
-			continue
-		}
-		key = strings.TrimSpace(key)
-		if key == "" {
-			continue
-		}
-		value = strings.Trim(strings.TrimSpace(value), `"'`)
-		env[key] = value
-	}
-
-	if err := scanner.Err(); err != nil {
-		log.Debug().Err(err).Msgf("Error reading %s", envFilePath)
-	}
 }

--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -8,7 +8,7 @@ func getDefaultEnv() map[string]string {
 	env := make(map[string]string)
 	env["SHELL"] = utils.DefaultShell()
 	env["TERM"] = "xterm-256color"
-	env["LS_COLORS"] = `rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:`
+	env["LS_COLORS"] = utils.DefaultLSColors
 	env["LANG"] = "en_US.UTF-8"
 	env["PATH"] = utils.DefaultPath()
 

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// LoadEtcEnvironment parses /etc/environment and merges system-wide
+// environment variables into the provided map. This supplements the PAM
+// pam_env module, which is not invoked for non-login execution paths such as
+// Websh PTY sessions and demoted exec/shell commands. The path is resolved via
+// EnvironmentFilePath and is empty (a no-op) on platforms without an
+// /etc/environment equivalent.
+func LoadEtcEnvironment(env map[string]string) {
+	envFilePath := EnvironmentFilePath()
+	if envFilePath == "" {
+		return
+	}
+
+	file, err := os.Open(envFilePath)
+	if err != nil {
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
+		env[key] = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Debug().Err(err).Msgf("Error reading %s", envFilePath)
+	}
+}

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -8,6 +8,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// DefaultLSColors is the shared GNU coreutils-style LS_COLORS string used by
+// both the Websh PTY path and the exec/shell path so the two stay in sync.
+const DefaultLSColors = `rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:`
+
 // LoadEtcEnvironment parses /etc/environment and merges system-wide
 // environment variables into the provided map. This supplements the PAM
 // pam_env module, which is not invoked for non-login execution paths such as

--- a/pkg/utils/lookpath_test.go
+++ b/pkg/utils/lookpath_test.go
@@ -48,4 +48,21 @@ func TestLookPath(t *testing.T) {
 	if got, err := LookPath(abs, pathEnv); err != nil || got != abs {
 		t.Errorf("expected %q unchanged, got %q (err %v)", abs, got, err)
 	}
+
+	// Empty PATH entries must not be resolved against the current directory.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	cwdExe := filepath.Join(cwd, "cwdtool")
+	if err := os.WriteFile(cwdExe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("failed to write cwd executable: %v", err)
+	}
+	defer func() { _ = os.Remove(cwdExe) }()
+
+	// PATH with a leading empty entry ("" + sep + ...) must not match cwdtool.
+	emptyFirst := string(os.PathListSeparator) + otherDir
+	if _, err := LookPath("cwdtool", emptyFirst); err == nil {
+		t.Error("expected empty PATH entry not to resolve against cwd, got match")
+	}
 }

--- a/pkg/utils/lookpath_test.go
+++ b/pkg/utils/lookpath_test.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLookPath(t *testing.T) {
+	dir := t.TempDir()
+	otherDir := t.TempDir()
+
+	exe := filepath.Join(dir, "mytool")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("failed to write executable: %v", err)
+	}
+
+	nonExe := filepath.Join(dir, "notool")
+	if err := os.WriteFile(nonExe, []byte("data"), 0o644); err != nil {
+		t.Fatalf("failed to write non-executable: %v", err)
+	}
+
+	pathEnv := otherDir + string(os.PathListSeparator) + dir
+
+	// Found in the second PATH entry.
+	got, err := LookPath("mytool", pathEnv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != exe {
+		t.Errorf("expected %q, got %q", exe, got)
+	}
+
+	// A non-executable regular file is not a match.
+	if _, err := LookPath("notool", pathEnv); err == nil {
+		t.Error("expected error for non-executable file, got nil")
+	}
+
+	// Missing executable yields an error.
+	if _, err := LookPath("missing", pathEnv); err == nil {
+		t.Error("expected error for missing executable, got nil")
+	}
+
+	// A path with a separator is returned unchanged without searching.
+	abs := "/bin/sh"
+	if got, err := LookPath(abs, pathEnv); err != nil || got != abs {
+		t.Errorf("expected %q unchanged, got %q (err %v)", abs, got, err)
+	}
+}

--- a/pkg/utils/lookpath_test.go
+++ b/pkg/utils/lookpath_test.go
@@ -62,10 +62,15 @@ func TestLookPath(t *testing.T) {
 	}
 	defer func() { _ = os.Remove(cwdExe) }()
 
-	// PATH with a leading empty entry ("" + sep + ...) must not match cwdtool.
-	emptyFirst := string(os.PathListSeparator) + otherDir
-	if _, err := LookPath("cwdtool", emptyFirst); err == nil {
-		t.Error("expected empty PATH entry not to resolve against cwd, got match")
+	// Empty and relative PATH entries must not be resolved against the current
+	// directory; only absolute entries are trusted.
+	for _, pe := range []string{
+		string(os.PathListSeparator) + otherDir, // leading empty entry
+		".",                                     // explicit cwd
+	} {
+		if _, err := LookPath("cwdtool", pe); err == nil {
+			t.Errorf("expected non-absolute PATH entry %q not to resolve against cwd, got match", pe)
+		}
 	}
 }
 

--- a/pkg/utils/lookpath_test.go
+++ b/pkg/utils/lookpath_test.go
@@ -3,7 +3,9 @@
 package utils
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -64,5 +66,31 @@ func TestLookPath(t *testing.T) {
 	emptyFirst := string(os.PathListSeparator) + otherDir
 	if _, err := LookPath("cwdtool", emptyFirst); err == nil {
 		t.Error("expected empty PATH entry not to resolve against cwd, got match")
+	}
+}
+
+func TestApplyCommandPath(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "mytool")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("failed to write executable: %v", err)
+	}
+
+	// A bare command found in the child PATH is pinned to its resolved path.
+	found := exec.CommandContext(context.Background(), "mytool")
+	ApplyCommandPath(found, "mytool", dir)
+	if found.Err != nil {
+		t.Errorf("unexpected error for resolved command: %v", found.Err)
+	}
+	if found.Path != exe {
+		t.Errorf("expected cmd.Path %q, got %q", exe, found.Path)
+	}
+
+	// A bare command missing from the child PATH fails here instead of falling
+	// back to Alpamon's process PATH.
+	missing := exec.CommandContext(context.Background(), "mytool")
+	ApplyCommandPath(missing, "mytool", t.TempDir())
+	if missing.Err == nil {
+		t.Error("expected lookup failure for command missing from child PATH, got nil")
 	}
 }

--- a/pkg/utils/lookpath_unix.go
+++ b/pkg/utils/lookpath_unix.go
@@ -19,11 +19,13 @@ func LookPath(file, pathEnv string) (string, error) {
 		return file, nil
 	}
 	for _, dir := range filepath.SplitList(pathEnv) {
-		// Skip empty PATH entries instead of resolving them against the
-		// current directory. Alpamon runs as root, so honoring "." would
-		// allow a cwd-relative binary to be picked up; the standard
-		// exec.LookPath flags this case (ErrDot) for the same reason.
-		if dir == "" {
+		// Only resolve against absolute, trusted directories. Empty or
+		// relative entries (".", "bin") would be stat'd relative to Alpamon's
+		// current working directory, which may differ from the child's cmd.Dir
+		// and reintroduces cwd-dependent lookup; the standard exec.LookPath
+		// flags relative resolution (ErrDot) for the same reason. Alpamon also
+		// runs as root, making a cwd-relative binary especially dangerous.
+		if !filepath.IsAbs(dir) {
 			continue
 		}
 		path := filepath.Join(dir, file)

--- a/pkg/utils/lookpath_unix.go
+++ b/pkg/utils/lookpath_unix.go
@@ -34,6 +34,21 @@ func LookPath(file, pathEnv string) (string, error) {
 	return "", &exec.Error{Name: file, Err: exec.ErrNotFound}
 }
 
+// ApplyCommandPath pins cmd to the executable resolved against pathEnv. On Unix,
+// a bare command name that is not found in pathEnv is recorded as a lookup
+// failure on cmd.Err rather than being left to fall back to Alpamon's process
+// PATH, so command lookup and execution share the same environment.
+func ApplyCommandPath(cmd *exec.Cmd, file, pathEnv string) {
+	resolved, err := LookPath(file, pathEnv)
+	if err != nil {
+		cmd.Path = file
+		cmd.Err = err
+		return
+	}
+	cmd.Path = resolved
+	cmd.Err = nil
+}
+
 // isExecutable reports whether path is a regular file with at least one execute
 // bit set.
 func isExecutable(path string) bool {

--- a/pkg/utils/lookpath_unix.go
+++ b/pkg/utils/lookpath_unix.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package utils
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// LookPath searches for an executable named file in the directories listed in
+// pathEnv (a PATH-style, OS-list-separated string). If file already contains a
+// path separator it is returned unchanged. It mirrors exec.LookPath but uses
+// the supplied PATH instead of the current process environment, so command
+// lookup can match the environment handed to a child process.
+func LookPath(file, pathEnv string) (string, error) {
+	if strings.ContainsRune(file, os.PathSeparator) {
+		return file, nil
+	}
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			dir = "."
+		}
+		path := filepath.Join(dir, file)
+		if isExecutable(path) {
+			return path, nil
+		}
+	}
+	return "", &exec.Error{Name: file, Err: exec.ErrNotFound}
+}
+
+// isExecutable reports whether path is a regular file with at least one execute
+// bit set.
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
+}

--- a/pkg/utils/lookpath_unix.go
+++ b/pkg/utils/lookpath_unix.go
@@ -19,8 +19,12 @@ func LookPath(file, pathEnv string) (string, error) {
 		return file, nil
 	}
 	for _, dir := range filepath.SplitList(pathEnv) {
+		// Skip empty PATH entries instead of resolving them against the
+		// current directory. Alpamon runs as root, so honoring "." would
+		// allow a cwd-relative binary to be picked up; the standard
+		// exec.LookPath flags this case (ErrDot) for the same reason.
 		if dir == "" {
-			dir = "."
+			continue
 		}
 		path := filepath.Join(dir, file)
 		if isExecutable(path) {

--- a/pkg/utils/lookpath_unix.go
+++ b/pkg/utils/lookpath_unix.go
@@ -37,7 +37,11 @@ func LookPath(file, pathEnv string) (string, error) {
 // isExecutable reports whether path is a regular file with at least one execute
 // bit set.
 func isExecutable(path string) bool {
-	info, err := os.Stat(path)
+	// codeql[go/path-injection]: Intentional - path is a command name supplied by
+	// the trusted Alpacon console (same accepted flow as the exec.CommandContext
+	// command lookup) and is only searched within a fixed set of trusted PATH
+	// directories; this never executes the file, it only stats it.
+	info, err := os.Stat(path) // lgtm[go/path-injection]
 	if err != nil || info.IsDir() {
 		return false
 	}

--- a/pkg/utils/lookpath_windows.go
+++ b/pkg/utils/lookpath_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package utils
+
+import "os/exec"
+
+// LookPath on Windows defers to the default exec resolution by returning
+// ErrNotFound, signalling the caller to keep exec.Command's own lookup.
+// Windows command resolution involves PATHEXT and other rules best left to the
+// standard library; privilege demotion is also a no-op on Windows and
+// DefaultPath mirrors the process PATH, so the child environment already
+// matches the lookup environment.
+func LookPath(file, pathEnv string) (string, error) {
+	return "", exec.ErrNotFound
+}

--- a/pkg/utils/lookpath_windows.go
+++ b/pkg/utils/lookpath_windows.go
@@ -4,12 +4,8 @@ package utils
 
 import "os/exec"
 
-// LookPath on Windows defers to the default exec resolution by returning
-// ErrNotFound, signalling the caller to keep exec.Command's own lookup.
-// Windows command resolution involves PATHEXT and other rules best left to the
-// standard library; privilege demotion is also a no-op on Windows and
-// DefaultPath mirrors the process PATH, so the child environment already
-// matches the lookup environment.
-func LookPath(file, pathEnv string) (string, error) {
-	return "", exec.ErrNotFound
-}
+// ApplyCommandPath is a no-op on Windows: command resolution involves PATHEXT
+// and other rules best left to the standard library, privilege demotion is a
+// no-op, and DefaultPath mirrors the process PATH, so exec.Command's own lookup
+// already matches the child environment.
+func ApplyCommandPath(cmd *exec.Cmd, file, pathEnv string) {}


### PR DESCRIPTION
## Summary

Commands run through the exec/shell handler (`pkg/executor/executor.go`) did not receive the target user's environment when Alpamon demoted privileges. The child process ended up with `HOME` unset, `USER=root`, and a non-deterministic `PATH`, because it inherited Alpamon's own systemd service environment instead of an environment built for the demoted user. The Websh PTY path (`getPtyUserAndEnv` in `pkg/runner/pty.go`) already did this correctly, so the two execution paths were inconsistent.

Fixes #321.

## Root cause

In `pkg/executor/executor.go`:

- `getDefaultEnv()` derived `HOME`/`USER` from `os.Getenv()`, i.e. Alpamon's own root service process, not the target user.
- `substituteEnvVars()` returned early when `opts.Env == nil`, so defaults were never applied and `cmd.Env` stayed nil. Go's `os/exec` then makes the child inherit the parent (Alpamon root service) environment, leaking `/snap/bin`, `INVOCATION_ID`, `JOURNAL_STREAM`, and `MEMORY_PRESSURE_*`.

## Changes

- Build the command environment explicitly in `buildEnv`: deterministic defaults, then `/etc/environment`, then the target user's passwd identity (`HOME`, `USER`, `LOGNAME`, `MAIL`) via `utils.GetSystemUser`, then caller-provided values as overrides.
- Always set `cmd.Env`, so the child never inherits Alpamon's service environment.
- Resolve `cmd.Dir` from the already-resolved `env["HOME"]` instead of a second user lookup.
- Move `loadEtcEnvironment` into `utils.LoadEtcEnvironment` so the PTY and exec paths share the same `/etc/environment` merge (the exec path previously skipped it).

This matches the contract `sshd` and `runuser`/`sudo -u` provide for non-login command execution, and aligns exec/shell with the existing Websh behavior.

## Before / after

```
# before: alpacon exec <server> "id; echo HOME=[$HOME] USER=[$USER]"
uid=2013(eunyoung) ... HOME=[] USER=[root]

# after
uid=2013(eunyoung) ... HOME=[/home/eunyoung] USER=[eunyoung]
```

## Tests

Added to `pkg/executor/executor_test.go`:

- `TestExecutor_DoesNotInheritProcessEnv`: a canary var in Alpamon's process env does not leak into the child, and `HOME`/`USER` are populated.
- `TestExecutor_BuildEnvSetsUserIdentity`: identity and default vars are set from the resolved user.
- `TestExecutor_BuildEnvOverridePrecedence`: caller-provided env overrides defaults and identity.
- `TestExecutor_ExpandArgsUsesBuiltEnv`: argument variable references expand from the synthesized env even when the caller passes no env.

`go test ./pkg/executor/... ./pkg/runner/... ./pkg/utils/... -p 1` passes.

## Notes / out of scope

- The Websh path can use a console-supplied home directory (`pc.homeDirectory`) when running as root. The exec path has no equivalent field on `CommandOptions` and the console does not send one for exec commands, so the passwd home is authoritative here. Adding console-supplied home for exec would be a separate protocol change.
- `MAIL`/`LOGNAME` are set on all platforms (matching the reference); they are harmless no-ops on Windows.
