### PR TITLE
feat(register): add `unregister` command and `register --force` to recover stuck servers

### DIFF
--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -36,15 +36,14 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"text/template"
 	"time"
 
+	"github.com/alpacax/alpamon/v2/pkg/config"
 	"github.com/alpacax/alpamon/v2/pkg/migrate"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/spf13/cobra"
-	"gopkg.in/ini.v1"
 )
 
 // restartDelay is how long systemd waits after the command returns before
@@ -143,7 +142,7 @@ func runMigrate(cmd *cobra.Command, _ []string) error {
 		platform = detectPlatform()
 	}
 
-	current, err := readCurrentServer(configPath)
+	current, err := config.ReadServer(configPath)
 	if err != nil {
 		return fmt.Errorf("read current server from conf: %w", err)
 	}
@@ -253,44 +252,6 @@ func runMigrate(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// currentServer is what we need from the active alpamon.conf to (a) know
-// what workspace we're migrating away from and (b) authenticate to that
-// workspace's API to look up our display name.
-type currentServer struct {
-	URL string
-	ID  string
-	Key string
-}
-
-// readCurrentServer parses the conf as INI and returns the [server]
-// section's url/id/key. config.LoadConfig is unsuitable here because it
-// log.Fatal()s on any validation problem; we want a graceful error path.
-func readCurrentServer(path string) (*currentServer, error) {
-	f, err := ini.Load(path)
-	if err != nil {
-		return nil, fmt.Errorf("parse conf: %w", err)
-	}
-	section, err := f.GetSection("server")
-	if err != nil {
-		return nil, errors.New("[server] section missing")
-	}
-	get := func(name string) string {
-		k, err := section.GetKey(name)
-		if err != nil {
-			return ""
-		}
-		return strings.TrimSpace(k.String())
-	}
-	sc := &currentServer{URL: get("url"), ID: get("id"), Key: get("key")}
-	if sc.URL == "" {
-		return nil, errors.New("url not found in [server] section")
-	}
-	if sc.ID == "" || sc.Key == "" {
-		return nil, errors.New("id/key not found in [server] section")
-	}
-	return sc, nil
-}
-
 // generatedSuffixRE matches the 6-hex-char suffix that
 // servers/api/serializers.py:ServerRegisterSerializer.create appends to
 // every registered server name. We strip it before reusing the operator-
@@ -310,7 +271,7 @@ func stripGeneratedSuffix(name string) string {
 //
 // On any failure (network, auth, 404), returns "" with a non-nil error
 // so the caller can fall back to hostname.
-func fetchCurrentName(ctx context.Context, sc *currentServer) (string, error) {
+func fetchCurrentName(ctx context.Context, sc *config.ServerConfig) (string, error) {
 	url := fmt.Sprintf("%s/api/servers/servers/%s/",
 		strings.TrimSuffix(sc.URL, "/"), sc.ID)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
@@ -349,35 +310,7 @@ func normalizeURL(u string) string {
 }
 
 func buildConfContent(url, id, key string, verify bool, caCertPath string) (string, error) {
-	tpl := `[server]
-url = {{ .URL }}
-id = {{ .ID }}
-key = {{ .Key }}
-
-[ssl]
-verify = {{ .Verify }}
-{{- if .CACert }}
-ca_cert = {{ .CACert }}
-{{- end }}
-
-[logging]
-debug = false
-`
-	t, err := template.New("conf").Parse(tpl)
-	if err != nil {
-		return "", err
-	}
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, map[string]any{
-		"URL":    url,
-		"ID":     id,
-		"Key":    key,
-		"Verify": verify,
-		"CACert": caCertPath,
-	}); err != nil {
-		return "", err
-	}
-	return buf.String(), nil
+	return config.RenderConf(config.ServerConfig{URL: url, ID: id, Key: key}, verify, caCertPath)
 }
 
 // registerRequest mirrors servers/api/serializers.py:ServerRegisterSerializer.

--- a/cmd/alpamon/command/migrate/migrate_test.go
+++ b/cmd/alpamon/command/migrate/migrate_test.go
@@ -4,57 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/alpacax/alpamon/v2/pkg/config"
 )
-
-func TestReadCurrentServer_FindsAllFields(t *testing.T) {
-	dir := t.TempDir()
-	conf := filepath.Join(dir, "alpamon.conf")
-	body := `[server]
-url = https://workspace-a.example.com
-id = abc
-key = secret
-
-[ssl]
-verify = true
-`
-	if err := os.WriteFile(conf, []byte(body), 0600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	got, err := readCurrentServer(conf)
-	if err != nil {
-		t.Fatalf("readCurrentServer: %v", err)
-	}
-	if got.URL != "https://workspace-a.example.com" || got.ID != "abc" || got.Key != "secret" {
-		t.Fatalf("got %+v", got)
-	}
-}
-
-func TestReadCurrentServer_MissingURL(t *testing.T) {
-	dir := t.TempDir()
-	conf := filepath.Join(dir, "alpamon.conf")
-	if err := os.WriteFile(conf, []byte("[server]\nid=abc\nkey=k\n"), 0600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	if _, err := readCurrentServer(conf); err == nil {
-		t.Fatalf("expected error on missing url, got nil")
-	}
-}
-
-func TestReadCurrentServer_MissingIDKey(t *testing.T) {
-	dir := t.TempDir()
-	conf := filepath.Join(dir, "alpamon.conf")
-	if err := os.WriteFile(conf, []byte("[server]\nurl=https://a\n"), 0600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	if _, err := readCurrentServer(conf); err == nil {
-		t.Fatalf("expected error on missing id/key, got nil")
-	}
-}
 
 func TestStripGeneratedSuffix(t *testing.T) {
 	cases := map[string]string{
@@ -94,7 +48,7 @@ func TestFetchCurrentName_HappyPath(t *testing.T) {
 	sslVerify = false
 	caCert = ""
 
-	got, err := fetchCurrentName(t.Context(), &currentServer{
+	got, err := fetchCurrentName(t.Context(), &config.ServerConfig{
 		URL: srv.URL, ID: "srv-xyz", Key: "key-xyz",
 	})
 	if err != nil {
@@ -115,7 +69,7 @@ func TestFetchCurrentName_404SurfacesAsError(t *testing.T) {
 	sslVerify = false
 	caCert = ""
 
-	_, err := fetchCurrentName(t.Context(), &currentServer{
+	_, err := fetchCurrentName(t.Context(), &config.ServerConfig{
 		URL: srv.URL, ID: "srv-xyz", Key: "key-xyz",
 	})
 	if err == nil {

--- a/cmd/alpamon/command/register/recovery_test.go
+++ b/cmd/alpamon/command/register/recovery_test.go
@@ -366,6 +366,7 @@ func TestConfirm(t *testing.T) {
 		"yes\n":  true,
 		"YES\n":  true,
 		" y \n":  true,
+		"y":      true, // no trailing newline (piped) must still count as yes
 		"n\n":    false,
 		"\n":     false,
 		"nope\n": false,

--- a/cmd/alpamon/command/register/recovery_test.go
+++ b/cmd/alpamon/command/register/recovery_test.go
@@ -325,6 +325,27 @@ func TestRunUnregister_DeletesRemoteServiceAndConfig(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "unregister must remove the config")
 }
 
+func TestRunUnregister_MalformedConfigStillClearsLocalState(t *testing.T) {
+	var deleted bool
+	cfg := withRecoveryTestEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = true
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	// Present but unparseable: ReadServer fails, but local state must still be cleared.
+	require.NoError(t, os.WriteFile(cfg, []byte("garbage, no [server] section\n"), 0o600))
+	var removeCalled bool
+	removeServiceFn = func() error { removeCalled = true; return nil }
+
+	err := runUnregister(testCmd(), nil)
+	require.NoError(t, err)
+	assert.False(t, deleted, "no id/key in a malformed config → no remote DELETE")
+	assert.True(t, removeCalled, "the OS service must still be removed")
+	_, statErr := os.Stat(cfg)
+	assert.True(t, os.IsNotExist(statErr), "the malformed config must still be removed")
+}
+
 func TestRunUnregister_NoConfigIsNoop(t *testing.T) {
 	var deleted bool
 	withRecoveryTestEnv(t, func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/alpamon/command/register/recovery_test.go
+++ b/cmd/alpamon/command/register/recovery_test.go
@@ -38,7 +38,7 @@ func mockRegisterServer(newID string, deletedIDs *[]string) http.HandlerFunc {
 
 // withRecoveryTestEnv points the package globals at a mock Alpacon server and a
 // temp config path, and stubs the side-effecting seams (dirs/service) to no-ops
-// so registration logic can be exercised hermetically — without touching the
+// so registration logic can be exercised hermetically—without touching the
 // real filesystem, OS service manager, or network. All globals are restored on
 // cleanup. Returns the temp config path.
 func withRecoveryTestEnv(t *testing.T, handler http.HandlerFunc) string {
@@ -186,7 +186,7 @@ func TestRunRegister_ForceRetiresOldRegistrationAfterNewSucceeds(t *testing.T) {
 func TestRunRegister_ForceStopsServiceEvenWhenPriorConfigUnreadable(t *testing.T) {
 	var deletedIDs []string
 	cfg := withRecoveryTestEnv(t, mockRegisterServer("new-id", &deletedIDs))
-	// Corrupt config: config.ReadServer fails (priorReg stays nil) — the core
+	// Corrupt config: config.ReadServer fails (priorReg stays nil)—the core
 	// stuck-after-failed-register case. A leftover service must still be stopped.
 	require.NoError(t, os.WriteFile(cfg, []byte("garbage, no [server] section\n"), 0o600))
 	force = true

--- a/cmd/alpamon/command/register/recovery_test.go
+++ b/cmd/alpamon/command/register/recovery_test.go
@@ -54,6 +54,7 @@ func withRecoveryTestEnv(t *testing.T, handler http.HandlerFunc) string {
 		oSSL, oForce, oNoRB, oNCP             = sslVerify, force, noRollback, noCloudProbe
 		oTags                                 = tags
 		oDetect                               = detectCloud
+		oEnsure                               = ensureInstalledFn
 		oWrite, oDirs, oStart, oStop, oRemove = writeConfigFileFn, ensureDirectoriesFn, startServiceFn, stopServiceFn, removeServiceFn
 		oUSSL, oUCA, oUYes, oUKeep            = unregisterSSLVerify, unregisterCaCert, unregisterYes, unregisterKeepConfig
 	)
@@ -62,6 +63,7 @@ func withRecoveryTestEnv(t *testing.T, handler http.HandlerFunc) string {
 		sslVerify, force, noRollback, noCloudProbe = oSSL, oForce, oNoRB, oNCP
 		tags = oTags
 		detectCloud = oDetect
+		ensureInstalledFn = oEnsure
 		writeConfigFileFn, ensureDirectoriesFn, startServiceFn, stopServiceFn, removeServiceFn = oWrite, oDirs, oStart, oStop, oRemove
 		unregisterSSLVerify, unregisterCaCert, unregisterYes, unregisterKeepConfig = oUSSL, oUCA, oUYes, oUKeep
 	})
@@ -81,6 +83,9 @@ func withRecoveryTestEnv(t *testing.T, handler http.HandlerFunc) string {
 
 	// Production config writer (writes to the temp configPath), no-op everything
 	// that would touch the OS. Individual tests override as needed.
+	// ensureInstalled is a no-op on Unix but copies the binary + re-execs +
+	// os.Exit on Windows, so it MUST be stubbed for hermetic, cross-platform tests.
+	ensureInstalledFn = func() (bool, error) { return false, nil }
 	writeConfigFileFn = writeConfigFile
 	ensureDirectoriesFn = func() error { return nil }
 	startServiceFn = func() error { return nil }

--- a/cmd/alpamon/command/register/recovery_test.go
+++ b/cmd/alpamon/command/register/recovery_test.go
@@ -1,0 +1,369 @@
+package register
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alpacax/alpamon/v2/pkg/cloud"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockRegisterServer is the common Alpacon mock for these tests: it answers the
+// register POST with a 201 + {newID}, and records the id of every unregister
+// DELETE into deletedIDs (nil to ignore).
+func mockRegisterServer(newID string, deletedIDs *[]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(RegisterResponse{ID: newID, Key: newID + "-key", Name: "test-server"})
+		case http.MethodDelete:
+			if deletedIDs != nil {
+				*deletedIDs = append(*deletedIDs, parseUnregisterID(r.URL.Path))
+			}
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+}
+
+// withRecoveryTestEnv points the package globals at a mock Alpacon server and a
+// temp config path, and stubs the side-effecting seams (dirs/service) to no-ops
+// so registration logic can be exercised hermetically — without touching the
+// real filesystem, OS service manager, or network. All globals are restored on
+// cleanup. Returns the temp config path.
+func withRecoveryTestEnv(t *testing.T, handler http.HandlerFunc) string {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cfg := filepath.Join(t.TempDir(), "alpamon.conf")
+
+	// Snapshot everything we mutate.
+	var (
+		oURL, oToken, oName, oPlat, oCA, oCfg = serverURL, apiToken, serverName, platform, caCert, configPath
+		oSSL, oForce, oNoRB, oNCP             = sslVerify, force, noRollback, noCloudProbe
+		oTags                                 = tags
+		oDetect                               = detectCloud
+		oWrite, oDirs, oStart, oStop, oRemove = writeConfigFileFn, ensureDirectoriesFn, startServiceFn, stopServiceFn, removeServiceFn
+		oUSSL, oUCA, oUYes, oUKeep            = unregisterSSLVerify, unregisterCaCert, unregisterYes, unregisterKeepConfig
+	)
+	t.Cleanup(func() {
+		serverURL, apiToken, serverName, platform, caCert, configPath = oURL, oToken, oName, oPlat, oCA, oCfg
+		sslVerify, force, noRollback, noCloudProbe = oSSL, oForce, oNoRB, oNCP
+		tags = oTags
+		detectCloud = oDetect
+		writeConfigFileFn, ensureDirectoriesFn, startServiceFn, stopServiceFn, removeServiceFn = oWrite, oDirs, oStart, oStop, oRemove
+		unregisterSSLVerify, unregisterCaCert, unregisterYes, unregisterKeepConfig = oUSSL, oUCA, oUYes, oUKeep
+	})
+
+	serverURL = server.URL
+	apiToken = "test-token"
+	serverName = "test-server"
+	platform = "debian"
+	caCert = ""
+	sslVerify = true
+	force = false
+	noRollback = false
+	noCloudProbe = true // keep detectCloudTags from touching the network
+	tags = nil
+	configPath = cfg
+	detectCloud = func(context.Context) (*cloud.Metadata, error) { return nil, cloud.ErrNoCloudProvider }
+
+	// Production config writer (writes to the temp configPath), no-op everything
+	// that would touch the OS. Individual tests override as needed.
+	writeConfigFileFn = writeConfigFile
+	ensureDirectoriesFn = func() error { return nil }
+	startServiceFn = func() error { return nil }
+	stopServiceFn = func() error { return nil }
+	removeServiceFn = func() error { return nil }
+
+	unregisterSSLVerify = true
+	unregisterCaCert = ""
+	unregisterYes = true
+	unregisterKeepConfig = false
+
+	return cfg
+}
+
+func testCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+	return c
+}
+
+func parseUnregisterID(p string) string {
+	p = strings.TrimSuffix(p, "/")
+	p = strings.TrimSuffix(p, "/unregister")
+	if idx := strings.LastIndex(p, "/"); idx >= 0 {
+		return p[idx+1:]
+	}
+	return p
+}
+
+func writeConf(t *testing.T, path, url, id, key string) {
+	t.Helper()
+	body := "[server]\nurl = " + url + "\nid = " + id + "\nkey = " + key + "\n\n[ssl]\nverify = true\n"
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+}
+
+// --- Within-run rollback ------------------------------------------------------
+
+func TestRunRegister_RollbackUnregistersOnConfigWriteFailure(t *testing.T) {
+	var deletedIDs []string
+	cfg := withRecoveryTestEnv(t, mockRegisterServer("new-id", &deletedIDs))
+
+	// Fault the config write: the remote record exists by then, so the deferred
+	// rollback must best-effort unregister it.
+	writeConfigFileFn = func(*RegisterResponse) error { return errors.New("disk full") }
+
+	err := runRegister(testCmd(), nil)
+	require.Error(t, err)
+	assert.Contains(t, deletedIDs, "new-id", "rollback must DELETE the just-created remote record")
+	_, statErr := os.Stat(cfg)
+	assert.True(t, os.IsNotExist(statErr), "no config should be left behind")
+}
+
+func TestRunRegister_NoRollbackLeavesRemoteRecord(t *testing.T) {
+	var deletedIDs []string
+	withRecoveryTestEnv(t, mockRegisterServer("new-id", &deletedIDs))
+	noRollback = true
+	writeConfigFileFn = func(*RegisterResponse) error { return errors.New("disk full") }
+
+	err := runRegister(testCmd(), nil)
+	require.Error(t, err)
+	assert.Empty(t, deletedIDs, "--no-rollback must not issue a compensating DELETE")
+}
+
+func TestRunRegister_ServiceStartFailureDoesNotRollback(t *testing.T) {
+	var deletedIDs []string
+	cfg := withRecoveryTestEnv(t, mockRegisterServer("new-id", &deletedIDs))
+	startServiceFn = func() error { return errors.New("service start failed") }
+
+	err := runRegister(testCmd(), nil)
+	require.NoError(t, err, "a best-effort service-start failure is non-fatal")
+	assert.Empty(t, deletedIDs, "service-start failure must not trigger rollback")
+	_, statErr := os.Stat(cfg)
+	assert.NoError(t, statErr, "config must persist when registration committed")
+}
+
+// --- register --force ---------------------------------------------------------
+
+func TestRunRegister_ForceRetiresOldRegistrationAfterNewSucceeds(t *testing.T) {
+	var deletedIDs []string
+	cfg := withRecoveryTestEnv(t, mockRegisterServer("new-id", &deletedIDs))
+	writeConf(t, cfg, serverURL, "old-id", "old-key")
+	force = true
+	var stopCalled bool
+	stopServiceFn = func() error { stopCalled = true; return nil }
+
+	err := runRegister(testCmd(), nil)
+	require.NoError(t, err)
+	assert.Contains(t, deletedIDs, "old-id", "old remote record must be unregistered after the new one succeeds")
+	assert.NotContains(t, deletedIDs, "new-id", "the new record must not be unregistered on success")
+	assert.True(t, stopCalled, "previous service must be stopped before the fresh start")
+
+	data, readErr := os.ReadFile(cfg)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "id = new-id", "config must be rewritten with the new identity")
+}
+
+func TestRunRegister_ForceStopsServiceEvenWhenPriorConfigUnreadable(t *testing.T) {
+	var deletedIDs []string
+	cfg := withRecoveryTestEnv(t, mockRegisterServer("new-id", &deletedIDs))
+	// Corrupt config: config.ReadServer fails (priorReg stays nil) — the core
+	// stuck-after-failed-register case. A leftover service must still be stopped.
+	require.NoError(t, os.WriteFile(cfg, []byte("garbage, no [server] section\n"), 0o600))
+	force = true
+	var stopCalled bool
+	stopServiceFn = func() error { stopCalled = true; return nil }
+
+	err := runRegister(testCmd(), nil)
+	require.NoError(t, err)
+	assert.True(t, stopCalled, "stopService must run under --force even when the prior config is unreadable")
+	assert.Empty(t, deletedIDs, "with an unreadable prior config there is no old id/key to unregister")
+
+	data, readErr := os.ReadFile(cfg)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "id = new-id", "corrupt config must be replaced with the new identity")
+}
+
+// finding #1: a write failure under --force must NOT lose the existing config.
+func TestRunRegister_ForceKeepsOldConfigWhenWriteFails(t *testing.T) {
+	var deletedIDs []string
+	cfg := withRecoveryTestEnv(t, mockRegisterServer("new-id", &deletedIDs))
+	writeConf(t, cfg, serverURL, "old-id", "old-key")
+	force = true
+	writeConfigFileFn = func(*RegisterResponse) error { return errors.New("disk full") }
+
+	err := runRegister(testCmd(), nil)
+	require.Error(t, err)
+	assert.Contains(t, deletedIDs, "new-id", "the just-created record must be rolled back")
+	assert.NotContains(t, deletedIDs, "old-id", "the old record must be left intact (its teardown never runs)")
+
+	data, readErr := os.ReadFile(cfg)
+	require.NoError(t, readErr, "the existing config must NOT be lost on a write failure")
+	assert.Contains(t, string(data), "id = old-id")
+}
+
+// finding #1: a post-write failure under --force must RESTORE the prior config.
+func TestRunRegister_ForceRestoresOldConfigWhenDirSetupFails(t *testing.T) {
+	var deletedIDs []string
+	cfg := withRecoveryTestEnv(t, mockRegisterServer("new-id", &deletedIDs))
+	writeConf(t, cfg, serverURL, "old-id", "old-key")
+	force = true
+	// writeConfigFile (real) succeeds and replaces the config with new-id; the
+	// next step then fails, so the rollback must restore the old config.
+	ensureDirectoriesFn = func() error { return errors.New("mkdir failed") }
+
+	err := runRegister(testCmd(), nil)
+	require.Error(t, err)
+	assert.Contains(t, deletedIDs, "new-id", "the just-created record must be rolled back")
+	assert.NotContains(t, deletedIDs, "old-id", "the old record must be left intact")
+
+	data, readErr := os.ReadFile(cfg)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "id = old-id", "the prior config must be restored on rollback")
+}
+
+func TestRunRegister_ForceDoesNotTearDownOldWhenNewRegistrationFails(t *testing.T) {
+	var deleted bool
+	cfg := withRecoveryTestEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			// New registration rejected (e.g. invalid/expired token).
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"detail":"invalid token"}`))
+		case http.MethodDelete:
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+	writeConf(t, cfg, serverURL, "old-id", "old-key")
+	force = true
+
+	err := runRegister(testCmd(), nil)
+	require.Error(t, err, "a rejected registration must surface as an error")
+	assert.False(t, deleted, "the existing registration must NOT be unregistered when the new POST fails")
+
+	data, readErr := os.ReadFile(cfg)
+	require.NoError(t, readErr, "the existing config must be left intact")
+	assert.Contains(t, string(data), "id = old-id")
+}
+
+// --- unregister ---------------------------------------------------------------
+
+func TestRunUnregister_DeletesRemoteServiceAndConfig(t *testing.T) {
+	var deleted bool
+	var auth string
+	cfg := withRecoveryTestEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = true
+			auth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+	writeConf(t, cfg, serverURL, "srv-1", "key-1")
+	var removeCalled bool
+	removeServiceFn = func() error { removeCalled = true; return nil }
+
+	err := runUnregister(testCmd(), nil)
+	require.NoError(t, err)
+	assert.True(t, deleted, "unregister must DELETE the remote record")
+	assert.Contains(t, auth, `id="srv-1"`, "unregister must authenticate with the server id/key")
+	assert.True(t, removeCalled, "unregister must remove the OS service")
+	_, statErr := os.Stat(cfg)
+	assert.True(t, os.IsNotExist(statErr), "unregister must remove the config")
+}
+
+func TestRunUnregister_NoConfigIsNoop(t *testing.T) {
+	var deleted bool
+	withRecoveryTestEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = true
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	// configPath points at a temp file that does not exist.
+	err := runUnregister(testCmd(), nil)
+	require.NoError(t, err, "unregister on a clean box is a no-op")
+	assert.False(t, deleted)
+}
+
+func TestRunUnregister_KeepConfigPreservesConfig(t *testing.T) {
+	var deleted bool
+	cfg := withRecoveryTestEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = true
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	writeConf(t, cfg, serverURL, "srv-1", "key-1")
+	unregisterKeepConfig = true
+
+	err := runUnregister(testCmd(), nil)
+	require.NoError(t, err)
+	assert.True(t, deleted)
+	_, statErr := os.Stat(cfg)
+	assert.NoError(t, statErr, "--keep-config must leave the config in place")
+}
+
+// --- confirm / flags / removeService -----------------------------------------
+
+func TestConfirm(t *testing.T) {
+	cases := map[string]bool{
+		"y\n":    true,
+		"Y\n":    true,
+		"yes\n":  true,
+		"YES\n":  true,
+		" y \n":  true,
+		"n\n":    false,
+		"\n":     false,
+		"nope\n": false,
+		"":       false, // EOF / empty stdin → abort
+	}
+	for in, want := range cases {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		_, _ = w.WriteString(in)
+		_ = w.Close()
+
+		old := os.Stdin
+		os.Stdin = r
+		got := confirm("proceed?")
+		os.Stdin = old
+		_ = r.Close()
+
+		assert.Equalf(t, want, got, "confirm(%q)", in)
+	}
+}
+
+func TestRecoveryFlagsRegistered(t *testing.T) {
+	assert.NotNil(t, RegisterCmd.Flags().Lookup("force"))
+	assert.NotNil(t, RegisterCmd.Flags().Lookup("no-rollback"))
+	assert.NotNil(t, UnregisterCmd.Flags().Lookup("yes"))
+	assert.NotNil(t, UnregisterCmd.Flags().Lookup("keep-config"))
+	assert.NotNil(t, UnregisterCmd.Flags().Lookup("ssl-verify"))
+	assert.NotNil(t, UnregisterCmd.Flags().Lookup("ca-cert"))
+}
+
+// TestRemoveService_Idempotent exercises the real per-OS removeService against
+// the live service manager. It is gated behind ALPAMON_TEST_SERVICE because it
+// would stop/delete a real alpamon service if one is installed on the host;
+// run with ALPAMON_TEST_SERVICE=1 on a throwaway box. On a clean box it must be
+// a no-op that returns nil.
+func TestRemoveService_Idempotent(t *testing.T) {
+	if os.Getenv("ALPAMON_TEST_SERVICE") != "1" {
+		t.Skip("set ALPAMON_TEST_SERVICE=1 to run (touches the real OS service manager)")
+	}
+	assert.NoError(t, removeService())
+}

--- a/cmd/alpamon/command/register/recovery_test.go
+++ b/cmd/alpamon/command/register/recovery_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -217,6 +218,40 @@ func TestRunRegister_ForceKeepsOldConfigWhenWriteFails(t *testing.T) {
 
 	data, readErr := os.ReadFile(cfg)
 	require.NoError(t, readErr, "the existing config must NOT be lost on a write failure")
+	assert.Contains(t, string(data), "id = old-id")
+}
+
+// --force must fail fast (before the POST) when an existing config is present
+// but unreadable, rather than overwriting it with no way to restore on rollback.
+func TestRunRegister_ForceFailsFastWhenExistingConfigUnreadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0000 does not block reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions")
+	}
+	var posted bool
+	cfg := withRecoveryTestEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			posted = true
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(RegisterResponse{ID: "new-id", Key: "new-key", Name: "test-server"})
+	})
+	writeConf(t, cfg, serverURL, "old-id", "old-key")
+	require.NoError(t, os.Chmod(cfg, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(cfg, 0o600) })
+	force = true
+
+	err := runRegister(testCmd(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot read existing config")
+	assert.False(t, posted, "must fail fast before creating a new remote record")
+
+	// The existing config must be left untouched.
+	require.NoError(t, os.Chmod(cfg, 0o600))
+	data, readErr := os.ReadFile(cfg)
+	require.NoError(t, readErr)
 	assert.Contains(t, string(data), "id = old-id")
 }
 

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -15,10 +15,11 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/alpacax/alpamon/v2/pkg/cloud"
+	"github.com/alpacax/alpamon/v2/pkg/config"
+	"github.com/alpacax/alpamon/v2/pkg/migrate"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/spf13/cobra"
@@ -38,6 +39,8 @@ var (
 	caCert       string
 	tags         map[string]string
 	noCloudProbe bool
+	force        bool
+	noRollback   bool
 
 	// detectCloud is overridable in tests to inject a stub detector. Production
 	// uses cloud.Detect with the default provider list.
@@ -45,6 +48,17 @@ var (
 		_, meta, err := cloud.Detect(ctx, cloud.DefaultProviders())
 		return meta, err
 	}
+
+	// Test seams: indirections over the side-effecting steps so registration
+	// logic (within-run rollback, --force ordering) can be exercised without
+	// touching the real filesystem, OS service manager, or relying on platform
+	// service behavior. They default to the production implementations, mirroring
+	// the detectCloud seam above.
+	writeConfigFileFn   = writeConfigFile
+	ensureDirectoriesFn = ensureDirectories
+	startServiceFn      = startService
+	stopServiceFn       = stopService
+	removeServiceFn     = removeService
 )
 
 // registerCloudDetectTimeout caps the synchronous cloud probe at register time
@@ -115,6 +129,8 @@ func init() {
 	RegisterCmd.Flags().StringVar(&caCert, "ca-cert", "", "CA certificate path")
 	RegisterCmd.Flags().StringToStringVar(&tags, "tag", nil, "Server tags in key=value format (repeatable, or comma-separated: \"k1=v1,k2=v2\")")
 	RegisterCmd.Flags().BoolVar(&noCloudProbe, "no-cloud-probe", false, "Skip cloud metadata IMDS probe at registration")
+	RegisterCmd.Flags().BoolVar(&force, "force", false, "Unregister any existing registration before registering (recover a stuck server)")
+	RegisterCmd.Flags().BoolVar(&noRollback, "no-rollback", false, "On failure, leave partial state in place instead of cleaning it up (for debugging)")
 
 	_ = RegisterCmd.MarkFlagRequired("url")
 	_ = RegisterCmd.MarkFlagRequired("token")
@@ -131,32 +147,160 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// 1. Check if config file already exists (prevent re-registration)
-	if info, err := os.Stat(configPath); err == nil {
-		if info.Size() > 0 {
-			return fmt.Errorf("config file already exists: %s\nServer is already registered. To re-register, first unregister this server from the Alpacon console, then delete the config file and run register again", configPath)
+	// 0b. With --force, capture the existing registration up front: the parsed
+	// [server] block (to retire the old remote record) and the raw config bytes
+	// (to restore on rollback). Reading now — before the new POST — is harmless;
+	// the actual teardown happens only once we are committed, so an invalid token
+	// or unreachable --url aborts before we touch the existing healthy install.
+	var priorReg *config.ServerConfig
+	var oldConf []byte
+	oldConfMode := os.FileMode(0o600)
+	if force {
+		if srv, err := config.ReadServer(configPath); err == nil {
+			priorReg = srv
 		}
-		// Empty config file exists (likely created by systemd-tmpfiles) — will be cleaned up during registration
-		fmt.Printf("Note: Empty config file found at %s, will be overwritten\n", configPath)
+		if b, err := os.ReadFile(configPath); err == nil {
+			oldConf = b
+			if fi, statErr := os.Stat(configPath); statErr == nil {
+				oldConfMode = fi.Mode().Perm()
+			}
+		}
 	}
 
-	// 2. Auto-detect server name from hostname if not provided
+	// 1. Reject a re-register when a live config already exists (skipped under
+	// --force, which intentionally replaces an existing registration).
+	if !force {
+		if err := ensureNotAlreadyRegistered(); err != nil {
+			return err
+		}
+	}
+
+	// 2–5. Resolve the server name (hostname fallback + slug normalization),
+	// platform, and merged cloud/user tags, and assemble the request body.
+	reqBody, err := buildRegisterRequest(cmd)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Registering server: %s\n", serverURL)
+
+	// Within-run rollback: unless --no-rollback, undo state THIS invocation
+	// created if a later step fails. Compensations run LIFO (local cleanup
+	// first, the single remote DELETE last — matching the saga ordering in
+	// pkg/migrate). committed is flipped once the registration is durably
+	// usable; after that point a best-effort service-start failure must NOT
+	// trigger a rollback (a registered server whose service merely failed to
+	// start is recoverable, and tearing it down would be hostile).
+	var rollbacks []func() error
+	committed := false
+	defer func() {
+		if committed || noRollback {
+			return
+		}
+		var errs []error
+		for i := len(rollbacks) - 1; i >= 0; i-- {
+			if e := rollbacks[i](); e != nil {
+				errs = append(errs, e)
+			}
+		}
+		if e := errors.Join(errs...); e != nil {
+			fmt.Printf("Warning: cleanup after the failed registration did not fully complete: %v\n", e)
+		}
+	}()
+
+	// 6. API call (creates the remote server record).
+	resp, err := sendRegisterRequest(reqBody)
+	if err != nil {
+		return err
+	}
+	rollbacks = append(rollbacks, func() error {
+		migrate.BestEffortUnregister(serverURL, resp.ID, resp.Key, sslVerify, caCert)
+		return nil
+	})
+
+	// 7. Write the config via atomic replace (temp + rename, see writeConfigFile).
+	// Under --force the previous config stays intact until the new one is renamed
+	// into place, so a failed write can never leave the host with no config. The
+	// rollback compensation restores the previous config under --force, or removes
+	// the freshly written one otherwise.
+	if err := writeConfigFileFn(resp); err != nil {
+		return fmt.Errorf("failed to create config file: %w", err)
+	}
+	if force && oldConf != nil {
+		rollbacks = append(rollbacks, func() error {
+			return migrate.WriteConfAtomic(configPath, oldConf, oldConfMode)
+		})
+	} else {
+		rollbacks = append(rollbacks, func() error { return removeOnRollback(configPath) })
+	}
+
+	// 8. Create required directories
+	if err := ensureDirectoriesFn(); err != nil {
+		return fmt.Errorf("failed to create directories: %w", err)
+	}
+
+	// Registration is durably usable from here (config + dirs written).
+	committed = true
+
+	// 8b. --force: now that the new registration is committed, retire the old one.
+	if force {
+		retirePriorRegistration(priorReg, resp.ID)
+	}
+
+	// 9. Start service
+	fmt.Println("\nStarting alpamon service...")
+	if err := startServiceFn(); err != nil {
+		fmt.Printf("Warning: Failed to start service: %v\n", err)
+		printManualStartHint()
+	}
+
+	// 10. Success message
+	printRegisterSuccess(resp)
+	return nil
+}
+
+// ensureNotAlreadyRegistered fails if a non-empty config already exists, telling
+// the operator how to re-register (unregister / --force). An empty config (e.g.
+// left by systemd-tmpfiles) is allowed and will be overwritten; a missing or
+// unreadable config does not block registration.
+func ensureNotAlreadyRegistered() error {
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return nil
+	}
+	if info.Size() > 0 {
+		return fmt.Errorf("config file already exists: %s\n"+
+			"This server appears to be already registered. To re-register, run:\n"+
+			"  alpamon unregister       # unregister and clear local state, then\n"+
+			"  alpamon register ...     # register again\n"+
+			"or do both at once with: alpamon register --force ...", configPath)
+	}
+	fmt.Printf("Note: Empty config file found at %s, will be overwritten\n", configPath)
+	return nil
+}
+
+// buildRegisterRequest resolves the server name (hostname fallback + slug
+// normalization), platform, and merged cloud/user tags, and returns the request
+// body to POST. It prints what it auto-detected/normalized. cmd's context is
+// passed through so the cloud IMDS probe stays cancelable. User-supplied --tag
+// values win over auto-detected cloud tags so an operator can override a
+// misdetection.
+func buildRegisterRequest(cmd *cobra.Command) (RegisterRequest, error) {
 	if serverName == "" {
 		hostname, err := os.Hostname()
 		if err != nil {
-			return fmt.Errorf("failed to get hostname: %w", err)
+			return RegisterRequest{}, fmt.Errorf("failed to get hostname: %w", err)
 		}
 		serverName = normalizeHostname(hostname)
 		fmt.Printf("Server name auto-detected: %s\n", serverName)
 	}
 
-	// 2b. Normalize to the server's slug rule (^[-a-zA-Z0-9_]+$). Applies to
-	// both the --name path and the hostname path so registration never fails
-	// with {"code":"invalid"} on a name the server would reject.
+	// Normalize to the server's slug rule (^[-a-zA-Z0-9_]+$) for both the --name
+	// and hostname paths so registration never fails with {"code":"invalid"}.
 	original := serverName
 	serverName = normalizeServerName(serverName)
 	if serverName == "" {
-		return fmt.Errorf(
+		return RegisterRequest{}, fmt.Errorf(
 			"server name %q is empty after normalization; pass a valid --name "+
 				"(allowed characters: A-Z a-z 0-9 _ -)", original)
 	}
@@ -164,51 +308,36 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Server name normalized to %q\n", serverName)
 	}
 
-	// 3. Auto-detect platform
 	if platform == "" {
 		platform = detectPlatform()
 		fmt.Printf("Platform auto-detected: %s\n", platform)
 	}
 
-	// 4. Auto-detect cloud provider metadata (best-effort) and merge with
-	// operator-supplied --tag flags. User-supplied tags win over auto-detected
-	// values so an operator can override a misdetection (e.g. forcing
-	// `--tag cloud:provider=aws` on a host where IMDS is restricted).
 	finalTags := mergeCloudAndUserTags(detectCloudTags(cmd.Context()), tags)
 
-	// 5. Create registration request body
-	reqBody := RegisterRequest{
-		Name:     serverName,
-		Platform: platform,
-		Tags:     finalTags,
+	return RegisterRequest{Name: serverName, Platform: platform, Tags: finalTags}, nil
+}
+
+// retirePriorRegistration tears down the registration that --force is replacing,
+// AFTER the new one is committed. It stops (not deletes) the previously-running
+// service so the fresh start reloads the new config — this runs even when the
+// prior config was unreadable, because a leftover service from a failed install
+// may still be running with stale credentials (the stuck case --force exists
+// for). The remote unregister needs the old id/key, so it is gated on a readable
+// prior config; its DELETE uses this invocation's TLS flags (assumes homogeneous
+// TLS across workspaces — the common same-workspace re-register).
+func retirePriorRegistration(priorReg *config.ServerConfig, newID string) {
+	if priorReg != nil && priorReg.ID != newID {
+		fmt.Printf("--force: unregistering previous server record %s ...\n", priorReg.ID)
+		migrate.BestEffortUnregister(priorReg.URL, priorReg.ID, priorReg.Key, sslVerify, caCert)
 	}
-
-	fmt.Printf("Registering server: %s\n", serverURL)
-
-	// 6. API call
-	resp, err := sendRegisterRequest(reqBody)
-	if err != nil {
-		return err
+	if err := stopServiceFn(); err != nil {
+		fmt.Printf("Warning: failed to stop the previous service: %v\n", err)
 	}
+}
 
-	// 7. Create config file
-	if err := writeConfigFile(resp); err != nil {
-		return fmt.Errorf("failed to create config file: %w", err)
-	}
-
-	// 8. Create required directories
-	if err := ensureDirectories(); err != nil {
-		return fmt.Errorf("failed to create directories: %w", err)
-	}
-
-	// 9. Start service
-	fmt.Println("\nStarting alpamon service...")
-	if err := startService(); err != nil {
-		fmt.Printf("Warning: Failed to start service: %v\n", err)
-		printManualStartHint()
-	}
-
-	// 10. Success message
+// printRegisterSuccess prints the post-registration summary banner.
+func printRegisterSuccess(resp *RegisterResponse) {
 	fmt.Printf("\n==========================================\n")
 	fmt.Printf("Server registered successfully!\n")
 	fmt.Printf("==========================================\n")
@@ -216,7 +345,14 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  ID:   %s\n", resp.ID)
 	fmt.Printf("  Config: %s\n", configPath)
 	fmt.Printf("==========================================\n")
+}
 
+// removeOnRollback deletes path, tolerating an already-absent file. Used as a
+// within-run rollback compensation for the config written during registration.
+func removeOnRollback(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
 	return nil
 }
 
@@ -423,49 +559,16 @@ func createHTTPClient() (*http.Client, error) {
 }
 
 func writeConfigFile(resp *RegisterResponse) error {
-	configTemplate := `[server]
-url = {{ .URL }}
-id = {{ .ID }}
-key = {{ .Key }}
-
-[ssl]
-verify = {{ .Verify }}
-{{- if .CACert }}
-ca_cert = {{ .CACert }}
-{{- end }}
-
-[logging]
-debug = false
-`
-	// Create directory
-	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
-	}
-
-	// Remove empty config file left by systemd-tmpfiles if present
-	if info, err := os.Stat(configPath); err == nil && info.Size() == 0 {
-		if err := os.Remove(configPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to remove empty config file: %w", err)
-		}
-	}
-
-	// Create config file (fail if already exists)
-	file, err := os.OpenFile(configPath, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0600)
+	content, err := config.RenderConf(
+		config.ServerConfig{URL: serverURL, ID: resp.ID, Key: resp.Key},
+		sslVerify, caCert,
+	)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = file.Close() }()
-
-	tmpl, err := template.New("config").Parse(configTemplate)
-	if err != nil {
-		return fmt.Errorf("failed to parse template: %w", err)
-	}
-
-	return tmpl.Execute(file, map[string]interface{}{
-		"URL":    serverURL,
-		"ID":     resp.ID,
-		"Key":    resp.Key,
-		"Verify": sslVerify,
-		"CACert": caCert,
-	})
+	// Atomic replace (temp + fsync + rename, creating the dir at 0700): the file
+	// is never left half-written, and any existing config (e.g. an empty file
+	// from systemd-tmpfiles, or a prior registration under --force) is replaced
+	// only at the final rename — so a failed write cannot orphan the host.
+	return migrate.WriteConfAtomic(configPath, []byte(content), 0o600)
 }

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -117,7 +117,9 @@ Options:
   --ssl-verify      SSL certificate verification (default: true)
   --ca-cert         CA certificate path
   --tag             Server tags in key=value format (repeatable, or comma-separated: "k1=v1,k2=v2")
-  --no-cloud-probe  Skip cloud metadata IMDS probe`,
+  --no-cloud-probe  Skip cloud metadata IMDS probe
+  --force           Recover a stuck server: register anew, then retire the previous registration
+  --no-rollback     On failure, leave partial state in place instead of cleaning it up (debug)`,
 	RunE: runRegister,
 }
 
@@ -130,7 +132,7 @@ func init() {
 	RegisterCmd.Flags().StringVar(&caCert, "ca-cert", "", "CA certificate path")
 	RegisterCmd.Flags().StringToStringVar(&tags, "tag", nil, "Server tags in key=value format (repeatable, or comma-separated: \"k1=v1,k2=v2\")")
 	RegisterCmd.Flags().BoolVar(&noCloudProbe, "no-cloud-probe", false, "Skip cloud metadata IMDS probe at registration")
-	RegisterCmd.Flags().BoolVar(&force, "force", false, "Unregister any existing registration before registering (recover a stuck server)")
+	RegisterCmd.Flags().BoolVar(&force, "force", false, "Recover a stuck server: register anew, then retire the previous registration once the new one is committed")
 	RegisterCmd.Flags().BoolVar(&noRollback, "no-rollback", false, "On failure, leave partial state in place instead of cleaning it up (for debugging)")
 
 	_ = RegisterCmd.MarkFlagRequired("url")

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -274,15 +274,19 @@ func runRegister(cmd *cobra.Command, args []string) error {
 }
 
 // ensureNotAlreadyRegistered fails if a non-empty config already exists, telling
-// the operator how to re-register (unregister / --force). An empty config (e.g.
-// left by systemd-tmpfiles) is allowed and will be overwritten; a missing or
-// unreadable config does not block registration.
+// the operator how to re-register (unregister / --force). A missing config is the
+// clean case; an empty config (e.g. left by systemd-tmpfiles) is allowed and will
+// be overwritten. A non-not-exist stat error (e.g. permission/ACL) is surfaced
+// rather than silently treated as "no config", which would otherwise fail later
+// with a less actionable error during the config write.
 func ensureNotAlreadyRegistered() error {
 	info, err := os.Stat(configPath)
-	if err != nil {
+	switch {
+	case os.IsNotExist(err):
 		return nil
-	}
-	if info.Size() > 0 {
+	case err != nil:
+		return fmt.Errorf("inspect config %s: %w", configPath, err)
+	case info.Size() > 0:
 		return fmt.Errorf("config file already exists: %s\n"+
 			"this server appears to be already registered; re-register by running "+
 			"'alpamon register --force', or 'alpamon unregister' and then 'alpamon register' again",

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -156,6 +156,8 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	var priorReg *config.ServerConfig
 	var oldConf []byte
 	oldConfMode := os.FileMode(0o600)
+	oldSSLVerify := true
+	var oldCACert string
 	if force {
 		// Capture the existing config so a later rollback can restore it. If a
 		// config is present but unreadable, fail fast: writeConfigFile would
@@ -163,6 +165,8 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		// then drop it via removeOnRollback, leaving the host with no config and
 		// breaking the --force guarantee. oldConf is therefore set iff a prior
 		// config existed and was captured (an empty placeholder, size 0, is not).
+		// Also capture the prior [ssl] so retiring the old remote record speaks
+		// the OLD workspace's TLS, not this invocation's flags.
 		if info, statErr := os.Stat(configPath); statErr == nil && info.Size() > 0 {
 			b, readErr := os.ReadFile(configPath)
 			if readErr != nil {
@@ -173,6 +177,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 			if srv, err := config.ReadServer(configPath); err == nil {
 				priorReg = srv
 			}
+			oldSSLVerify, oldCACert = config.ReadSSL(configPath)
 		}
 	}
 
@@ -253,7 +258,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 
 	// 8b. --force: now that the new registration is committed, retire the old one.
 	if force {
-		retirePriorRegistration(priorReg, resp.ID)
+		retirePriorRegistration(priorReg, resp.ID, oldSSLVerify, oldCACert)
 	}
 
 	// 9. Start service
@@ -328,13 +333,13 @@ func buildRegisterRequest(cmd *cobra.Command) (RegisterRequest, error) {
 
 // retirePriorRegistration tears down the registration that --force is replacing,
 // AFTER the new one is committed. It stops (not deletes) the previously-running
-// service so the fresh start reloads the new config — this runs even when the
+// service so the fresh start reloads the new config; this runs even when the
 // prior config was unreadable, because a leftover service from a failed install
 // may still be running with stale credentials (the stuck case --force exists
 // for). The remote unregister needs the old id/key, so it is gated on a readable
-// prior config; its DELETE uses this invocation's TLS flags (assumes homogeneous
-// TLS across workspaces — the common same-workspace re-register).
-func retirePriorRegistration(priorReg *config.ServerConfig, newID string) {
+// prior config, and it uses the OLD config's TLS settings (sslVerify/caCert) so
+// it works against a self-signed / private-CA prior workspace.
+func retirePriorRegistration(priorReg *config.ServerConfig, newID string, sslVerify bool, caCert string) {
 	if priorReg != nil && priorReg.ID != newID {
 		fmt.Printf("--force: unregistering previous server record %s ...\n", priorReg.ID)
 		migrate.BestEffortUnregister(priorReg.URL, priorReg.ID, priorReg.Key, sslVerify, caCert)

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -150,7 +150,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 
 	// 0b. With --force, capture the existing registration up front: the parsed
 	// [server] block (to retire the old remote record) and the raw config bytes
-	// (to restore on rollback). Reading now — before the new POST — is harmless;
+	// (to restore on rollback). Reading now—before the new POST—is harmless;
 	// the actual teardown happens only once we are committed, so an invalid token
 	// or unreachable --url aborts before we touch the existing healthy install.
 	var priorReg *config.ServerConfig
@@ -200,7 +200,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 
 	// Within-run rollback: unless --no-rollback, undo state THIS invocation
 	// created if a later step fails. Compensations run LIFO (local cleanup
-	// first, the single remote DELETE last — matching the saga ordering in
+	// first, the single remote DELETE last—matching the saga ordering in
 	// pkg/migrate). committed is flipped once the registration is durably
 	// usable; after that point a best-effort service-start failure must NOT
 	// trigger a rollback (a registered server whose service merely failed to
@@ -582,6 +582,6 @@ func writeConfigFile(resp *RegisterResponse) error {
 	// Atomic replace (temp + fsync + rename, creating the dir at 0700): the file
 	// is never left half-written, and any existing config (e.g. an empty file
 	// from systemd-tmpfiles, or a prior registration under --force) is replaced
-	// only at the final rename — so a failed write cannot orphan the host.
+	// only at the final rename—so a failed write cannot orphan the host.
 	return migrate.WriteConfAtomic(configPath, []byte(content), 0o600)
 }

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -157,13 +157,21 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	var oldConf []byte
 	oldConfMode := os.FileMode(0o600)
 	if force {
-		if srv, err := config.ReadServer(configPath); err == nil {
-			priorReg = srv
-		}
-		if b, err := os.ReadFile(configPath); err == nil {
+		// Capture the existing config so a later rollback can restore it. If a
+		// config is present but unreadable, fail fast: writeConfigFile would
+		// atomically replace it and a post-write failure (e.g. dir setup) would
+		// then drop it via removeOnRollback, leaving the host with no config and
+		// breaking the --force guarantee. oldConf is therefore set iff a prior
+		// config existed and was captured (an empty placeholder, size 0, is not).
+		if info, statErr := os.Stat(configPath); statErr == nil && info.Size() > 0 {
+			b, readErr := os.ReadFile(configPath)
+			if readErr != nil {
+				return fmt.Errorf("--force: cannot read existing config %s to enable rollback: %w", configPath, readErr)
+			}
 			oldConf = b
-			if fi, statErr := os.Stat(configPath); statErr == nil {
-				oldConfMode = fi.Mode().Perm()
+			oldConfMode = info.Mode().Perm()
+			if srv, err := config.ReadServer(configPath); err == nil {
+				priorReg = srv
 			}
 		}
 	}

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -54,6 +54,7 @@ var (
 	// touching the real filesystem, OS service manager, or relying on platform
 	// service behavior. They default to the production implementations, mirroring
 	// the detectCloud seam above.
+	ensureInstalledFn   = ensureInstalled
 	writeConfigFileFn   = writeConfigFile
 	ensureDirectoriesFn = ensureDirectories
 	startServiceFn      = startService
@@ -141,7 +142,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	// re-exec from there so the Service Manager entry we're about to
 	// create points at a stable path. No-op on Linux/macOS, where
 	// apt/brew already handled placement.
-	if relaunched, err := ensureInstalled(); err != nil {
+	if relaunched, err := ensureInstalledFn(); err != nil {
 		return err
 	} else if relaunched {
 		return nil

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -270,10 +270,9 @@ func ensureNotAlreadyRegistered() error {
 	}
 	if info.Size() > 0 {
 		return fmt.Errorf("config file already exists: %s\n"+
-			"This server appears to be already registered. To re-register, run:\n"+
-			"  alpamon unregister       # unregister and clear local state, then\n"+
-			"  alpamon register ...     # register again\n"+
-			"or do both at once with: alpamon register --force ...", configPath)
+			"this server appears to be already registered; re-register by running "+
+			"'alpamon register --force', or 'alpamon unregister' and then 'alpamon register' again",
+			configPath)
 	}
 	fmt.Printf("Note: Empty config file found at %s, will be overwritten\n", configPath)
 	return nil

--- a/cmd/alpamon/command/register/service_darwin.go
+++ b/cmd/alpamon/command/register/service_darwin.go
@@ -85,3 +85,26 @@ func printManualStartHint() {
 	fmt.Println("Please start the service manually:")
 	fmt.Printf("  sudo launchctl load %s/%s\n", launchdDir, plistName)
 }
+
+// stopService unloads the launchd job, leaving its plist in place. Used by
+// register --force to bounce the job so the subsequent load reloads the new
+// config (startService keeps the existing plist when present). Best-effort/
+// idempotent: `launchctl unload` of an already-unloaded job is ignored.
+func stopService() error {
+	plistDst := filepath.Join(launchdDir, plistName)
+	_, _ = exec.Command("launchctl", "unload", plistDst).CombinedOutput()
+	return nil
+}
+
+// removeService unloads the launchd job and removes its plist (full teardown for
+// unregister). Best-effort/idempotent: `launchctl unload` of an already-unloaded
+// job is ignored, and a missing plist is treated as success so unregister never
+// fails on an already-clean box.
+func removeService() error {
+	plistDst := filepath.Join(launchdDir, plistName)
+	_, _ = exec.Command("launchctl", "unload", plistDst).CombinedOutput()
+	if err := os.Remove(plistDst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove launchd plist: %w", err)
+	}
+	return nil
+}

--- a/cmd/alpamon/command/register/service_linux.go
+++ b/cmd/alpamon/command/register/service_linux.go
@@ -92,3 +92,28 @@ func printManualStartHint() {
 		fmt.Printf("  %s\n", alpamonBinPath)
 	}
 }
+
+// stopService stops the alpamon systemd unit without disabling it. Used by
+// register --force to bounce the unit so the fresh start reloads the new config.
+// Best-effort/idempotent: a `systemctl stop` of an already-stopped or
+// non-existent unit is ignored. No-op on hosts without systemd.
+func stopService() error {
+	if utils.HasSystemd() {
+		_, _ = exec.Command("systemctl", "stop", "alpamon.service").CombinedOutput()
+	}
+	return nil
+}
+
+// removeService stops and disables the alpamon systemd unit (full teardown for
+// unregister). Best-effort/idempotent: errors from `systemctl stop`/`disable` on
+// an already-stopped or non-existent unit are intentionally ignored so
+// unregister never fails on an already-clean box. On hosts without systemd there
+// is no durable service to remove (the agent runs as a detached background
+// process that exits on host teardown).
+func removeService() error {
+	if utils.HasSystemd() {
+		_, _ = exec.Command("systemctl", "stop", "alpamon.service").CombinedOutput()
+		_, _ = exec.Command("systemctl", "disable", "alpamon.service").CombinedOutput()
+	}
+	return nil
+}

--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -207,7 +207,7 @@ func removeService() error {
 // Stopped so the binary handle is released. ERROR_SERVICE_NOT_ACTIVE (already
 // stopped) is fine. The caller owns the handle. Errors are logged, not returned,
 // because both callers are best-effort. The poll only returns early on a
-// confirmed Stopped state — a transient Query error must NOT be mistaken for
+// confirmed Stopped state—a transient Query error must NOT be mistaken for
 // "stopped", otherwise a still-running service could be deleted/bounced
 // prematurely.
 func stopRunningService(s *mgr.Service) {

--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
@@ -19,6 +20,11 @@ const (
 	serviceDescription   = "Secure server agent for the Alpacon infrastructure access platform."
 	recoveryResetSeconds = 60
 	recoveryRestartDelay = 5 * time.Second
+
+	// serviceStopPoll* bound how long removeService waits for the SCM to report
+	// the service Stopped before deleting it (15s total).
+	serviceStopPollAttempts = 30
+	serviceStopPollInterval = 500 * time.Millisecond
 )
 
 // defaultInstallBinPath returns the canonical SCM BinaryPathName that
@@ -149,6 +155,73 @@ func startService() error {
 func printManualStartHint() {
 	fmt.Println("Please start alpamon manually:")
 	fmt.Println("  sc.exe start alpamon")
+}
+
+// withService connects to the SCM, opens the alpamon service, runs fn against
+// it, and closes both handles. A service that does not exist is treated as a
+// no-op success so the teardown helpers never fail on an already-clean box.
+// Requires Administrator (same as startService).
+func withService(fn func(*mgr.Service) error) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect to service manager: %w%s", err, elevationHint(err))
+	}
+	defer func() { _ = m.Disconnect() }()
+
+	s, err := m.OpenService(serviceName)
+	if err != nil {
+		if isServiceNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("open service: %w%s", err, elevationHint(err))
+	}
+	defer func() { _ = s.Close() }()
+
+	return fn(s)
+}
+
+// stopService stops the alpamon SCM service without deleting it. Used by
+// register --force to bounce a running service so it reloads the freshly
+// written config (a delete+recreate would race the SCM with
+// ERROR_SERVICE_MARKED_FOR_DELETE). Best-effort/idempotent.
+func stopService() error {
+	return withService(func(s *mgr.Service) error {
+		stopRunningService(s)
+		return nil
+	})
+}
+
+// removeService stops and deletes the alpamon SCM service (full teardown for
+// unregister). Best-effort/idempotent.
+func removeService() error {
+	return withService(func(s *mgr.Service) error {
+		stopRunningService(s)
+		if err := s.Delete(); err != nil {
+			return fmt.Errorf("delete service: %w%s", err, elevationHint(err))
+		}
+		return nil
+	})
+}
+
+// stopRunningService signals Stop and waits (best-effort) for the SCM to report
+// Stopped so the binary handle is released. ERROR_SERVICE_NOT_ACTIVE (already
+// stopped) is fine. The caller owns the handle. Errors are logged, not returned,
+// because both callers are best-effort. The poll only returns early on a
+// confirmed Stopped state — a transient Query error must NOT be mistaken for
+// "stopped", otherwise a still-running service could be deleted/bounced
+// prematurely.
+func stopRunningService(s *mgr.Service) {
+	if _, err := s.Control(svc.Stop); err != nil {
+		if errno, ok := err.(windows.Errno); !ok || errno != windows.ERROR_SERVICE_NOT_ACTIVE {
+			fmt.Printf("Warning: failed to signal service stop: %v\n", err)
+		}
+	}
+	for i := 0; i < serviceStopPollAttempts; i++ {
+		if status, qerr := s.Query(); qerr == nil && status.State == svc.Stopped {
+			return
+		}
+		time.Sleep(serviceStopPollInterval)
+	}
 }
 
 // elevationHint returns an annotation to append to error messages

--- a/cmd/alpamon/command/register/unregister.go
+++ b/cmd/alpamon/command/register/unregister.go
@@ -33,7 +33,7 @@ console, stops and removes the OS service, and deletes the local config file.
 Data/log directories and the agent binary are left in place.
 
 Run this on the server itself (locally or via an out-of-band console such as
-RDP / cloud serial console / SSM) — not over Websh, since stopping the service
+RDP / cloud serial console / SSM)—not over Websh, since stopping the service
 would terminate the Websh session before the command finishes.
 
 Run before re-registering a server whose previous 'register' failed, or use
@@ -59,10 +59,18 @@ func runUnregister(cmd *cobra.Command, _ []string) error {
 
 	// Genuinely nothing to do only when there is no local config (or just an
 	// empty size-0 placeholder). A present-but-malformed config still needs
-	// local cleanup so the host can re-register.
+	// local cleanup so the host can re-register. A non-not-exist stat error
+	// (e.g. permission) is surfaced rather than silently treated as "no config".
 	info, statErr := os.Stat(configPath)
-	if statErr != nil || info.Size() == 0 {
+	switch {
+	case os.IsNotExist(statErr):
 		fmt.Printf("No registration found at %s.\n", configPath)
+		fmt.Println("If a stale server still shows in the Alpacon console, remove it there.")
+		return nil
+	case statErr != nil:
+		return fmt.Errorf("inspect config %s: %w", configPath, statErr)
+	case info.Size() == 0:
+		fmt.Printf("No registration found at %s (empty config).\n", configPath)
 		fmt.Println("If a stale server still shows in the Alpacon console, remove it there.")
 		return nil
 	}

--- a/cmd/alpamon/command/register/unregister.go
+++ b/cmd/alpamon/command/register/unregister.go
@@ -51,7 +51,7 @@ func init() {
 func runUnregister(_ *cobra.Command, _ []string) error {
 	// On Windows, run from the installed location so SCM operations match the
 	// service register created. No-op on Linux/macOS.
-	if relaunched, err := ensureInstalled(); err != nil {
+	if relaunched, err := ensureInstalledFn(); err != nil {
 		return err
 	} else if relaunched {
 		return nil

--- a/cmd/alpamon/command/register/unregister.go
+++ b/cmd/alpamon/command/register/unregister.go
@@ -57,33 +57,47 @@ func runUnregister(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	srv, err := config.ReadServer(configPath)
-	if err != nil {
-		// No usable config: nothing local to clean. The remote record (if any)
-		// can only be removed from the console.
-		fmt.Printf("No registration found at %s (%v).\n", configPath, err)
+	// Genuinely nothing to do only when there is no local config (or just an
+	// empty size-0 placeholder). A present-but-malformed config still needs
+	// local cleanup so the host can re-register.
+	info, statErr := os.Stat(configPath)
+	if statErr != nil || info.Size() == 0 {
+		fmt.Printf("No registration found at %s.\n", configPath)
 		fmt.Println("If a stale server still shows in the Alpacon console, remove it there.")
 		return nil
 	}
 
-	// Talk to the server with its OWN recorded TLS settings by default, so the
-	// DELETE works on self-signed / private-CA workspaces. The flags override
-	// the config only when the operator explicitly sets them.
-	sslVerify, caCert := config.ReadSSL(configPath)
-	if cmd.Flags().Changed("ssl-verify") {
-		sslVerify = unregisterSSLVerify
-	}
-	if cmd.Flags().Changed("ca-cert") {
-		caCert = unregisterCaCert
-	}
+	// Read best-effort: srv is nil when the config is present but malformed
+	// (corrupt INI, missing id/key). We still clear local state in that case;
+	// we just can't address the remote record without id/key.
+	srv, readErr := config.ReadServer(configPath)
 
-	if !unregisterYes && !confirm(fmt.Sprintf("Unregister server %s from %s and remove local state?", srv.ID, srv.URL)) {
+	prompt := fmt.Sprintf("Remove local registration state at %s?", configPath)
+	if srv != nil {
+		prompt = fmt.Sprintf("Unregister server %s from %s and remove local state?", srv.ID, srv.URL)
+	}
+	if !unregisterYes && !confirm(prompt) {
 		return fmt.Errorf("aborted")
 	}
 
-	// Remote delete first (smallest-orphan ordering); best-effort, never fatal.
-	fmt.Printf("Unregistering %s from %s ...\n", srv.ID, srv.URL)
-	migrate.BestEffortUnregister(srv.URL, srv.ID, srv.Key, sslVerify, caCert)
+	if srv != nil {
+		// Talk to the server with its OWN recorded TLS settings by default, so
+		// the DELETE works on self-signed / private-CA workspaces. The flags
+		// override the config only when the operator explicitly sets them.
+		sslVerify, caCert := config.ReadSSL(configPath)
+		if cmd.Flags().Changed("ssl-verify") {
+			sslVerify = unregisterSSLVerify
+		}
+		if cmd.Flags().Changed("ca-cert") {
+			caCert = unregisterCaCert
+		}
+		// Remote delete first (smallest-orphan ordering); best-effort, never fatal.
+		fmt.Printf("Unregistering %s from %s ...\n", srv.ID, srv.URL)
+		migrate.BestEffortUnregister(srv.URL, srv.ID, srv.Key, sslVerify, caCert)
+	} else {
+		fmt.Printf("Config at %s is present but unreadable (%v); skipping the remote unregister.\n", configPath, readErr)
+		fmt.Println("Remove the server from the Alpacon console manually if it lingers.")
+	}
 
 	if err := removeServiceFn(); err != nil {
 		fmt.Printf("Warning: failed to remove service: %v\n", err)
@@ -97,7 +111,7 @@ func runUnregister(cmd *cobra.Command, _ []string) error {
 
 	// The remote DELETE is best-effort (logged, not surfaced), so be honest that
 	// the local side is cleared but the console record should be verified.
-	fmt.Println("Local registration state removed. The remote record was deleted on a")
+	fmt.Println("Local registration state removed. Any remote record was deleted on a")
 	fmt.Println("best-effort basis; verify in the Alpacon console if it still appears.")
 	fmt.Println("You can run 'alpamon register' again.")
 	return nil

--- a/cmd/alpamon/command/register/unregister.go
+++ b/cmd/alpamon/command/register/unregister.go
@@ -1,0 +1,108 @@
+package register
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/alpacax/alpamon/v2/pkg/config"
+	"github.com/alpacax/alpamon/v2/pkg/migrate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	unregisterSSLVerify  bool
+	unregisterCaCert     string
+	unregisterYes        bool
+	unregisterKeepConfig bool
+)
+
+// UnregisterCmd reverses register: it drops the server record on the Alpacon
+// console, stops/removes the OS service, and deletes the local config so the
+// host can be registered again. It is the supported recovery path for a server
+// stuck after a failed register (where re-running register hits the
+// "config file already exists" wall).
+var UnregisterCmd = &cobra.Command{
+	Use:   "unregister",
+	Short: "Unregister this server and remove local registration state",
+	Long: `Unregister this server so it can be registered again.
+
+Reads the existing config, best-effort deletes the server record on the Alpacon
+console, stops and removes the OS service, and deletes the local config file.
+Data/log directories and the agent binary are left in place.
+
+Run this on the server itself (locally or via an out-of-band console such as
+RDP / cloud serial console / SSM) — not over Websh, since stopping the service
+would terminate the Websh session before the command finishes.
+
+Run before re-registering a server whose previous 'register' failed, or use
+'alpamon register --force' to do both in one step.`,
+	RunE: runUnregister,
+}
+
+func init() {
+	UnregisterCmd.Flags().BoolVar(&unregisterSSLVerify, "ssl-verify", true, "SSL certificate verification")
+	UnregisterCmd.Flags().StringVar(&unregisterCaCert, "ca-cert", "", "CA certificate path")
+	UnregisterCmd.Flags().BoolVar(&unregisterYes, "yes", false, "Skip the confirmation prompt (required for non-interactive use)")
+	UnregisterCmd.Flags().BoolVar(&unregisterKeepConfig, "keep-config", false, "Remove the remote record and service but keep the local config (debug)")
+}
+
+func runUnregister(_ *cobra.Command, _ []string) error {
+	// On Windows, run from the installed location so SCM operations match the
+	// service register created. No-op on Linux/macOS.
+	if relaunched, err := ensureInstalled(); err != nil {
+		return err
+	} else if relaunched {
+		return nil
+	}
+
+	srv, err := config.ReadServer(configPath)
+	if err != nil {
+		// No usable config: nothing local to clean. The remote record (if any)
+		// can only be removed from the console.
+		fmt.Printf("No registration found at %s (%v).\n", configPath, err)
+		fmt.Println("If a stale server still shows in the Alpacon console, remove it there.")
+		return nil
+	}
+
+	if !unregisterYes && !confirm(fmt.Sprintf("Unregister server %s from %s and remove local state?", srv.ID, srv.URL)) {
+		return fmt.Errorf("aborted")
+	}
+
+	// Remote delete first (smallest-orphan ordering); best-effort, never fatal.
+	fmt.Printf("Unregistering %s from %s ...\n", srv.ID, srv.URL)
+	migrate.BestEffortUnregister(srv.URL, srv.ID, srv.Key, unregisterSSLVerify, unregisterCaCert)
+
+	if err := removeServiceFn(); err != nil {
+		fmt.Printf("Warning: failed to remove service: %v\n", err)
+	}
+
+	if !unregisterKeepConfig {
+		if err := os.Remove(configPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove config %s: %w", configPath, err)
+		}
+	}
+
+	// The remote DELETE is best-effort (logged, not surfaced), so be honest that
+	// the local side is cleared but the console record should be verified.
+	fmt.Println("Local registration state removed. The remote record was deleted on a")
+	fmt.Println("best-effort basis — verify in the Alpacon console if it still appears.")
+	fmt.Println("You can run 'alpamon register' again.")
+	return nil
+}
+
+// confirm prompts on stdin and returns true only on an explicit "y"/"yes". Any
+// other answer, or a read error (e.g. piped/empty stdin in a non-interactive
+// context without --yes), returns false so the destructive action safely aborts
+// rather than proceeding.
+func confirm(prompt string) bool {
+	// Prompt on stderr so stdout stays clean when the command output is piped.
+	fmt.Fprintf(os.Stderr, "%s [y/N]: ", prompt)
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
+}

--- a/cmd/alpamon/command/register/unregister.go
+++ b/cmd/alpamon/command/register/unregister.go
@@ -48,7 +48,7 @@ func init() {
 	UnregisterCmd.Flags().BoolVar(&unregisterKeepConfig, "keep-config", false, "Remove the remote record and service but keep the local config (debug)")
 }
 
-func runUnregister(_ *cobra.Command, _ []string) error {
+func runUnregister(cmd *cobra.Command, _ []string) error {
 	// On Windows, run from the installed location so SCM operations match the
 	// service register created. No-op on Linux/macOS.
 	if relaunched, err := ensureInstalledFn(); err != nil {
@@ -66,13 +66,24 @@ func runUnregister(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
+	// Talk to the server with its OWN recorded TLS settings by default, so the
+	// DELETE works on self-signed / private-CA workspaces. The flags override
+	// the config only when the operator explicitly sets them.
+	sslVerify, caCert := config.ReadSSL(configPath)
+	if cmd.Flags().Changed("ssl-verify") {
+		sslVerify = unregisterSSLVerify
+	}
+	if cmd.Flags().Changed("ca-cert") {
+		caCert = unregisterCaCert
+	}
+
 	if !unregisterYes && !confirm(fmt.Sprintf("Unregister server %s from %s and remove local state?", srv.ID, srv.URL)) {
 		return fmt.Errorf("aborted")
 	}
 
 	// Remote delete first (smallest-orphan ordering); best-effort, never fatal.
 	fmt.Printf("Unregistering %s from %s ...\n", srv.ID, srv.URL)
-	migrate.BestEffortUnregister(srv.URL, srv.ID, srv.Key, unregisterSSLVerify, unregisterCaCert)
+	migrate.BestEffortUnregister(srv.URL, srv.ID, srv.Key, sslVerify, caCert)
 
 	if err := removeServiceFn(); err != nil {
 		fmt.Printf("Warning: failed to remove service: %v\n", err)
@@ -87,7 +98,7 @@ func runUnregister(_ *cobra.Command, _ []string) error {
 	// The remote DELETE is best-effort (logged, not surfaced), so be honest that
 	// the local side is cleared but the console record should be verified.
 	fmt.Println("Local registration state removed. The remote record was deleted on a")
-	fmt.Println("best-effort basis — verify in the Alpacon console if it still appears.")
+	fmt.Println("best-effort basis; verify in the Alpacon console if it still appears.")
 	fmt.Println("You can run 'alpamon register' again.")
 	return nil
 }
@@ -99,10 +110,11 @@ func runUnregister(_ *cobra.Command, _ []string) error {
 func confirm(prompt string) bool {
 	// Prompt on stderr so stdout stays clean when the command output is piped.
 	fmt.Fprintf(os.Stderr, "%s [y/N]: ", prompt)
-	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
-	if err != nil {
-		return false
-	}
+	// ReadString returns the data read so far together with io.EOF when stdin
+	// ends without a trailing newline (common when piping, e.g. `echo -n y |`),
+	// so parse the line regardless of err; an empty/EOF-only read falls through
+	// to "no", which is the safe default for a destructive action.
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
 	answer := strings.ToLower(strings.TrimSpace(line))
 	return answer == "y" || answer == "yes"
 }

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -74,7 +74,7 @@ control plane and https://github.com/alpacax/alpacon-cli for the CLI.`,
 
 func init() {
 	setup.SetConfigPaths(name)
-	RootCmd.AddCommand(setup.SetupCmd, ftp.FtpCmd, tunnel.TunnelDaemonCmd, register.RegisterCmd, migratecmd.Cmd)
+	RootCmd.AddCommand(setup.SetupCmd, ftp.FtpCmd, tunnel.TunnelDaemonCmd, register.RegisterCmd, register.UnregisterCmd, migratecmd.Cmd)
 	// Emit just the version string (no "alpamon version ..." prefix) so
 	// shell one-liners like `alpamon --version` are easy to parse.
 	RootCmd.SetVersionTemplate("{{.Version}}\n")

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -80,7 +80,9 @@ Re-running on an **already-registered** host still fails at the
 `%ProgramData%\alpamon\alpamon.conf` already exists—this matches the
 Linux and macOS behavior and prevents a silent re-registration. To
 upgrade an already-registered host, use `alpamon upgrade` or the
-[Manual fallback](#manual-fallback) recipe below.
+[Manual fallback](#manual-fallback) recipe below. To recover a host left
+half-registered by a failed attempt, or to deliberately register it
+again, see [Unregister and re-register](#unregister-and-re-register).
 
 If the install fails after the service was stopped, the script
 best-effort restarts the previously-running service before exiting
@@ -321,6 +323,40 @@ already-registered machine—it refuses to run when a configuration
 file already exists, to avoid silently clobbering an existing
 registration.
 
+## Unregister and re-register
+
+If a previous `register` failed partway (or you want to register this
+host again), the leftover config makes a plain re-run stop at the
+`config file already exists` message. There are two supported recovery
+paths — run either from **elevated** PowerShell:
+
+```powershell
+# One step: unregister, then register fresh.
+& "$env:ProgramFiles\alpamon\alpamon.exe" register --force `
+    --url https://<workspace> --token <token>
+
+# Or two explicit steps:
+& "$env:ProgramFiles\alpamon\alpamon.exe" unregister --yes
+& "$env:ProgramFiles\alpamon\alpamon.exe" register `
+    --url https://<workspace> --token <token>
+```
+
+`unregister` best-effort deletes the server record on the Alpacon
+console, stops and deletes the `alpamon` service, and removes
+`%ProgramData%\alpamon\alpamon.conf`. The binary and the
+`%ProgramData%\alpamon\{data,log,run}` directories are left in place
+(use [Uninstall](#uninstall) to remove those too). Pass `--yes` to skip
+the confirmation prompt in non-interactive contexts (cloud-init, SSM).
+
+`register --force` performs that teardown and then registers again in a
+single command. It registers with the workspace **first** and only
+retires the old registration after the new one succeeds, so an invalid
+token or unreachable URL leaves the existing registration untouched.
+
+Run these **on the server itself** (locally, or via RDP / cloud serial
+console / SSM), not over Websh: stopping the service would end the Websh
+session before the command finishes.
+
 ## Uninstall
 
 There is no dedicated uninstaller; the footprint is small and cleanup
@@ -339,9 +375,10 @@ deleting the binary. Otherwise `Remove-Item` will fail with a sharing
 violation because `alpamon.exe` is held open by the still-running
 service.
 
-After the uninstall, the server still exists on the Alpacon side.
-Delete it from the Alpacon console separately if you do not plan to
-re-register.
+The commands above leave the server record on the Alpacon side. To drop
+it as part of teardown, run `alpamon unregister` **first** (it deletes
+the remote record and the service), then `Remove-Item` the directories
+above. Otherwise delete the server from the Alpacon console separately.
 
 ## Feature compatibility
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -328,7 +328,7 @@ registration.
 If a previous `register` failed partway (or you want to register this
 host again), the leftover config makes a plain re-run stop at the
 `config file already exists` message. There are two supported recovery
-paths — run either from **elevated** PowerShell:
+paths; run either from **elevated** PowerShell:
 
 ```powershell
 # One step: unregister, then register fresh.

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"gopkg.in/ini.v1"
+)
+
+// confTemplate is the on-disk alpamon.conf layout ([server]/[ssl]/[logging];
+// ca_cert is omitted when empty). Compiled once at init via template.Must — a
+// parse failure here is a programmer error in this static template, not a
+// runtime condition, so panicking at startup is appropriate.
+var confTemplate = template.Must(template.New("conf").Parse(`[server]
+url = {{ .URL }}
+id = {{ .ID }}
+key = {{ .Key }}
+
+[ssl]
+verify = {{ .Verify }}
+{{- if .CACert }}
+ca_cert = {{ .CACert }}
+{{- end }}
+
+[logging]
+debug = false
+`))
+
+// ServerConfig is the [server] section of alpamon.conf: the identity and
+// credentials an already-registered agent uses to authenticate back to Alpacon.
+// It is embedded in Config so the on-disk schema is declared exactly once.
+type ServerConfig struct {
+	URL string `ini:"url"`
+	ID  string `ini:"id"`
+	Key string `ini:"key"`
+}
+
+// ReadServer parses path as INI and returns the [server] url/id/key. Unlike
+// LoadConfig it returns a normal error (no log.Fatal) so callers on recovery
+// paths (migrate, unregister) can degrade gracefully — e.g. treat a missing or
+// malformed config as "nothing to clean up".
+func ReadServer(path string) (*ServerConfig, error) {
+	f, err := ini.Load(path)
+	if err != nil {
+		return nil, fmt.Errorf("parse conf: %w", err)
+	}
+	section, err := f.GetSection("server")
+	if err != nil {
+		return nil, errors.New("[server] section missing")
+	}
+	get := func(name string) string {
+		k, err := section.GetKey(name)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(k.String())
+	}
+	s := &ServerConfig{URL: get("url"), ID: get("id"), Key: get("key")}
+	if s.URL == "" {
+		return nil, errors.New("url not found in [server] section")
+	}
+	if s.ID == "" || s.Key == "" {
+		return nil, errors.New("id/key not found in [server] section")
+	}
+	return s, nil
+}
+
+// RenderConf produces the alpamon.conf body for the given server identity and
+// SSL settings. It is the single source of truth for the on-disk config format,
+// shared by register and migrate so the two cannot drift.
+func RenderConf(s ServerConfig, sslVerify bool, caCertPath string) (string, error) {
+	var buf bytes.Buffer
+	if err := confTemplate.Execute(&buf, map[string]any{
+		"URL":    s.URL,
+		"ID":     s.ID,
+		"Key":    s.Key,
+		"Verify": sslVerify,
+		"CACert": caCertPath,
+	}); err != nil {
+		return "", fmt.Errorf("render conf: %w", err)
+	}
+	return buf.String(), nil
+}

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -68,6 +68,32 @@ func ReadServer(path string) (*ServerConfig, error) {
 	return s, nil
 }
 
+// ReadSSL reads the [ssl] section (verify, ca_cert) from path. Best-effort: a
+// missing file/section/key yields the secure default verify=true and no CA, so
+// callers can use it as a sane TLS baseline. Recovery paths (unregister,
+// register --force) use it so the DELETE to a server speaks that server's own
+// TLS settings rather than whatever flags the current invocation defaulted to.
+func ReadSSL(path string) (verify bool, caCert string) {
+	verify = true
+	f, err := ini.Load(path)
+	if err != nil {
+		return verify, ""
+	}
+	section, err := f.GetSection("ssl")
+	if err != nil {
+		return verify, ""
+	}
+	if k, err := section.GetKey("verify"); err == nil {
+		if b, perr := k.Bool(); perr == nil {
+			verify = b
+		}
+	}
+	if k, err := section.GetKey("ca_cert"); err == nil {
+		caCert = strings.TrimSpace(k.String())
+	}
+	return verify, caCert
+}
+
 // RenderConf produces the alpamon.conf body for the given server identity and
 // SSL settings. It is the single source of truth for the on-disk config format,
 // shared by register and migrate so the two cannot drift.

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -11,7 +11,7 @@ import (
 )
 
 // confTemplate is the on-disk alpamon.conf layout ([server]/[ssl]/[logging];
-// ca_cert is omitted when empty). Compiled once at init via template.Must — a
+// ca_cert is omitted when empty). Compiled once at init via template.Must—a
 // parse failure here is a programmer error in this static template, not a
 // runtime condition, so panicking at startup is appropriate.
 var confTemplate = template.Must(template.New("conf").Parse(`[server]
@@ -40,7 +40,7 @@ type ServerConfig struct {
 
 // ReadServer parses path as INI and returns the [server] url/id/key. Unlike
 // LoadConfig it returns a normal error (no log.Fatal) so callers on recovery
-// paths (migrate, unregister) can degrade gracefully — e.g. treat a missing or
+// paths (migrate, unregister) can degrade gracefully—e.g. treat a missing or
 // malformed config as "nothing to clean up".
 func ReadServer(path string) (*ServerConfig, error) {
 	f, err := ini.Load(path)

--- a/pkg/config/server_test.go
+++ b/pkg/config/server_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeServerConf(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "alpamon.conf")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+	return p
+}
+
+func TestReadServer_Valid(t *testing.T) {
+	p := writeServerConf(t, "[server]\nurl = https://alpacon.example.com\nid = srv-1\nkey = k-1\n")
+	s, err := ReadServer(p)
+	require.NoError(t, err)
+	assert.Equal(t, "https://alpacon.example.com", s.URL)
+	assert.Equal(t, "srv-1", s.ID)
+	assert.Equal(t, "k-1", s.Key)
+}
+
+func TestReadServer_TrimsWhitespace(t *testing.T) {
+	p := writeServerConf(t, "[server]\nurl =   https://x   \nid =  abc \nkey = def\n")
+	s, err := ReadServer(p)
+	require.NoError(t, err)
+	assert.Equal(t, "https://x", s.URL)
+	assert.Equal(t, "abc", s.ID)
+}
+
+func TestReadServer_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing [server] section", body: "[other]\nx = 1\n"},
+		{name: "missing url", body: "[server]\nid = abc\nkey = def\n"},
+		{name: "missing id", body: "[server]\nurl = https://x\nkey = def\n"},
+		{name: "missing key", body: "[server]\nurl = https://x\nid = abc\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ReadServer(writeServerConf(t, tt.body))
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestReadServer_NonexistentFile(t *testing.T) {
+	_, err := ReadServer(filepath.Join(t.TempDir(), "does-not-exist.conf"))
+	assert.Error(t, err)
+}
+
+func TestRenderConf_RoundTripsThroughReadServer(t *testing.T) {
+	out, err := RenderConf(ServerConfig{URL: "https://x.example.com", ID: "srv-1", Key: "k-1"}, true, "/etc/ssl/ca.pem")
+	require.NoError(t, err)
+	for _, want := range []string{
+		"url = https://x.example.com",
+		"id = srv-1",
+		"key = k-1",
+		"verify = true",
+		"ca_cert = /etc/ssl/ca.pem",
+		"debug = false",
+	} {
+		assert.Contains(t, out, want)
+	}
+
+	// What RenderConf writes, ReadServer must parse back identically.
+	got, err := ReadServer(writeServerConf(t, out))
+	require.NoError(t, err)
+	assert.Equal(t, "https://x.example.com", got.URL)
+	assert.Equal(t, "srv-1", got.ID)
+	assert.Equal(t, "k-1", got.Key)
+}
+
+func TestRenderConf_OmitsCACertWhenEmpty(t *testing.T) {
+	out, err := RenderConf(ServerConfig{URL: "https://x", ID: "a", Key: "b"}, false, "")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "ca_cert")
+	assert.Contains(t, out, "verify = false")
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -24,12 +24,8 @@ type Settings struct {
 }
 
 type Config struct {
-	Server struct {
-		URL string `ini:"url"`
-		ID  string `ini:"id"`
-		Key string `ini:"key"`
-	} `ini:"server"`
-	SSL struct {
+	Server ServerConfig `ini:"server"`
+	SSL    struct {
 		Verify bool   `ini:"verify"`
 		CaCert string `ini:"ca_cert"`
 	} `ini:"ssl"`


### PR DESCRIPTION
## Summary

Closes #336.

When `alpamon register` fails partway, leftover state — the local config, the OS
service, and a **live server record on the Alpacon console** — blocks the next
attempt: a plain re-run aborts at `config file already exists`. Operators retry
and stay stuck, most painfully on Windows. This PR adds a first-class recovery
path so a stuck operator gets unstuck **without manual console + file cleanup**:

- **`alpamon unregister`** — best-effort deletes the console record, stops and
  removes the OS service, and removes the local config.
- **`alpamon register --force`** — does that teardown and re-registers in one
  command, ordered so a bad token can never tear down a healthy registration.
- **Default-on within-run rollback** — a `register` that fails *after* creating
  the remote record now cleans up after itself instead of leaving an orphan
  (`--no-rollback` to opt out for debugging).
- The dead-end "config already exists" message now points at these commands.

## Why

`register` is not transactional and there was no supported teardown/redo command
(the only compensating-unregister logic lived inside `pkg/migrate`). A **key
invariant** shapes the design: the local config is written **only after** the
server-creating `POST .../register/` succeeds — so a leftover non-empty config
*always* implies a live remote record, and any recovery must include a
compensating remote `DELETE`, not just a local file delete. Pure
"rollback-on-failure" can't fix the reported symptom (it only undoes the current
run and is itself interruptible); the durable cure is a forward teardown /
re-register path, reusing the saga-style compensation already in `pkg/migrate`.

## What changed

- **`pkg/config`** becomes the single source of truth for the `alpamon.conf`
  format: new `ServerConfig` (reused by `Config.Server` so the `[server]` schema
  is declared once), `ReadServer` (graceful reader — normal error, not
  `LoadConfig`'s `log.Fatal`), and `RenderConf` (renders the conf body). `migrate`
  now uses these, dropping its private reader and a duplicate template.
- **Per-OS service teardown** in the `register` package: `stopService` (stop
  only) and `removeService` (stop + delete), the inverse of `startService`, with
  shared Windows SCM helpers. All best-effort and idempotent.
- **`alpamon unregister`** command (`unregister.go`), wired into `root.go`,
  reusing `migrate.BestEffortUnregister` + `removeService`; confirmation prompt
  with `--yes` for non-interactive use, `--keep-config` for debugging.
- **`register`**: `--force` and `--no-rollback` flags; the within-run rollback
  (deferred LIFO compensations gated by a `committed` flag); atomic config write
  (`RenderConf` + `WriteConfAtomic`, temp + rename); rewritten step-1 message;
  `runRegister` split into focused helpers.
- **docs/windows.md**: an "Unregister and re-register" section plus updated
  re-run/uninstall notes.

## Design notes

**Within-run rollback (default on).** After the POST succeeds a
`BestEffortUnregister` compensation is registered; after the config write a
config-cleanup/restore compensation is registered. `committed` flips once
config + dirs are durable. On an earlier failure, compensations run LIFO — local
cleanup first, the single remote `DELETE` last (matching the `pkg/migrate` saga
ordering). `startService` is best-effort and deliberately outside the rollback
scope: a registered server whose service merely failed to start is recoverable,
and tearing it down would be hostile.

**`register --force` is register-new-first.** It registers the new record
*first* and only retires the old one after that succeeds, so an invalid/expired
token or unreachable URL aborts before touching the existing healthy
registration. The config is replaced atomically (old config intact until the
rename), and on failure the old config is restored. On Windows the old service
is **stopped, not deleted+recreated**, to avoid the `ERROR_SERVICE_MARKED_FOR_DELETE`
race.

## Security considerations

Blocking every malicious use on the client is impossible — a root/Administrator
attacker can already stop the service, read the `id`/`key`, call the unregister
API directly, or wipe the box. So defense is placed where it belongs: both
commands require that same privilege, are explicit/confirmed, are operator-run
CLI subcommands (not console-dispatched protocol commands), and the durable
control is server-side (audit logging + TTL-GC; see follow-ups). The default-on
within-run rollback only undoes the current run, so it can never disconnect a
healthy pre-existing registration.

## Testing

- Builds for `linux/amd64`, `darwin/arm64`, `windows/amd64`; `go vet ./...`
  (including the Windows-only service file) is clean; `gofmt` clean.
- `go test ./... -p 1` passes. New tests cover: within-run rollback (fires /
  `--no-rollback` / not-on-service-start-failure), `--force` (success /
  token-rejected-keeps-old / write-fail-keeps-old / dir-fail-restores-old /
  unreadable-config-still-stops), `unregister` (DELETE + auth / no-op on clean
  box / `--keep-config`), `confirm`, flag wiring, and `pkg/config` Read/Render
  round-trip.
- The six commits are individually buildable (bisect-friendly).

## Follow-ups (alpacon-server, separate)

A crash *between* the POST and the config write leaves an orphan remote record
with no local `id`/`key` to clean up, and a retry mints a duplicate. Closing this
needs a server-side idempotency key on `POST .../register/` and/or TTL-GC of
never-activated records — also the durable security control (audit logging +
TTL-GC). To be tracked on alpacon-server.
