### PR TITLE
fix(sudo): resolve sudo to its session by sid, not parent pid

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -59,6 +59,15 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 		}
 	}
 
+	// When a PID hook is registered (command exec / deploy shell), start the
+	// command in its own session so sudo invoked inside it resolves back to this
+	// Command by session ID—even if the shell execs sudo and they share a pid
+	// (see auth_manager session resolution). Gated on the hook to keep the blast
+	// radius to the sudo-tracked path.
+	if opts.PIDHook != nil {
+		enableSessionLeader(cmd)
+	}
+
 	// Set the environment explicitly so the child never inherits Alpamon's
 	// own service environment (e.g. USER=root, systemd-injected variables).
 	for key, value := range env {

--- a/pkg/executor/session_unix.go
+++ b/pkg/executor/session_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package executor
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// enableSessionLeader makes cmd start in a new session (setsid) so its pid
+// becomes the session-leader pid that the PAM tracker registers. sudo invoked
+// inside the command then resolves back to the originating Command by session
+// ID—including when the shell execs sudo and they share a pid. The new session
+// has no controlling terminal, which is correct for non-interactive command
+// execution. It is merged into any existing SysProcAttr (e.g. privilege
+// demotion) rather than replacing it.
+func enableSessionLeader(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}

--- a/pkg/executor/session_windows.go
+++ b/pkg/executor/session_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package executor
+
+import "os/exec"
+
+// enableSessionLeader is a no-op on Windows, which has no PAM/sudo session model.
+func enableSessionLeader(cmd *exec.Cmd) {}

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -352,8 +352,8 @@ func (am *AuthManager) handleSudoRequest(unixConn net.Conn) {
 			return
 		}
 
-		am.mu.RLock()
 		sid, sidOK := sessionID(isAlpconReq.PID)
+		am.mu.RLock()
 		session, exists := am.lookupSessionLocked(sid, sidOK, isAlpconReq.PPID)
 		am.mu.RUnlock()
 

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -304,6 +304,22 @@ func (am *AuthManager) createSendOperation(ctx context.Context, req SudoApproval
 	}
 }
 
+// lookupSessionLocked resolves a sudo request to its tracked session. It prefers
+// the caller's session ID (sid)—shared by every process in the Websh or command
+// session, so it survives the shell exec'ing sudo and any intermediate
+// processes between the shell and sudo—and falls back to the direct parent-pid
+// lookup for sessions whose registered leader is the caller's parent. The caller
+// must hold am.mu (read or write).
+func (am *AuthManager) lookupSessionLocked(sid int, sidOK bool, parentPID int) (*SessionInfo, bool) {
+	if sidOK {
+		if session, exists := am.pidToSessionMap[sid]; exists {
+			return session, true
+		}
+	}
+	session, exists := am.pidToSessionMap[parentPID]
+	return session, exists
+}
+
 func (am *AuthManager) handleSudoRequest(unixConn net.Conn) {
 	buf := make([]byte, 1024)
 	n, err := unixConn.Read(buf)
@@ -337,17 +353,18 @@ func (am *AuthManager) handleSudoRequest(unixConn net.Conn) {
 		}
 
 		am.mu.RLock()
-		session, exists := am.pidToSessionMap[isAlpconReq.PPID]
+		sid, sidOK := sessionID(isAlpconReq.PID)
+		session, exists := am.lookupSessionLocked(sid, sidOK, isAlpconReq.PPID)
 		am.mu.RUnlock()
 
 		if !exists {
-			log.Warn().Msgf("No session found for PID %d, username: %s, groupname: %s", isAlpconReq.PPID, isAlpconReq.Username, isAlpconReq.Groupname)
+			log.Warn().Msgf("No session found for PID %d (ppid %d, sid %d), username: %s, groupname: %s", isAlpconReq.PID, isAlpconReq.PPID, sid, isAlpconReq.Username, isAlpconReq.Groupname)
 			am.sendIsAlpconResponse(unixConn, isAlpconReq.Username, isAlpconReq.Groupname, isAlpconReq.PID, isAlpconReq.PPID, false)
 			_ = unixConn.Close()
 			return
 		}
 
-		log.Debug().Msgf("Session found for PID %d: %s", isAlpconReq.PPID, session.SessionID)
+		log.Debug().Msgf("Session found for PID %d (sid %d): %s", isAlpconReq.PID, sid, session.SessionID)
 		am.sendIsAlpconResponse(unixConn, isAlpconReq.Username, isAlpconReq.Groupname, isAlpconReq.PID, isAlpconReq.PPID, true)
 		_ = unixConn.Close()
 
@@ -372,8 +389,9 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 	// Create completion channel to signal when response is received
 	completionChan := make(chan struct{})
 
+	sid, sidOK := sessionID(sudoApprovalReq.PID)
 	am.mu.Lock()
-	session, exists := am.pidToSessionMap[sudoApprovalReq.PPID]
+	session, exists := am.lookupSessionLocked(sid, sidOK, sudoApprovalReq.PPID)
 	blockLocalSudo := am.blockLocalSudo
 	if !exists {
 		// Non-WebSH session (local SSH, etc.)

--- a/pkg/runner/session_test.go
+++ b/pkg/runner/session_test.go
@@ -1,0 +1,62 @@
+package runner
+
+import "testing"
+
+// lookupSessionLocked resolves a sudo request to its tracked session, preferring
+// the session ID (sid) and falling back to the parent pid. These tests pin that
+// precedence, which is what lets sudo invoked inside a command—possibly after
+// the shell execs sudo—still resolve to the originating session.
+
+func TestLookupSessionLocked_PrefersSessionID(t *testing.T) {
+	am := newTestAuthManager()
+	sidSession := &SessionInfo{SessionID: "via-sid"}
+	am.pidToSessionMap[1000] = sidSession
+
+	got, ok := am.lookupSessionLocked(1000, true, 2000)
+	if !ok || got != sidSession {
+		t.Fatalf("expected sid lookup to win, got %v ok=%v", got, ok)
+	}
+}
+
+func TestLookupSessionLocked_FallsBackToParentPID(t *testing.T) {
+	am := newTestAuthManager()
+	parentSession := &SessionInfo{SessionID: "via-ppid"}
+	am.pidToSessionMap[2000] = parentSession
+
+	// sid is known but not registered -> fall back to the parent pid.
+	got, ok := am.lookupSessionLocked(9999, true, 2000)
+	if !ok || got != parentSession {
+		t.Fatalf("expected parent-pid fallback, got %v ok=%v", got, ok)
+	}
+}
+
+func TestLookupSessionLocked_SessionIDUnavailable_UsesParent(t *testing.T) {
+	am := newTestAuthManager()
+	parentSession := &SessionInfo{SessionID: "via-ppid"}
+	am.pidToSessionMap[2000] = parentSession
+
+	got, ok := am.lookupSessionLocked(0, false, 2000)
+	if !ok || got != parentSession {
+		t.Fatalf("expected parent-pid lookup when sid unavailable, got %v ok=%v", got, ok)
+	}
+}
+
+func TestLookupSessionLocked_SessionIDWinsOverParent(t *testing.T) {
+	am := newTestAuthManager()
+	sidSession := &SessionInfo{SessionID: "via-sid"}
+	parentSession := &SessionInfo{SessionID: "via-ppid"}
+	am.pidToSessionMap[1000] = sidSession
+	am.pidToSessionMap[2000] = parentSession
+
+	got, ok := am.lookupSessionLocked(1000, true, 2000)
+	if !ok || got != sidSession {
+		t.Fatalf("expected sid to take precedence over parent pid, got %v ok=%v", got, ok)
+	}
+}
+
+func TestLookupSessionLocked_NoMatch(t *testing.T) {
+	am := newTestAuthManager()
+	if got, ok := am.lookupSessionLocked(1, true, 2); ok {
+		t.Fatalf("expected no match on empty map, got %v ok=%v", got, ok)
+	}
+}

--- a/pkg/runner/session_unix.go
+++ b/pkg/runner/session_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package runner
+
+import "golang.org/x/sys/unix"
+
+// sessionID returns the session ID (sid) of pid. Every process in the same
+// session shares one sid—the session-leader pid—so sudo invoked anywhere inside
+// a tracked Websh or command session resolves to the leader pid the tracker is
+// keyed on, even when the shell execs sudo and they share a pid, or when
+// intermediate processes sit between the shell and sudo. Reports ok=false when
+// the sid cannot be determined; the caller then falls back to the parent pid.
+func sessionID(pid int) (int, bool) {
+	if pid <= 0 {
+		return 0, false
+	}
+	sid, err := unix.Getsid(pid)
+	if err != nil || sid <= 0 {
+		return 0, false
+	}
+	return sid, true
+}

--- a/pkg/runner/session_unix_test.go
+++ b/pkg/runner/session_unix_test.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package runner
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSessionID_CurrentProcess(t *testing.T) {
+	sid, ok := sessionID(os.Getpid())
+	if !ok || sid <= 0 {
+		t.Fatalf("expected a valid sid for the current process, got sid=%d ok=%v", sid, ok)
+	}
+}
+
+func TestSessionID_InvalidPID(t *testing.T) {
+	// pid 0 would make getsid report the caller's (Alpamon's) own session; we
+	// reject it up front so a bogus request can never match Alpamon's session.
+	if _, ok := sessionID(0); ok {
+		t.Error("expected ok=false for pid 0")
+	}
+	if _, ok := sessionID(-1); ok {
+		t.Error("expected ok=false for negative pid")
+	}
+}

--- a/pkg/runner/session_windows.go
+++ b/pkg/runner/session_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package runner
+
+// sessionID is meaningful only on Unix, where PAM and sudo exist. On Windows it
+// always reports unknown so session resolution falls back to the parent-pid
+// lookup.
+func sessionID(pid int) (int, bool) { return 0, false }


### PR DESCRIPTION
## Problem

Host `sudo` is gated by alpamon's PAM module + sudo approval plugin, which send `{pid, ppid}` over a unix socket. alpamon resolves which tracked Websh/command session the sudo belongs to via `pidToSessionMap`, keyed on the **parent pid**.

That misses for command exec. When `/bin/sh -c "sudo ..."` execs sudo, the sudo process inherits the sh's pid but its **ppid becomes alpamon**, so `pidToSessionMap[ppid]` fails and the sudo is denied or falls through to a password prompt. **An agent running `alpacon exec server -- sudo ...` (or `alpacon websh server -- sudo ...`) could not sudo even when the work session granted the scope** — the headline gap blocking AI agents.

## Fix

Resolve by **session id (sid)** instead of parent pid. The sid is shared by every process in a session, so it survives the shell exec'ing sudo and any intermediate processes.

1. **`sessionID(pid)`** (`unix.Getsid`, unix-only; windows stub) — rejects `pid <= 0` so a bogus payload can never match Alpamon's own session (`getsid(0)` would otherwise return Alpamon's sid).
2. **`enableSessionLeader`** (`Setsid`) on the command exec path, **gated on `PIDHook != nil`** so only the sudo-tracked command path is affected and it merges into (not overwrites) the privilege-demotion `SysProcAttr`. This makes each command's registered pid its own session-leader pid. (Websh's PTY child is already a session leader via creack/pty.)
3. **`lookupSessionLocked(sid, sidOK, parentPID)`** tries `pidToSessionMap[sid]` first, then falls back to the parent-pid lookup. Both `check_user` and `sudo_approval` use it.

The ppid fallback is a **strict superset** of prior behavior — Websh and forked-sudo keep resolving exactly as before; the only outcome that changes is a previously-missed agent sudo is now correctly attributed to its own session. A sid match only ever maps to a session the caller genuinely belongs to (getsid returns the leader pid by kernel definition), so there is no cross-session misattribution.

## Tests

- New: sid-precedence, ppid-fallback, sid-unavailable, no-match (`session_test.go`); current-process happy path + `pid<=0` rejection (`session_unix_test.go`).
- `go build` linux/windows/darwin, `go vet ./...`, `gofmt`, and `go test ./pkg/runner ./pkg/executor -p 1` all green (go1.25.10). (A pre-existing `-race` data race in `resource_test.go`'s perf counter is unrelated and not in CI's `-p 1` command.)

## Review

Security + quality reviewed (subagent): **APPROVED**, 0 blockers / 0 important / 2 nits (both pre-existing lines outside this diff). Confirmed: the `pid<=0` guard closes the `getsid(0)→Alpamon session` hole, `Setsid` is correctly gated and merges with demotion, lock discipline holds, ppid fallback preserves prior grants/denials.

## Dependencies & deploy order

| PR | Repo | Depends on | Deploy |
|---|---|---|---|
| PR-A CLI auth error | alpacon-cli | — | anytime |
| **this (PR-T0)** | alpamon | — | **anytime, independent** |
| PR-P user-scoped presence | alpacon-server | — | anytime (flagged) |
| PR-X gate separation + exec unblock | server + cli | PR-P | after PR-P **and** this |

**PR-T0 is independent and can merge/deploy on its own.** It is the runtime prerequisite for the agent exec-sudo unblock in PR-X: PR-X routes a no-bypass-policy command sudo to risk-gated HITL instead of a hard deny, but the sudo only reaches that logic correctly bound once this sid resolution lands. Deploy this before flipping PR-X to enforce.