### PR TITLE
fix(packaging): set KillMode=process so agent restart keeps spawned sessions alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ sudo systemctl restart alpamon
 sudo journalctl -u alpamon -f
 ```
 
+The unit sets `KillMode=process`, so restarting or stopping alpamon signals only the agent itself, not the whole control-group. Sessions it launched—Websh terminals and detached jobs such as `tmux`, `screen`, or `nohup`'d commands—keep running across a restart, the same way `sshd` leaves active login sessions alone. Reattach to them from a new session after the agent reconnects.
+
 ### macOS (launchd)
 
 ```bash

--- a/configs/alpamon.service
+++ b/configs/alpamon.service
@@ -8,6 +8,7 @@ ExecStart=/usr/bin/alpamon
 WorkingDirectory=/var/lib/alpamon
 StateDirectory=alpamon
 StateDirectoryMode=0750
+KillMode=process
 SELinuxContext=-unconfined_u:unconfined_r:unconfined_t:s0
 AppArmorProfile=-unconfined
 Restart=on-failure


### PR DESCRIPTION
## Summary

Alpamon acts as a control plane on each server: terminal (Websh) sessions, file transfers, and remote commands are all spawned as descendants of the `alpamon` process. Today, **restarting the agent kills everything it spawned** — including detached sessions like `tmux`, `screen`, or `nohup`'d jobs that users expect to outlive the agent.

### Root cause

`alpamon.service` does not set `KillMode`, so it uses the systemd default **`KillMode=control-group`**. On stop/restart, systemd sends `SIGTERM`→`SIGKILL` to **every process in the unit's cgroup**. Everything Alpamon launches lives in that cgroup, so `systemctl restart alpamon` (also triggered by self-restart after upgrade/migrate) tears it all down.

`tmux` double-forks + `setsid` to escape the process tree and controlling terminal, but that does **not** escape the cgroup, so the cgroup kill catches it anyway. The codebase already documents this behaviour in `migrate.go` and works around it for self-restart via a PID 1-owned `systemd-run` transient unit.

### How sshd avoids this

Restarting `sshd` does not kill active sessions because the sessions live **outside** `sshd.service`'s cgroup:

- **logind session scopes**: `pam_systemd` registers each login with `systemd-logind`, which places the session in its own `session-N.scope` cgroup under the user slice.
- **`KillMode=process`**: historically set on `ssh.service` so reload/restart signals only the daemon, not active connections.

## Change

Set `KillMode=process` on `alpamon.service`. systemd now signals only the main agent process on stop/restart; spawned processes keep running — the same posture as sshd.

- Detached sessions (`tmux`, `screen`, `nohup`) **survive** an agent restart.
- Interactive Websh shells still exit naturally via PTY hangup when the agent closes its master fd.
- Resources Alpamon must reclaim (tunnels, code-server) are already stopped explicitly in `gracefulShutdown` (`CloseAllActiveTunnels()` etc.), so they never depended on the cgroup kill.

This is the minimal, unit-level fix (mirrors sshd's `KillMode=process`). A more selective, code-level approach — launching durable sessions in their own transient `systemd-run --scope` cgroup, the way logind does — is intentionally left as a separate follow-up.

## Follow-ups (not in this PR)

- The `restartDelay` comment in `cmd/alpamon/command/migrate/migrate.go` still reasons from the old `KillMode=control-group` default. With this change the Websh-launched `migrate` process is no longer torn down by the restart, so that rationale is now overly cautious (harmless — the delay remains as UX padding). To be reconciled alongside the follow-up work.
- Selective per-session transient scopes (the logind-equivalent approach).

## Testing

Config-only change; no Go code affected. Behaviour to verify on a systemd host:

```bash
# Before: tmux dies. After: tmux survives.
tmux new-session -d -s keepme 'sleep 100000'
systemctl restart alpamon
tmux ls   # `keepme` still listed after the restart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
