### PR TITLE
refactor: remove dead code in utils

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"os/user"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -74,14 +73,6 @@ func JoinPath(base string, paths ...string) string {
 
 func IsSuccessStatusCode(code int) bool {
 	return code/100 == 2
-}
-
-func JoinUint64s(values []uint64) string {
-	var strValues []string
-	for _, value := range values {
-		strValues = append(strValues, fmt.Sprintf("%d", value))
-	}
-	return strings.Join(strValues, ",")
 }
 
 // ScanBlock is a utility function that can be used to scan through text files
@@ -209,59 +200,4 @@ func LookUpGID(groupname string) (int, error) {
 	}
 
 	return strconv.Atoi(group.Gid)
-}
-
-// expandGlobArgs expands glob patterns in arguments using filepath.Glob.
-// baseDir is used as the working directory for relative path glob expansion.
-func ExpandGlobArgs(args []string, baseDir string) []string {
-	var result []string
-	for _, arg := range args {
-		result = append(result, expandSingleGlobArg(arg, baseDir)...)
-	}
-	return result
-}
-
-// expandSingleGlobArg expands a single argument if it contains glob patterns.
-func expandSingleGlobArg(arg, baseDir string) []string {
-	if !containsGlobPattern(arg) {
-		return []string{arg}
-	}
-
-	pattern, isRelative := toAbsolutePattern(arg, baseDir)
-	matches, err := filepath.Glob(pattern)
-	if err != nil || len(matches) == 0 {
-		return []string{arg}
-	}
-
-	if !isRelative {
-		return matches
-	}
-
-	return toRelativePaths(matches, baseDir)
-}
-
-// toAbsolutePattern converts a glob pattern to absolute path if it's relative.
-func toAbsolutePattern(arg, baseDir string) (pattern string, isRelative bool) {
-	if filepath.IsAbs(arg) {
-		return arg, false
-	}
-	return filepath.Join(baseDir, arg), true
-}
-
-// toRelativePaths converts absolute paths back to relative paths based on baseDir.
-func toRelativePaths(paths []string, baseDir string) []string {
-	result := make([]string, 0, len(paths))
-	for _, p := range paths {
-		if rel, err := filepath.Rel(baseDir, p); err == nil {
-			result = append(result, rel)
-		} else {
-			result = append(result, p)
-		}
-	}
-	return result
-}
-
-// containsGlobPattern checks if a string contains glob pattern characters.
-func containsGlobPattern(s string) bool {
-	return strings.ContainsAny(s, "*?[")
 }


### PR DESCRIPTION
## What

Remove unused functions from `pkg/utils/utils.go`: `JoinUint64s` and the `ExpandGlobArgs` family (`expandSingleGlobArg`, `toAbsolutePattern`, `toRelativePaths`, `containsGlobPattern`), plus the now-unneeded `path/filepath` import.

## Why

The removed functions had zero callers. `ExpandGlobArgs` was only ever used by the old `pkg/runner/shell.go`; once shell execution moved to `executor/handlers/shell/`, the call site went away and the functions became dead code.

No behavior change. Build and tests pass.