### PR TITLE
fix(ftp): decouple WebFTP command handling from the WebSocket read loop

### DIFF
--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -122,6 +122,10 @@ func (fc *FtpClient) handleCommands(ctx context.Context, cancel context.CancelFu
 		case <-ctx.Done():
 			return
 		case message := <-fc.commandChan:
+			// A buffered command can be selected after cancel(); don't start a new command during shutdown.
+			if ctx.Err() != nil {
+				return
+			}
 			var content FtpContent
 			if err := json.Unmarshal(message, &content); err != nil {
 				fc.log.Debug().Err(err).Msg("Failed to unmarshal websocket message.")
@@ -165,6 +169,10 @@ func (fc *FtpClient) write(ctx context.Context, cancel context.CancelFunc) {
 		case <-ctx.Done():
 			return
 		case response := <-fc.responseChan:
+			// A buffered response can be selected after cancel(); don't write during shutdown.
+			if ctx.Err() != nil {
+				return
+			}
 			err := fc.conn.WriteMessage(websocket.TextMessage, response)
 			if err != nil {
 				if ctx.Err() != nil {

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/alpacax/alpamon/v2/pkg/config"
 	"github.com/alpacax/alpamon/v2/pkg/logger"
@@ -25,6 +26,9 @@ type FtpClient struct {
 	homeDirectory    string
 	workingDirectory string
 	log              logger.FtpLogger
+	commandChan      chan []byte
+	responseChan     chan []byte
+	execute          func(command FtpCommand, data FtpData) (CommandResult, error)
 }
 
 func NewFtpClient(data FtpConfigData) *FtpClient {
@@ -45,13 +49,17 @@ func NewFtpClient(data FtpConfigData) *FtpClient {
 		data.Logger.Debug().Msg("Refusing to open WebFTP session with empty home directory on Windows.")
 		return nil
 	}
-	return &FtpClient{
+	client := &FtpClient{
 		requestHeader:    headers,
 		url:              data.URL,
 		homeDirectory:    homeDir,
 		workingDirectory: homeDir,
 		log:              data.Logger,
+		commandChan:      make(chan []byte, 1),
+		responseChan:     make(chan []byte, 1),
 	}
+	client.execute = client.handleFtpCommand
+	return client
 }
 
 func (fc *FtpClient) RunFtpBackground() {
@@ -74,6 +82,8 @@ func (fc *FtpClient) RunFtpBackground() {
 	defer cancel()
 
 	go fc.read(ctx, cancel)
+	go fc.handleCommands(ctx, cancel)
+	go fc.write(ctx, cancel)
 
 	<-ctx.Done()
 }
@@ -84,6 +94,7 @@ func (fc *FtpClient) read(ctx context.Context, cancel context.CancelFunc) {
 		case <-ctx.Done():
 			return
 		default:
+			// A parked ReadMessage is woken only by conn.Close() (RunFtpBackground's deferred close()), not cancel().
 			_, message, err := fc.conn.ReadMessage()
 			if err != nil {
 				if ctx.Err() != nil {
@@ -96,9 +107,23 @@ func (fc *FtpClient) read(ctx context.Context, cancel context.CancelFunc) {
 				return
 			}
 
+			select {
+			case fc.commandChan <- message:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (fc *FtpClient) handleCommands(ctx context.Context, cancel context.CancelFunc) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case message := <-fc.commandChan:
 			var content FtpContent
-			err = json.Unmarshal(message, &content)
-			if err != nil {
+			if err := json.Unmarshal(message, &content); err != nil {
 				fc.log.Debug().Err(err).Msg("Failed to unmarshal websocket message.")
 				cancel()
 				return
@@ -109,7 +134,7 @@ func (fc *FtpClient) read(ctx context.Context, cancel context.CancelFunc) {
 				Success: true,
 			}
 
-			data, err := fc.handleFtpCommand(content.Command, content.Data)
+			data, err := fc.execute(content.Command, content.Data)
 			if err != nil {
 				result.Success = false
 				result.Data, result.Code = GetFtpErrorCode(content.Command, data)
@@ -120,15 +145,27 @@ func (fc *FtpClient) read(ctx context.Context, cancel context.CancelFunc) {
 
 			response, err := json.Marshal(result)
 			if err != nil {
-				if ctx.Err() != nil {
-					return
-				}
 				fc.log.Debug().Err(err).Msg("Failed to marshal response.")
 				cancel()
 				return
 			}
 
-			err = fc.conn.WriteMessage(websocket.TextMessage, response)
+			select {
+			case fc.responseChan <- response:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (fc *FtpClient) write(ctx context.Context, cancel context.CancelFunc) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case response := <-fc.responseChan:
+			err := fc.conn.WriteMessage(websocket.TextMessage, response)
 			if err != nil {
 				if ctx.Err() != nil {
 					return
@@ -145,7 +182,12 @@ func (fc *FtpClient) read(ctx context.Context, cancel context.CancelFunc) {
 
 func (fc *FtpClient) close() {
 	if fc.conn != nil {
-		_ = fc.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		// Use WriteControl, not WriteMessage: the write pump may still be mid-WriteMessage here, and gorilla allows only one concurrent writer.
+		_ = fc.conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			time.Now().Add(5*time.Second),
+		)
 		_ = fc.conn.Close()
 	}
 

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -310,7 +310,14 @@ func newWiredFtpClient(t *testing.T) (*FtpClient, *websocket.Conn, func()) {
 		t.Fatalf("failed to dial test server: %v", err)
 	}
 
-	serverConn := <-serverConnCh
+	var serverConn *websocket.Conn
+	select {
+	case serverConn = <-serverConnCh:
+	case <-time.After(3 * time.Second):
+		clientConn.Close()
+		srv.Close()
+		t.Fatal("server did not accept the websocket upgrade")
+	}
 
 	home := t.TempDir()
 	fc := &FtpClient{
@@ -390,7 +397,7 @@ func TestFtpCommandsAreSerializedInOrder(t *testing.T) {
 	defer cleanup()
 
 	base := fc.workingDirectory
-	names := []string{"a", "b", "c", "d"}
+	names := []string{"dir_a", "dir_b", "dir_c", "dir_d"}
 
 	_, cancel := startPumps(fc)
 	defer cancel()
@@ -423,6 +430,11 @@ func TestFtpCommandsAreSerializedInOrder(t *testing.T) {
 		}
 		if !result.Success {
 			t.Fatalf("response %d: mkd failed: %+v", i, result.Data)
+		}
+		// The ith response must be for the ith requested directory; identical
+		// commands would let out-of-order responses slip past this loop otherwise.
+		if want := filepath.Join(base, names[i]); !strings.Contains(result.Data.Message, want) {
+			t.Fatalf("response %d out of order: want path %q in message, got %q", i, want, result.Data.Message)
 		}
 	}
 

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -9,10 +9,19 @@
 package runner
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/alpacax/alpamon/v2/pkg/config"
+	"github.com/alpacax/alpamon/v2/pkg/logger"
+	"github.com/gorilla/websocket"
 )
 
 func newTestFtpClient(home string) *FtpClient {
@@ -277,5 +286,149 @@ func TestValidateWebSocketURL_ServerWithExplicitPort(t *testing.T) {
 				t.Fatalf("validateWebSocketURL(%q) unexpected error: %v", tc.url, err)
 			}
 		})
+	}
+}
+
+// newWiredFtpClient wires an FtpClient to a real httptest websocket peer; tests drive the pumps directly to avoid RunFtpBackground's os.Exit teardown.
+func newWiredFtpClient(t *testing.T) (*FtpClient, *websocket.Conn, func()) {
+	t.Helper()
+
+	serverConnCh := make(chan *websocket.Conn, 1)
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		serverConnCh <- conn
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+
+	serverConn := <-serverConnCh
+
+	home := t.TempDir()
+	fc := &FtpClient{
+		homeDirectory:    home,
+		workingDirectory: home,
+		log:              logger.NewFtpLogger(),
+		conn:             clientConn,
+		commandChan:      make(chan []byte, 1),
+		responseChan:     make(chan []byte, 1),
+	}
+	fc.execute = fc.handleFtpCommand
+
+	cleanup := func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+		srv.Close()
+	}
+	return fc, serverConn, cleanup
+}
+
+// startPumps launches the read/handleCommands/write goroutines; call it after any fc.execute override so the worker can't race the assignment.
+func startPumps(fc *FtpClient) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go fc.read(ctx, cancel)
+	go fc.handleCommands(ctx, cancel)
+	go fc.write(ctx, cancel)
+	return ctx, cancel
+}
+
+func TestFtpReadLoopStaysResponsiveDuringLongCommand(t *testing.T) {
+	fc, serverConn, cleanup := newWiredFtpClient(t)
+	defer cleanup()
+
+	// execute blocks until released, pinning the worker like a long-running command.
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	fc.execute = func(command FtpCommand, data FtpData) (CommandResult, error) {
+		close(blocked)
+		<-release
+		return CommandResult{}, nil
+	}
+
+	ctx, cancel := startPumps(fc)
+	defer cancel()
+
+	msg, err := json.Marshal(FtpContent{Command: Pwd})
+	if err != nil {
+		t.Fatalf("failed to marshal command: %v", err)
+	}
+	if err := serverConn.WriteMessage(websocket.TextMessage, msg); err != nil {
+		t.Fatalf("failed to send command: %v", err)
+	}
+
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker never started executing the command")
+	}
+
+	// With the worker stuck, a responsive read loop still observes the peer's close frame and cancels.
+	_ = serverConn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+		time.Now().Add(time.Second),
+	)
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("read loop did not observe close while worker was busy")
+	}
+}
+
+func TestFtpCommandsAreSerializedInOrder(t *testing.T) {
+	fc, serverConn, cleanup := newWiredFtpClient(t)
+	defer cleanup()
+
+	base := fc.workingDirectory
+	names := []string{"a", "b", "c", "d"}
+
+	_, cancel := startPumps(fc)
+	defer cancel()
+
+	for _, name := range names {
+		msg, err := json.Marshal(FtpContent{
+			Command: Mkd,
+			Data:    FtpData{Path: filepath.Join(base, name)},
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal command: %v", err)
+		}
+		if err := serverConn.WriteMessage(websocket.TextMessage, msg); err != nil {
+			t.Fatalf("failed to send command: %v", err)
+		}
+	}
+
+	_ = serverConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for i := range names {
+		_, raw, err := serverConn.ReadMessage()
+		if err != nil {
+			t.Fatalf("failed to read response %d: %v", i, err)
+		}
+		var result FtpResult
+		if err := json.Unmarshal(raw, &result); err != nil {
+			t.Fatalf("failed to unmarshal response %d: %v", i, err)
+		}
+		if result.Command != Mkd {
+			t.Fatalf("response %d: expected command %q, got %q", i, Mkd, result.Command)
+		}
+		if !result.Success {
+			t.Fatalf("response %d: mkd failed: %+v", i, result.Data)
+		}
+	}
+
+	for _, name := range names {
+		if _, err := os.Stat(filepath.Join(base, name)); err != nil {
+			t.Fatalf("expected directory %q to exist: %v", name, err)
+		}
 	}
 }

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -314,7 +314,7 @@ func newWiredFtpClient(t *testing.T) (*FtpClient, *websocket.Conn, func()) {
 	select {
 	case serverConn = <-serverConnCh:
 	case <-time.After(3 * time.Second):
-		clientConn.Close()
+		_ = clientConn.Close()
 		srv.Close()
 		t.Fatal("server did not accept the websocket upgrade")
 	}


### PR DESCRIPTION
## Background

A WebFTP session ran three things on a single goroutine: reading frames, executing the command, and writing the response. Because command execution sat inside the read loop, a long-running command blocked `ReadMessage`. While blocked, the agent could not send pongs or process control frames, so the WebSocket connection stalled during large FTP operations and could be dropped by the server on ping timeout.

## Changes

Split the single loop in `pkg/runner/ftp.go` into three goroutines that communicate over buffered channels:

- `read`: reads frames and forwards them to `commandChan`
- `handleCommands`: unmarshals, executes via the `execute` field, marshals the result, forwards to `responseChan`
- `write`: reads from `responseChan` and calls `WriteMessage`

The read goroutine no longer waits on command execution, so it stays responsive regardless of how long a command takes. Commands are still processed one at a time and in order, because `commandChan` is drained by the single `handleCommands` goroutine.

## Safety

With a dedicated write goroutine, the write pump may be in the middle of a `WriteMessage` call when `close()` runs. gorilla/websocket allows only one concurrent writer, and `WriteControl` is documented as the exception that is safe to call alongside a writer. `close()` now sends the close frame via `WriteControl` instead of `WriteMessage` to avoid violating that contract.

In-flight command cancellation (for example via `SetReadDeadline`) is out of scope. This PR only decouples the read loop, which is what issue #334 asks for.

## Testing

Unit tests (`pkg/runner/ftp_test.go`) add a WebSocket harness (httptest server plus a real dialed connection) and an injectable `execute` seam so a command can be held mid-flight:

- one test holds a command open and asserts the read goroutine still reacts to a close frame while the command is blocked
- one test asserts commands are executed in FIFO order

`go build ./cmd/alpamon`, `go vet ./pkg/runner/`, and `go test -race -run Ftp ./pkg/runner/ -p 1` all pass.

Manual validation on a Linux arm64 VM connected to a live workspace: replaced the running agent binary with this branch's build (same `/etc/alpamon/alpamon.conf`, same workspace), then uploaded a 200MB file into a writable directory via `alpacon cp`. The agent-side transfer took about 20 seconds and completed with exit code 0, the file landed intact, and the WebSocket connection stayed up throughout and after the transfer. A 20-second single operation completing without a disconnect is the behavior #334 was about: before this change, that operation would have blocked the read loop and stalled pongs long enough for the server to close the connection.

## Checklist

- [x] Read goroutine stays responsive during a long-running command
- [x] Command execution order preserved (FIFO)
- [x] `close()` uses `WriteControl` to respect gorilla's single-writer contract
- [x] Race tests pass
- [x] Validated end-to-end against a live workspace with a 20s transfer

Closes #334