### PR TITLE
ci: bump create-github-app-token v1 → v3 and switch to client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,9 @@ jobs:
       # "Publish stable-alias checksums file" step.
       - name: Generate App token
         id: release-publisher-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_PUBLISHER_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PUBLISHER_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |


### PR DESCRIPTION
## Summary
The token-issuing action `actions/create-github-app-token@v1` in the release workflow (`release.yml`) emits a Node 20 runtime deprecation warning (Node 24 enforced from 2026-06-16). Bump to `@v3` (Node 24) and switch the `app-id` input to `client-id`. Same change as alpacon-cli #224.

## Changes
`.github/workflows/release.yml`

* `actions/create-github-app-token@v1` → `@v3` (Node 24, clears the warning)
* `app-id` → `client-id` input (`app-id` is deprecated as of v3.1.0)
* No changes to the remaining inputs (`private-key`, `owner`, `repositories`, etc.)

## Prerequisites (done)
The `client-id` switch requires the `RELEASE_PUBLISHER_CLIENT_ID` secret. Already registered as an org secret (selected: alpacon-cli, alpamon, homebrew-alpacon — same scope as the existing `RELEASE_PUBLISHER_APP_ID`/`PRIVATE_KEY`). The existing `RELEASE_PUBLISHER_APP_ID` is kept for now as a rollback safeguard.

## Test plan
* Verify token issuance works on the next release tag (`v*`) push (release + homebrew tap push)