### PR TITLE
chore: gofmt migrate files and fix race in executor scaling test

### DIFF
--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -7,7 +7,7 @@
 //
 //  1. Operator creates a registration token in workspace B.
 //  2. Operator opens Websh on the agent's current workspace (A) and runs:
-//       sudo alpamon migrate --url https://b... --token <REGISTRATION_TOKEN>
+//     sudo alpamon migrate --url https://b... --token <REGISTRATION_TOKEN>
 //  3. The command registers on B, atomically swaps /etc/alpamon/alpamon.conf,
 //     writes a marker file, schedules a systemd-run timer to restart
 //     alpamon ~30s later, and returns. The Websh session disconnects as

--- a/cmd/alpamon/command/migrate/migrate_test.go
+++ b/cmd/alpamon/command/migrate/migrate_test.go
@@ -61,11 +61,11 @@ func TestStripGeneratedSuffix(t *testing.T) {
 		"mybox-a3f9c1":                 "mybox",
 		"prod-web-1-deadbe":            "prod-web-1",
 		"production-web-server-abcdef": "production-web-server",
-		"mybox":                        "mybox",                    // no suffix
-		"mybox-AB":                     "mybox-AB",                 // wrong length
-		"mybox-zzzzzz":                 "mybox-zzzzzz",             // non-hex
-		"mybox-a3f9c1-deadbe":          "mybox-a3f9c1",             // strips only the trailing hex suffix
-		"mybox-deadbe-xyz789":          "mybox-deadbe-xyz789",      // trailing non-hex blocks strip
+		"mybox":                        "mybox",               // no suffix
+		"mybox-AB":                     "mybox-AB",            // wrong length
+		"mybox-zzzzzz":                 "mybox-zzzzzz",        // non-hex
+		"mybox-a3f9c1-deadbe":          "mybox-a3f9c1",        // strips only the trailing hex suffix
+		"mybox-deadbe-xyz789":          "mybox-deadbe-xyz789", // trailing non-hex blocks strip
 	}
 	for in, want := range cases {
 		if got := stripGeneratedSuffix(in); got != want {

--- a/pkg/executor/resource_test.go
+++ b/pkg/executor/resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -165,7 +166,7 @@ func TestPerformance_ConcurrentCommandScaling(t *testing.T) {
 				defer cancel()
 				_, _, err := h.Execute(ctx, "scale_cmd", args)
 				if err == nil {
-					completed++
+					atomic.AddInt32(&completed, 1)
 				}
 				return err
 			})
@@ -178,9 +179,10 @@ func TestPerformance_ConcurrentCommandScaling(t *testing.T) {
 
 		wg.Wait()
 		elapsed := time.Since(start)
+		completedCount := atomic.LoadInt32(&completed)
 
 		t.Logf("Concurrency %d: completed %d/%d tasks in %v (%.2f tasks/sec)",
-			concurrency, completed, taskCount, elapsed, float64(completed)/elapsed.Seconds())
+			concurrency, completedCount, taskCount, elapsed, float64(completedCount)/elapsed.Seconds())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Apply gofmt to `cmd/alpamon/command/migrate/` (doc comment indentation, test map literal alignment). No logic changes.
- Fix a data race in `TestPerformance_ConcurrentCommandScaling`: the shared `completed` counter was incremented and read by concurrent goroutines without synchronization. Switched to `sync/atomic` (`AddInt32`/`LoadInt32`).

## Test plan

- [x] `gofmt -l` reports clean
- [x] `go test -race -run TestPerformance_ConcurrentCommandScaling ./pkg/executor/ -p 1` passes