### PR TITLE
fix(register): normalize `--name` to the slug charset before registration

### DIFF
--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"text/template"
@@ -50,6 +51,15 @@ var (
 // so a non-cloud host (where all probes time out) still finishes registration
 // within a reasonable budget.
 const registerCloudDetectTimeout = 5 * time.Second
+
+// serverNameMaxLength mirrors the server's SlugField(max_length=64) on the
+// register endpoint.
+const serverNameMaxLength = 64
+
+// nameSeparatorRe matches any run of characters outside the slug set
+// [A-Za-z0-9_]; hyphens are intentionally excluded so existing/duplicate
+// hyphens collapse with adjacent separators.
+var nameSeparatorRe = regexp.MustCompile(`[^A-Za-z0-9_]+`)
 
 // RegisterRequest represents the request body for server registration
 type RegisterRequest struct {
@@ -138,6 +148,20 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		}
 		serverName = normalizeHostname(hostname)
 		fmt.Printf("Server name auto-detected: %s\n", serverName)
+	}
+
+	// 2b. Normalize to the server's slug rule (^[-a-zA-Z0-9_]+$). Applies to
+	// both the --name path and the hostname path so registration never fails
+	// with {"code":"invalid"} on a name the server would reject.
+	original := serverName
+	serverName = normalizeServerName(serverName)
+	if serverName == "" {
+		return fmt.Errorf(
+			"server name %q is empty after normalization; pass a valid --name "+
+				"(allowed characters: A-Z a-z 0-9 _ -)", original)
+	}
+	if serverName != original {
+		fmt.Printf("Server name normalized to %q\n", serverName)
 	}
 
 	// 3. Auto-detect platform
@@ -275,6 +299,23 @@ func normalizeHostname(hostname string) string {
 		return hostname[:idx]
 	}
 	return hostname
+}
+
+// normalizeServerName coerces an arbitrary name into the server's SlugField
+// character set (^[-a-zA-Z0-9_]+$, max 64). It replaces every run of
+// disallowed characters (spaces, '.', '/', non-ASCII, ...) with a single '-',
+// trims leading/trailing '-', and truncates to serverNameMaxLength. May return
+// "" — the caller chooses a fallback.
+//
+// MUST stay in sync with alpacon-server's normalize_server_name; shared test
+// vectors live in both repos' plan docs.
+func normalizeServerName(value string) string {
+	n := nameSeparatorRe.ReplaceAllString(value, "-")
+	n = strings.Trim(n, "-")
+	if len(n) > serverNameMaxLength {
+		n = n[:serverNameMaxLength]
+	}
+	return strings.TrimRight(n, "-")
 }
 
 func detectPlatform() string {

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/pkg/cloud"
@@ -205,6 +206,36 @@ func TestHostnameFQDNStripping(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, normalizeHostname(tt.hostname))
+		})
+	}
+}
+
+func TestNormalizeServerName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "space replaced with hyphen", input: "web server", expected: "web-server"},
+		{name: "dot replaced with hyphen", input: "api.prod", expected: "api-prod"},
+		{name: "parentheses and space collapse", input: "db (backup)", expected: "db-backup"},
+		{name: "slash replaced with hyphen", input: "app/v2", expected: "app-v2"},
+		{name: "FQDN dots all replaced", input: "server.example.com", expected: "server-example-com"},
+		{name: "duplicate hyphens collapse", input: "web--server", expected: "web-server"},
+		{name: "underscores preserved", input: "web__server", expected: "web__server"},
+		{name: "leading and trailing separators trimmed", input: "--leading--", expected: "leading"},
+		{name: "surrounding whitespace trimmed", input: "  spaced  ", expected: "spaced"},
+		{name: "mixed case preserved", input: "MyServer", expected: "MyServer"},
+		{name: "EC2 style instance id preserved", input: "i-0abc123", expected: "i-0abc123"},
+		{name: "all non-ASCII returns empty", input: "한글-서버", expected: ""},
+		{name: "truncated to 64 characters", input: strings.Repeat("a", 70), expected: strings.Repeat("a", 64)},
+		{name: "empty input returns empty", input: "", expected: ""},
+		{name: "only separators returns empty", input: "...", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeServerName(tt.input))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`alpamon register` now normalizes the server name to the alpacon-server slug
charset (`^[-a-zA-Z0-9_]+$`, `max_length=64`) before sending the registration
request. This eliminates `registration failed (status 400): {"code":"invalid"}`
on the cloud auto-install path (most visibly EC2 `Name` tags like
`web server.prod`) and on any manual invocation whose `--name` falls outside
the slug set.

The primary fix lives in alpacon-server (it generates the install command).
This change is independent defense-in-depth so any caller of `register` —
auto-install, manual CLI, scripts — submits a name the server accepts.

## Why

The alpacon-server register endpoint validates the server name with a DRF
`SlugField`. The name reaching it comes from `--name`, which on the
auto-install path is the raw cloud-instance `Name` tag (e.g.
`web server.prod`). alpamon currently forwards `--name` verbatim, so any
character outside `[-A-Za-z0-9_]` (including `.`) caused the server to return
`{"code":"invalid"}` and the registration to fail with
`failed to run commands: exit status 1`.

## What changed

Two files touched:

- [cmd/alpamon/command/register/register.go](cmd/alpamon/command/register/register.go)
  - Added `"regexp"` import.
  - Added `serverNameMaxLength` constant and `nameSeparatorRe` package-level
    regexp (compiled once at init) next to the existing
    `registerCloudDetectTimeout` declaration to keep all package-level
    declarations in the file header block.
  - Added `normalizeServerName(value string) string` helper that replaces every
    run of disallowed characters with a single `-`, trims leading/trailing
    `-`, truncates to 64 bytes, and trims any trailing `-` left by truncation.
  - In `runRegister`, normalize `serverName` immediately after the `--name` /
    hostname auto-detect step. Empty result fails fast with an actionable
    error; a name that changed shape prints `Server name normalized to "..."`.
    Already-valid slugs go through unchanged with no extra output.
- [cmd/alpamon/command/register/register_test.go](cmd/alpamon/command/register/register_test.go)
  - Added `"strings"` import.
  - Added table-driven `TestNormalizeServerName` covering 15 cases: the full
    cross-repo shared vector table plus the empty-input and separator-only
    edge cases.

No other call sites construct `RegisterRequest`, and the `Name` field is the
only attribute affected — `Platform`, `Tags`, and the rest of the flow are
untouched.

## Algorithm

```
normalizeServerName(value):
  1. Replace every maximal run of characters NOT in [A-Za-z0-9_] with a
     single '-'. (Hyphens are intentionally excluded from the slug set here
     so existing/duplicate hyphens collapse with adjacent separators.)
  2. Trim leading and trailing '-'.
  3. Truncate to 64 characters (server SlugField max_length).
  4. Trim trailing '-' again (truncation may have left one).
  5. Return the result (may be empty — caller decides the fallback).
```

After step 1 every remaining byte is ASCII, so the byte slice `[:64]` matches
Python character-level truncation on the server side.

### Shared test vectors (cross-repo contract)

| input | output |
|---|---|
| `web server` | `web-server` |
| `api.prod` | `api-prod` |
| `db (backup)` | `db-backup` |
| `app/v2` | `app-v2` |
| `server.example.com` | `server-example-com` |
| `web--server` | `web-server` |
| `web__server` | `web__server` |
| `--leading--` | `leading` |
| `  spaced  ` | `spaced` |
| `MyServer` | `MyServer` (case preserved) |
| `i-0abc123` | `i-0abc123` |
| `한글-서버` | `` (empty → fail fast with a clear error) |
| 70×`a` | 64×`a` (truncated) |

Empty / separator-only inputs additionally fail fast in `runRegister` with:

```
server name "<original>" is empty after normalization; pass a valid --name (allowed characters: A-Z a-z 0-9 _ -)
```

## Behaviour matrix

| Path | Before | After |
|---|---|---|
| `--name "web-server"` (already a slug) | sent as-is | sent as-is, no extra output |
| `--name "web server"` | server returns 400 `{"code":"invalid"}` | normalized to `"web-server"`, printed, registration succeeds |
| `--name ""` (omitted), hostname `host.example.com` | `normalizeHostname` → `"host"`, sent | `normalizeHostname` → `"host"` → `normalizeServerName` no-op, sent |
| `--name ""`, hostname contains unusual chars | sent as-is (could fail at server) | sanitized to safe slug as a final safety net |
| `--name "한글-서버"` (all non-ASCII) | server returns 400 `{"code":"invalid"}` | fails fast locally before any network call, actionable error message |

## Verification

```bash
# Package-scoped tests (15 new sub-tests, no regressions).
go test -v ./cmd/alpamon/command/register -p 1

# Targeted run.
go test -v ./cmd/alpamon/command/register -run TestNormalizeServerName -p 1

# Full binary build.
go build -v ./cmd/alpamon
```

End-to-end (manual, against a dev alpacon-server):

```bash
# Was failing — now succeeds with the normalized name "web-server".
alpamon register --url <URL> --token <TOKEN> --name "web server" --platform debian

# Already-valid slug — identical behaviour to current main.
alpamon register --url <URL> --token <TOKEN> --name "web-server" --platform debian

# Fails fast locally with an actionable error and no network call.
alpamon register --url <URL> --token <TOKEN> --name "한글-서버" --platform debian
```

## Test plan checklist

- [x] `TestNormalizeServerName` covers every row of the shared vector table
- [x] Empty / separator-only inputs return `""` from the helper
- [x] `runRegister` fail-fast path returns a clear, actionable error
- [x] Identity rows (`MyServer`, `i-0abc123`, `web__server`) confirm valid
      slugs pass through byte-for-byte
- [x] Hostname auto-detect path keeps `normalizeHostname` semantics and gets
      the slug pass as a safety net
- [x] `go test -v ./cmd/alpamon/command/register -p 1` — all pass
- [x] `go build -v ./cmd/alpamon` — succeeds

## Risk and rollback

- **Risk**: Low. The change is additive at a single call site
  ([register.go runRegister](cmd/alpamon/command/register/register.go)) and
  preserves byte-identical output for any name that is already a valid slug.
  The only behavioural change for valid slugs is silent — no extra logging.
- **Failure mode**: If normalization yields an empty string we fail fast
  before any network call, so a misuse cannot leak credentials or create a
  half-registered server.
- **Rollback**: Revert this PR. The fix is self-contained; no DB / config
  migrations, no flag changes, no API contract changes.

## Cross-repo coordination

- The alpacon-server change alone fixes the reported auto-install failure;
  this alpamon change is independent defense-in-depth. Apply order does not
  matter — both sides produce identical valid slugs.
- The shared test-vector table is the contract between the two repos. If
  the algorithm ever changes, **both repos must update their tables together
  and re-verify identical output**. A code comment on `normalizeServerName`
  calls this out.

## Related

- Issue: #329
- Server-side fix (primary): alpacon-server `render_install_script`
  normalizes the cloud-instance name before invoking `alpamon register`.
