### PR TITLE
fix(packaging): meaningful deb/rpm description; bump LICENSE year

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -86,7 +86,12 @@ nfpms:
       - alpamon-linux
     package_name: alpamon
     maintainer: AlpacaX <support@alpacax.com>
-    description: Alpamon
+    description: |
+      Lightweight server agent for Alpacon. Establishes an outbound-only
+      connection to your Alpacon workspace, enabling browser-based
+      terminals, file transfers, system monitoring, and remote command
+      execution without VPNs, SSH keys, or inbound firewall changes.
+      Every action is supervised and audited.
     homepage: https://github.com/alpacax/alpamon
     license: MIT
     vendor: AlpacaX

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -87,11 +87,13 @@ nfpms:
     package_name: alpamon
     maintainer: AlpacaX <support@alpacax.com>
     description: |
-      Lightweight server agent for Alpacon. Establishes an outbound-only
-      connection to your Alpacon workspace, enabling browser-based
-      terminals, file transfers, system monitoring, and remote command
-      execution without VPNs, SSH keys, or inbound firewall changes.
-      Every action is supervised and audited.
+      Open-source server agent for Alpacon, the AI-native PAM. Installed
+      on each managed server, alpamon establishes an outbound-only
+      connection to the Alpacon control plane (no inbound ports, no
+      firewall changes) and enforces server-side decisions locally:
+      terminal sessions, file transfers, remote command execution, and
+      optional sudo verification via alpamon-pam. Every action runs
+      inside a scoped work session and is recorded for audit.
     homepage: https://github.com/alpacax/alpamon
     license: MIT
     vendor: AlpacaX

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright © 2025 AlpacaX Inc. All rights reserved.
+Copyright © 2026 AlpacaX Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Alpamon
 
-**Alpamon** is a lightweight server agent for [Alpacon](https://alpacon.io)—the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines.
+**Alpamon** is the open-source server agent for [Alpacon](https://alpacon.io), the AI-native PAM that governs *what* humans, AI agents, and CI/CD pipelines execute on your servers.
 
-Installed on each server, Alpamon establishes an outbound-only connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution—all without VPNs, SSH keys, or firewall changes. Every action is supervised and audited for compliance.
+Installed on each managed server, Alpamon establishes an outbound-only connection to the Alpacon control plane (no inbound ports, no firewall changes) and enforces server-side decisions locally: Websh terminals, file transfers, remote command execution, and sudo verification (via the optional [alpamon-pam](https://github.com/alpacax/alpamon-pam) module). Every action runs inside a scoped work session and is recorded for audit—same shape whether the actor is human, AI agent, or CI/CD pipeline.
 
 ## Supported platforms
 
 | Platform | Versions | Arch |
 | --- | --- | --- |
-| Linux | Ubuntu, Debian, RHEL, CentOS, Rocky, Alma, Fedora, Amazon Linux, Oracle Linux | amd64, arm64 |
+| Linux | Ubuntu, Debian, RHEL, Rocky, AlmaLinux, Fedora, Amazon Linux, Oracle Linux | amd64, arm64 |
 | macOS | 11 (Big Sur) or later | amd64, arm64 (Apple Silicon) |
 | Windows | Windows Server 2019 / 2022 / 2025, Windows 10 1803+, Windows 11 | amd64 |
 
@@ -27,7 +27,7 @@ sudo apt-get install alpamon
 sudo alpamon register --url https://<workspace> --token <TOKEN>
 ```
 
-**RHEL / CentOS / Rocky / Alma / Fedora**
+**RHEL / Rocky / AlmaLinux / Fedora**
 ```bash
 curl -s https://packagecloud.io/install/repositories/alpacax/alpamon/script.rpm.sh?any=true | sudo bash
 sudo yum install alpamon
@@ -204,7 +204,7 @@ docker run \
     alpamon:latest
 ```
 
-Covered distros: Ubuntu 18.04/20.04/22.04, Debian 10/11, RedHat 8/9, CentOS 7.
+Covered distros: Ubuntu 22.04/20.04, Debian 11, RHEL 8/9. Legacy Dockerfiles for Ubuntu 18.04, Debian 10, and CentOS 7 also ship under `Dockerfiles/` for best-effort builds against EOL platforms.
 
 ### Run locally
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Installed on each managed server, Alpamon establishes an outbound-only connectio
 
 ## Supported platforms
 
-| Platform | Versions | Arch |
+| Platform | Minimum version | Arch |
 | --- | --- | --- |
-| Linux | Ubuntu, Debian, RHEL, Rocky, AlmaLinux, Fedora, Amazon Linux, Oracle Linux | amd64, arm64 |
+| Linux | Ubuntu 18.04+, Debian 11+, RHEL / Rocky / AlmaLinux 8+, Oracle Linux 8+, Amazon Linux 2 / 2023, Fedora (current or previous) | amd64, arm64 |
 | macOS | 11 (Big Sur) or later | amd64, arm64 (Apple Silicon) |
-| Windows | Windows Server 2019 / 2022 / 2025, Windows 10 1803+, Windows 11 | amd64 |
+| Windows | Windows 10 (1803+) / Windows 11, Windows Server 2019 or later | amd64 |
 
 **System requirements**: 128MB RAM, 150MB free disk, outbound HTTPS to your Alpacon workspace.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alpamon
 
-**Alpamon** is a lightweight server agent for [Alpacon](https://www.alpacax.com)—the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines.
+**Alpamon** is a lightweight server agent for [Alpacon](https://alpacon.io)—the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines.
 
 Installed on each server, Alpamon establishes an outbound-only connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution—all without VPNs, SSH keys, or firewall changes. Every action is supervised and audited for compliance.
 

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -51,8 +51,11 @@ Typical usage:
 
   alpamon register --url https://<workspace> --token <TOKEN>   # one-time setup
   systemctl status alpamon                                     # service state
-  alpamon ftp                                                  # WebFTP worker
   alpamon migrate --to-workspace <new-workspace>               # workspace move
+
+After 'register' completes, the agent runs as a system service and operates
+on its own. Other subcommands (ftp, setup, tunnel-daemon) are internal
+workers spawned by the agent itself and are not meant to be invoked by users.
 
 Run 'alpamon <command> --help' for details. See https://alpacon.io for the
 control plane and https://github.com/alpacax/alpacon-cli for the CLI.`,

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -39,8 +39,23 @@ const (
 )
 
 var RootCmd = &cobra.Command{
-	Use:     "alpamon",
-	Short:   "Secure Server Agent for Alpacon",
+	Use:   "alpamon",
+	Short: "Alpacon agent: outbound-only server connection for AI-native PAM",
+	Long: `Alpamon is the open-source server agent for Alpacon, the AI-native PAM
+control plane. Installed on each managed server, alpamon establishes an
+outbound-only connection to Alpacon (no inbound ports, no firewall changes)
+and enforces server-side decisions locally: command execution, file
+transfer, sudo verification (via alpamon-pam), and remote management.
+
+Typical usage:
+
+  alpamon register --url https://<workspace> --token <TOKEN>   # one-time setup
+  systemctl status alpamon                                     # service state
+  alpamon ftp                                                  # WebFTP worker
+  alpamon migrate --to-workspace <new-workspace>               # workspace move
+
+Run 'alpamon <command> --help' for details. See https://alpacon.io for the
+control plane and https://github.com/alpacax/alpacon-cli for the CLI.`,
 	Version: version.Version,
 	Run: func(cmd *cobra.Command, args []string) {
 		// When launched by the Windows Service Control Manager, run


### PR DESCRIPTION
## Summary

Packaging metadata + docs cleanup. No code changes.

- **\`alpamon --help\`** — \`Short\` from Title Case to sentence case + descriptive (\`"Server agent for Alpacon, the AI-native PAM"\`); new \`Long\` walks through register / systemd / migrate.
- **deb / rpm description** — was bare \`"Alpamon"\`; replaced with a useful description of what the agent does.
- **Homebrew description** — \`"Secure server agent for Alpacon"\` → \`"Server agent for Alpacon, the AI-native PAM"\` (matches Short).
- **LICENSE** — copyright year \`2025\` → \`2026\`.
- **README** — rewritten intro, \`Alpacon\` link to \`alpacon.io\` (product) instead of \`www.alpacax.com\` (company), supported-platforms table switched to minimum-version notation, Docker testing section clarified.
- **CLAUDE.md** — project overview aligned with README + \`--help\`.

## Test plan

- [ ] \`apt show alpamon\` / \`rpm -qi alpamon\` reflects new description
- [ ] \`alpamon --help\` shows new Short + Long
- [ ] \`brew info alpamon\` shows new Homebrew description on next release