### PR TITLE
fix(iam): idempotent user/group provisioning via os/user lookup verification (#344)

### DIFF
--- a/pkg/executor/handlers/common/lookup.go
+++ b/pkg/executor/handlers/common/lookup.go
@@ -81,12 +81,17 @@ func GroupGIDConflictMessage(groupname string, existingGID, requestedGID uint64)
 		groupname, existingGID, requestedGID)
 }
 
-// alreadyExists reports whether a create tool's output indicates the entity
-// already exists. This is a locale-sensitive last-resort check—the executor
-// runs commands with LANG=en_US.UTF-8, so the message is English in practice—
-// used only AFTER the lookup-based checks, never as the primary decision (E-16).
-func alreadyExists(output string) bool {
-	return strings.Contains(output, "already exists")
+// alreadyExists reports whether a create tool's output indicates that the
+// REQUESTED entity (by name) already exists. It requires both the "already
+// exists" phrase and the entity name so that a collision on a different entity
+// sharing the requested numeric id—e.g. groupadd printing "GID '1001' already
+// exists" when a differently-named group owns that gid—is NOT mistaken for the
+// requested name existing (which would leave that name uncreated and break a
+// later lookup/Demote by name). This is a locale-sensitive last resort—the
+// executor runs commands with LANG=en_US.UTF-8—used only AFTER the lookup-based
+// checks, never as the primary decision (E-16).
+func alreadyExists(output, name string) bool {
+	return strings.Contains(output, "already exists") && strings.Contains(output, name)
 }
 
 // ClassifyGroupForCreate is the shared idempotency gate for group creation, used
@@ -158,9 +163,11 @@ func ReconcileUserCreate(
 		return 0, "", nil
 	}
 	// Tertiary net: invisible to the pure-Go resolver but the NSS-aware create
-	// tool says it already exists (LDAP/SSSD-backed). Tolerate, since failing
-	// here would reintroduce the #344 breakage; identity is unverifiable.
-	if alreadyExists(out) {
+	// tool says this NAME already exists (LDAP/SSSD-backed). Tolerate, since
+	// failing here would reintroduce the #344 breakage; identity is unverifiable.
+	// A collision on a different account sharing the uid is not tolerated here
+	// (alreadyExists requires the username in the output).
+	if alreadyExists(out, username) {
 		log.Warn().
 			Str("username", username).
 			Str("output", out).
@@ -173,9 +180,9 @@ func ReconcileUserCreate(
 // ReconcileGroupCreate is the create-time secondary net for addgroup/groupadd,
 // mirroring ReconcileUserCreate. A group has no "omitted gid" case in the
 // provisioning payloads (GID is validated required,min=1), so the gid is always
-// compared when the group is visible. The "already exists" tertiary net also
-// covers a gid-in-use collision with a differently-named group (groupadd fails
-// but the numeric gid is usable), preserving the pre-#344 behavior.
+// compared when the group is visible. The "already exists" tertiary net tolerates
+// only a same-name collision (NSS-backed group); a gid-in-use collision by a
+// differently-named group is surfaced, since the requested name stays uncreated.
 func ReconcileGroupCreate(
 	lookup GroupLookupFunc, groupname string, wantGID uint64,
 	code int, out string, cmdErr error,
@@ -196,11 +203,15 @@ func ReconcileGroupCreate(
 			Msg("Create returned non-zero but the group is already present with the expected gid; treating as idempotent success")
 		return 0, "", nil
 	}
-	if alreadyExists(out) {
+	// Tertiary net: tolerate only when the output names THIS group (NSS-backed
+	// same-name group invisible to the pure-Go resolver). A "GID already exists"
+	// collision by a differently-named group is not tolerated—the requested
+	// name would remain uncreated—so it falls through to the original failure.
+	if alreadyExists(out, groupname) {
 		log.Warn().
 			Str("groupname", groupname).
 			Str("output", out).
-			Msg("Create reported the group already exists but it is invisible to the pure-Go resolver (likely NSS-backed or a gid-in-use collision); treating as idempotent (identity unverifiable)")
+			Msg("Create reported the group already exists but it is invisible to the pure-Go resolver (likely NSS-backed); treating as idempotent (identity unverifiable)")
 		return 0, "", nil
 	}
 	return code, out, cmdErr

--- a/pkg/executor/handlers/common/lookup.go
+++ b/pkg/executor/handlers/common/lookup.go
@@ -82,16 +82,32 @@ func GroupGIDConflictMessage(groupname string, existingGID, requestedGID uint64)
 }
 
 // alreadyExists reports whether a create tool's output indicates that the
-// REQUESTED entity (by name) already exists. It requires both the "already
-// exists" phrase and the entity name so that a collision on a different entity
-// sharing the requested numeric id—e.g. groupadd printing "GID '1001' already
-// exists" when a differently-named group owns that gid—is NOT mistaken for the
-// requested name existing (which would leave that name uncreated and break a
-// later lookup/Demote by name). This is a locale-sensitive last resort—the
-// executor runs commands with LANG=en_US.UTF-8—used only AFTER the lookup-based
-// checks, never as the primary decision (E-16).
-func alreadyExists(output, name string) bool {
-	return strings.Contains(output, "already exists") && strings.Contains(output, name)
+// REQUESTED entity already exists, identified by its kind ("user"/"group") and
+// name as the tools quote it—e.g. "group 'x' already exists" or (Debian
+// adduser) "The user `x' already exists". Matching the kind+name token, rather
+// than the bare name, ensures a collision on a DIFFERENT entity that merely
+// shares the requested numeric id—e.g. groupadd printing "GID '1001' already
+// exists" when another group owns that gid, even if the requested name is
+// itself "1001"—is NOT mistaken for the requested name existing (which would
+// leave that name uncreated and break a later lookup/Demote by name). This is a
+// locale-sensitive last resort—the executor runs commands with
+// LANG=en_US.UTF-8—used only AFTER the lookup-based checks, never as the primary
+// decision (E-16).
+func alreadyExists(output, kind, name string) bool {
+	if !strings.Contains(output, "already exists") {
+		return false
+	}
+	// shadow-utils (useradd/groupadd) quote with 'name'; Debian adduser/addgroup
+	// quote with `name'. Accept either so the kind+name token is matched exactly.
+	for _, token := range []string{
+		kind + " '" + name + "'",
+		kind + " `" + name + "'",
+	} {
+		if strings.Contains(output, token) {
+			return true
+		}
+	}
+	return false
 }
 
 // ClassifyGroupForCreate is the shared idempotency gate for group creation, used
@@ -166,8 +182,8 @@ func ReconcileUserCreate(
 	// tool says this NAME already exists (LDAP/SSSD-backed). Tolerate, since
 	// failing here would reintroduce the #344 breakage; identity is unverifiable.
 	// A collision on a different account sharing the uid is not tolerated here
-	// (alreadyExists requires the username in the output).
-	if alreadyExists(out, username) {
+	// (alreadyExists requires the "user 'name'" token in the output).
+	if alreadyExists(out, "user", username) {
 		log.Warn().
 			Str("username", username).
 			Str("output", out).
@@ -207,7 +223,7 @@ func ReconcileGroupCreate(
 	// same-name group invisible to the pure-Go resolver). A "GID already exists"
 	// collision by a differently-named group is not tolerated—the requested
 	// name would remain uncreated—so it falls through to the original failure.
-	if alreadyExists(out, groupname) {
+	if alreadyExists(out, "group", groupname) {
 		log.Warn().
 			Str("groupname", groupname).
 			Str("output", out).

--- a/pkg/executor/handlers/common/lookup.go
+++ b/pkg/executor/handlers/common/lookup.go
@@ -1,0 +1,207 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"os/user"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// UserLookupFunc resolves a user by name. It mirrors os/user.Lookup so the
+// production default can be assigned directly, while tests inject a fake.
+type UserLookupFunc func(name string) (*user.User, error)
+
+// GroupLookupFunc resolves a group by name, mirroring os/user.LookupGroup.
+type GroupLookupFunc func(name string) (*user.Group, error)
+
+// DefaultUserLookup is the production user lookup backed by os/user.
+//
+// NOTE: the release binary is built with CGO_ENABLED=0 (see .goreleaser.yaml),
+// so this uses the pure-Go resolver that reads only /etc/passwd—it does NOT
+// consult NSS (nsswitch.conf). Local users (the provisioning target) resolve
+// correctly, but names that exist only in LDAP/SSSD/AD are INVISIBLE here.
+// Callers must not assume this lookup is authoritative for directory-backed
+// names; ReconcileUserCreate adds a best-effort create-time net (a re-lookup
+// for local TOCTOU races, plus an "already exists" output fallback for the
+// NSS-backed case the resolver cannot see).
+func DefaultUserLookup(name string) (*user.User, error) { return user.Lookup(name) }
+
+// DefaultGroupLookup is the production group lookup backed by os/user. The same
+// CGO_ENABLED=0 caveat as DefaultUserLookup applies (reads /etc/group only).
+func DefaultGroupLookup(name string) (*user.Group, error) { return user.LookupGroup(name) }
+
+// UserExists classifies a user lookup result:
+//   - found=true            : the user is present (u is non-nil).
+//   - found=false, err==nil : the user is definitively absent (UnknownUserError).
+//   - found=false, err!=nil : the lookup itself failed (e.g. unreadable
+//     /etc/passwd); the caller must fail loud rather than blind-create.
+func UserExists(lookup UserLookupFunc, name string) (u *user.User, found bool, err error) {
+	u, e := lookup(name)
+	if e == nil {
+		return u, true, nil
+	}
+	var notFound user.UnknownUserError
+	if errors.As(e, &notFound) {
+		return nil, false, nil
+	}
+	return nil, false, e
+}
+
+// GroupExists mirrors UserExists for groups (UnknownGroupError means absent).
+func GroupExists(lookup GroupLookupFunc, name string) (g *user.Group, found bool, err error) {
+	g, e := lookup(name)
+	if e == nil {
+		return g, true, nil
+	}
+	var notFound user.UnknownGroupError
+	if errors.As(e, &notFound) {
+		return nil, false, nil
+	}
+	return nil, false, e
+}
+
+// UserUIDConflictMessage is the single wording used whenever an existing user's
+// uid differs from the requested one, so the up-front gate and the create-time
+// secondary net surface identical, unambiguous drift messages.
+func UserUIDConflictMessage(username string, existingUID, requestedUID uint64) string {
+	return fmt.Sprintf(
+		"user %q already exists with uid %d but provisioning requested uid %d; "+
+			"refusing to modify an existing account",
+		username, existingUID, requestedUID)
+}
+
+// GroupGIDConflictMessage mirrors UserUIDConflictMessage for groups.
+func GroupGIDConflictMessage(groupname string, existingGID, requestedGID uint64) string {
+	return fmt.Sprintf(
+		"group %q already exists with gid %d but provisioning requested gid %d; "+
+			"refusing to modify an existing group",
+		groupname, existingGID, requestedGID)
+}
+
+// alreadyExists reports whether a create tool's output indicates the entity
+// already exists. This is a locale-sensitive last-resort check—the executor
+// runs commands with LANG=en_US.UTF-8, so the message is English in practice—
+// used only AFTER the lookup-based checks, never as the primary decision (E-16).
+func alreadyExists(output string) bool {
+	return strings.Contains(output, "already exists")
+}
+
+// ClassifyGroupForCreate is the shared idempotency gate for group creation, used
+// by both standalone addgroup (group handler) and the RHEL primary-group ensure
+// inside handleAddUser, so the two paths stay consistent (A-3). It decides,
+// purely from a lookup, whether the caller should create the group:
+//   - needCreate=false, code==0  : group present with the expected gid; skip create.
+//   - needCreate=true,  code==0  : group absent; caller should create it (then
+//     pass the result through ReconcileGroupCreate as the secondary net).
+//   - needCreate=false, code!=0  : gid conflict, unparseable gid, or a lookup
+//     that itself failed; caller returns (code, out, err) as-is.
+func ClassifyGroupForCreate(lookup GroupLookupFunc, groupname string, wantGID uint64) (needCreate bool, code int, out string, err error) {
+	existing, groupExists, lookupErr := GroupExists(lookup, groupname)
+	if lookupErr != nil {
+		// Cannot confirm current state; do not blind-create over a possibly
+		// shadowed entry. Fail loud so the drift is visible.
+		return false, 1, fmt.Sprintf("unable to verify whether group %q exists: %v", groupname, lookupErr), lookupErr
+	}
+	if !groupExists {
+		return true, 0, "", nil
+	}
+	gotGID, perr := strconv.ParseUint(existing.Gid, 10, 64)
+	if perr != nil {
+		return false, 1, fmt.Sprintf("group %q exists but its gid %q is not a valid number; refusing to modify an existing group", groupname, existing.Gid), nil
+	}
+	if gotGID != wantGID {
+		return false, 1, GroupGIDConflictMessage(groupname, gotGID, wantGID), nil
+	}
+	return false, 0, "", nil
+}
+
+// ReconcileUserCreate is the create-time secondary net for adduser/useradd.
+//
+// The primary idempotency decision is made by an up-front UserExists gate. This
+// net covers the two cases the gate cannot: a concurrent provisioner that
+// created the user between the gate and the create call (TOCTOU), and—because
+// the CGO_ENABLED=0 resolver cannot see NSS/LDAP/SSSD names—a directory-backed
+// account the gate reported absent. On a non-zero create result:
+//   - re-lookup finds the user with a matching (or omitted, uidRequested=false)
+//     uid -> idempotent success (0, "", nil).
+//   - re-lookup finds the user with a DIFFERENT uid -> surface a conflict.
+//   - re-lookup still cannot see the user BUT the create tool (which is
+//     NSS-aware) reported "already exists" -> tolerate as idempotent success.
+//     Identity cannot be verified here, so this is a best-effort last resort.
+//   - otherwise -> return the original create failure unchanged.
+//
+// When code == 0 it is a no-op that returns the inputs untouched, so callers can
+// wrap every create unconditionally without affecting the success path.
+func ReconcileUserCreate(
+	lookup UserLookupFunc, username string, wantUID uint64, uidRequested bool,
+	code int, out string, cmdErr error,
+) (int, string, error) {
+	if code == 0 {
+		return code, out, cmdErr
+	}
+	if existing, found, lookupErr := UserExists(lookup, username); lookupErr == nil && found {
+		if uidRequested {
+			gotUID, perr := strconv.ParseUint(existing.Uid, 10, 64)
+			if perr != nil {
+				return code, out, cmdErr // cannot verify identity; surface original failure
+			}
+			if gotUID != wantUID {
+				return 1, UserUIDConflictMessage(username, gotUID, wantUID), nil
+			}
+		}
+		log.Info().
+			Str("username", username).
+			Msg("Create returned non-zero but the user is already present with the expected identity; treating as idempotent success")
+		return 0, "", nil
+	}
+	// Tertiary net: invisible to the pure-Go resolver but the NSS-aware create
+	// tool says it already exists (LDAP/SSSD-backed). Tolerate, since failing
+	// here would reintroduce the #344 breakage; identity is unverifiable.
+	if alreadyExists(out) {
+		log.Warn().
+			Str("username", username).
+			Str("output", out).
+			Msg("Create reported the user already exists but it is invisible to the pure-Go resolver (likely NSS/LDAP/SSSD-backed); treating as idempotent (identity unverifiable)")
+		return 0, "", nil
+	}
+	return code, out, cmdErr
+}
+
+// ReconcileGroupCreate is the create-time secondary net for addgroup/groupadd,
+// mirroring ReconcileUserCreate. A group has no "omitted gid" case in the
+// provisioning payloads (GID is validated required,min=1), so the gid is always
+// compared when the group is visible. The "already exists" tertiary net also
+// covers a gid-in-use collision with a differently-named group (groupadd fails
+// but the numeric gid is usable), preserving the pre-#344 behavior.
+func ReconcileGroupCreate(
+	lookup GroupLookupFunc, groupname string, wantGID uint64,
+	code int, out string, cmdErr error,
+) (int, string, error) {
+	if code == 0 {
+		return code, out, cmdErr
+	}
+	if existing, found, lookupErr := GroupExists(lookup, groupname); lookupErr == nil && found {
+		gotGID, perr := strconv.ParseUint(existing.Gid, 10, 64)
+		if perr != nil {
+			return code, out, cmdErr
+		}
+		if gotGID != wantGID {
+			return 1, GroupGIDConflictMessage(groupname, gotGID, wantGID), nil
+		}
+		log.Info().
+			Str("groupname", groupname).
+			Msg("Create returned non-zero but the group is already present with the expected gid; treating as idempotent success")
+		return 0, "", nil
+	}
+	if alreadyExists(out) {
+		log.Warn().
+			Str("groupname", groupname).
+			Str("output", out).
+			Msg("Create reported the group already exists but it is invisible to the pure-Go resolver (likely NSS-backed or a gid-in-use collision); treating as idempotent (identity unverifiable)")
+		return 0, "", nil
+	}
+	return code, out, cmdErr
+}

--- a/pkg/executor/handlers/common/testing.go
+++ b/pkg/executor/handlers/common/testing.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"os/user"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -126,4 +127,38 @@ func (m *MockCommandExecutor) SetResult(command string, exitCode int, output str
 
 func (m *MockCommandExecutor) GetExecutedCommands() []ExecutedCommand {
 	return m.commands
+}
+
+// Invoked reports whether a command whose program name equals program was run.
+func (m *MockCommandExecutor) Invoked(program string) bool {
+	for _, c := range m.commands {
+		if c.Name == program {
+			return true
+		}
+	}
+	return false
+}
+
+// Lookup fakes shared by the user and group handler tests. They let tests drive
+// the idempotency gate (UserExists/GroupExists) without touching the host's
+// /etc/passwd or /etc/group, keeping create-path tests hermetic.
+
+// AbsentUserLookup reports the user absent (UnknownUserError).
+func AbsentUserLookup(string) (*user.User, error) { return nil, user.UnknownUserError("absent") }
+
+// AbsentGroupLookup reports the group absent (UnknownGroupError).
+func AbsentGroupLookup(string) (*user.Group, error) { return nil, user.UnknownGroupError("absent") }
+
+// ExistingUserLookup returns a fake reporting a user present with the given uid.
+func ExistingUserLookup(uid string) UserLookupFunc {
+	return func(name string) (*user.User, error) {
+		return &user.User{Username: name, Uid: uid, Gid: uid, HomeDir: "/home/" + name}, nil
+	}
+}
+
+// ExistingGroupLookup returns a fake reporting a group present with the given gid.
+func ExistingGroupLookup(gid string) GroupLookupFunc {
+	return func(name string) (*user.Group, error) {
+		return &user.Group{Name: name, Gid: gid}, nil
+	}
 }

--- a/pkg/executor/handlers/group/group.go
+++ b/pkg/executor/handlers/group/group.go
@@ -92,7 +92,7 @@ func (h *GroupHandler) Validate(cmd string, args *common.CommandArgs) error {
 func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandArgs) (int, string, error) {
 	// Extract arguments
 	groupname := args.Groupname
-	gid := int(args.GID)
+	gid := args.GID
 
 	// Validate
 	err := h.Validate(common.AddGroup.String(), args)
@@ -102,7 +102,7 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 
 	log.Info().
 		Str("groupname", groupname).
-		Uint64("gid", uint64(gid)).
+		Uint64("gid", gid).
 		Msg("Adding group")
 
 	// Idempotency gate (M8): verify by lookup whether the group already exists
@@ -120,7 +120,7 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 		// lets Execute still run SyncSystemInfo, reconciling DB<->reality drift.
 		log.Info().
 			Str("groupname", groupname).
-			Uint64("gid", uint64(gid)).
+			Uint64("gid", gid).
 			Msg("Group already exists with matching gid; skipping creation")
 		return 0, fmt.Sprintf("Group '%s' already exists with GID %d", groupname, gid), nil
 	}
@@ -133,14 +133,14 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 		createCode, output, err = h.Executor.Run(
 			ctx,
 			"/usr/sbin/addgroup",
-			"--gid", strconv.Itoa(gid),
+			"--gid", strconv.FormatUint(gid, 10),
 			groupname,
 		)
 	case "rhel":
 		createCode, output, err = h.Executor.Run(
 			ctx,
 			"/usr/sbin/groupadd",
-			"--gid", strconv.Itoa(gid),
+			"--gid", strconv.FormatUint(gid, 10),
 			groupname,
 		)
 	default:
@@ -160,14 +160,14 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 	if createCode != 0 {
 		log.Info().
 			Str("groupname", groupname).
-			Uint64("gid", uint64(gid)).
+			Uint64("gid", gid).
 			Msg("Group already exists; reconciled to idempotent success")
 		return 0, fmt.Sprintf("Group '%s' already exists with GID %d", groupname, gid), nil
 	}
 
 	log.Info().
 		Str("groupname", groupname).
-		Uint64("gid", uint64(gid)).
+		Uint64("gid", gid).
 		Int("exitCode", exitCode).
 		Msg("Group added successfully")
 

--- a/pkg/executor/handlers/group/group.go
+++ b/pkg/executor/handlers/group/group.go
@@ -14,6 +14,10 @@ import (
 type GroupHandler struct {
 	*common.BaseHandler
 	syncManager common.SystemInfoManager
+	// lookupGroup verifies existence before creating (idempotency gate). It
+	// defaults to an os/user-backed implementation and is overridden in tests.
+	// See pkg/executor/handlers/common/lookup.go.
+	lookupGroup common.GroupLookupFunc
 }
 
 // NewGroupHandler creates a new group handler
@@ -28,6 +32,7 @@ func NewGroupHandler(cmdExecutor common.CommandExecutor, syncManager common.Syst
 			cmdExecutor,
 		),
 		syncManager: syncManager,
+		lookupGroup: common.DefaultGroupLookup,
 	}
 	return h
 }
@@ -100,6 +105,26 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 		Uint64("gid", uint64(gid)).
 		Msg("Adding group")
 
+	// Idempotency gate (M8): verify by lookup whether the group already exists
+	// before attempting creation, so re-provisioning an already-present group
+	// is a no-op instead of a hard addgroup/groupadd "already exists" failure.
+	// A same-name/different-gid group is real drift and is surfaced, not masked.
+	// The classifier is shared with the RHEL primary-group ensure in handleAddUser
+	// so both paths behave identically (A-3 consistency).
+	needCreate, code, out, err := common.ClassifyGroupForCreate(h.lookupGroup, groupname, args.GID)
+	if code != 0 {
+		return code, out, err
+	}
+	if !needCreate {
+		// Group present with the expected gid: idempotent success. Returning 0
+		// lets Execute still run SyncSystemInfo, reconciling DB<->reality drift.
+		log.Info().
+			Str("groupname", groupname).
+			Uint64("gid", uint64(gid)).
+			Msg("Group already exists with matching gid; skipping creation")
+		return 0, fmt.Sprintf("Group '%s' already exists with GID %d", groupname, gid), nil
+	}
+
 	var exitCode int
 	var output string
 	// Platform-specific group addition
@@ -111,9 +136,6 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 			"--gid", strconv.Itoa(gid),
 			groupname,
 		)
-		if exitCode != 0 {
-			return exitCode, output, err
-		}
 	case "rhel":
 		exitCode, output, err = h.Executor.Run(
 			ctx,
@@ -121,11 +143,16 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 			"--gid", strconv.Itoa(gid),
 			groupname,
 		)
-		if exitCode != 0 {
-			return exitCode, output, err
-		}
 	default:
 		return 1, fmt.Sprintf("Platform '%s' not supported for group management", utils.PlatformLike), nil
+	}
+
+	// Secondary net: a raced or NSS-backed group invisible to the pure-Go
+	// lookup above may cause a non-zero "already exists". Re-verify and treat a
+	// matching group as idempotent success.
+	exitCode, output, err = common.ReconcileGroupCreate(h.lookupGroup, groupname, args.GID, exitCode, output, err)
+	if exitCode != 0 {
+		return exitCode, output, err
 	}
 
 	log.Info().

--- a/pkg/executor/handlers/group/group.go
+++ b/pkg/executor/handlers/group/group.go
@@ -125,19 +125,19 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 		return 0, fmt.Sprintf("Group '%s' already exists with GID %d", groupname, gid), nil
 	}
 
-	var exitCode int
+	var createCode, exitCode int
 	var output string
 	// Platform-specific group addition
 	switch utils.PlatformLike {
 	case "debian":
-		exitCode, output, err = h.Executor.Run(
+		createCode, output, err = h.Executor.Run(
 			ctx,
 			"/usr/sbin/addgroup",
 			"--gid", strconv.Itoa(gid),
 			groupname,
 		)
 	case "rhel":
-		exitCode, output, err = h.Executor.Run(
+		createCode, output, err = h.Executor.Run(
 			ctx,
 			"/usr/sbin/groupadd",
 			"--gid", strconv.Itoa(gid),
@@ -150,9 +150,19 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 	// Secondary net: a raced or NSS-backed group invisible to the pure-Go
 	// lookup above may cause a non-zero "already exists". Re-verify and treat a
 	// matching group as idempotent success.
-	exitCode, output, err = common.ReconcileGroupCreate(h.lookupGroup, groupname, args.GID, exitCode, output, err)
+	exitCode, output, err = common.ReconcileGroupCreate(h.lookupGroup, groupname, args.GID, createCode, output, err)
 	if exitCode != 0 {
 		return exitCode, output, err
+	}
+
+	// A non-zero create that reconciled to success means the group already
+	// existed (raced or NSS-backed); report it as such rather than "added".
+	if createCode != 0 {
+		log.Info().
+			Str("groupname", groupname).
+			Uint64("gid", uint64(gid)).
+			Msg("Group already exists; reconciled to idempotent success")
+		return 0, fmt.Sprintf("Group '%s' already exists with GID %d", groupname, gid), nil
 	}
 
 	log.Info().

--- a/pkg/executor/handlers/group/group.go
+++ b/pkg/executor/handlers/group/group.go
@@ -111,7 +111,7 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 	// A same-name/different-gid group is real drift and is surfaced, not masked.
 	// The classifier is shared with the RHEL primary-group ensure in handleAddUser
 	// so both paths behave identically (A-3 consistency).
-	needCreate, code, out, err := common.ClassifyGroupForCreate(h.lookupGroup, groupname, args.GID)
+	needCreate, code, out, err := common.ClassifyGroupForCreate(h.lookupGroup, groupname, gid)
 	if code != 0 {
 		return code, out, err
 	}
@@ -150,7 +150,7 @@ func (h *GroupHandler) handleAddGroup(ctx context.Context, args *common.CommandA
 	// Secondary net: a raced or NSS-backed group invisible to the pure-Go
 	// lookup above may cause a non-zero "already exists". Re-verify and treat a
 	// matching group as idempotent success.
-	exitCode, output, err = common.ReconcileGroupCreate(h.lookupGroup, groupname, args.GID, createCode, output, err)
+	exitCode, output, err = common.ReconcileGroupCreate(h.lookupGroup, groupname, gid, createCode, output, err)
 	if exitCode != 0 {
 		return exitCode, output, err
 	}

--- a/pkg/executor/handlers/group/group_test.go
+++ b/pkg/executor/handlers/group/group_test.go
@@ -8,10 +8,24 @@
 package group
 
 import (
+	"context"
+	"errors"
+	"os/user"
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
+	"github.com/alpacax/alpamon/v2/pkg/utils"
 )
+
+// newTestGroupHandler builds a GroupHandler whose lookup reports absent by
+// default (via the shared fake in common/testing.go). Individual tests override
+// h.lookupGroup for the exists/conflict matrix.
+func newTestGroupHandler(exec common.CommandExecutor) *GroupHandler {
+	h := NewGroupHandler(exec, nil)
+	h.lookupGroup = common.AbsentGroupLookup
+	return h
+}
 
 func TestGroupHandler_AddGroup(t *testing.T) {
 	// Create mock executor
@@ -131,5 +145,169 @@ func TestGroupHandler_Name(t *testing.T) {
 
 	if handler.Name() != "group" {
 		t.Errorf("Expected handler name 'group', got '%s'", handler.Name())
+	}
+}
+
+// TestGroupHandler_AddGroup_Execute exercises handleAddGroup end-to-end for the
+// absent (create) path on both platforms.
+func TestGroupHandler_AddGroup_Execute(t *testing.T) {
+	tests := []struct {
+		name       string
+		platform   string
+		createCmd  string
+		createArgs string
+	}{
+		{name: "debian addgroup", platform: "debian", createCmd: "/usr/sbin/addgroup", createArgs: "--gid 1001 testgroup"},
+		{name: "rhel groupadd", platform: "rhel", createCmd: "/usr/sbin/groupadd", createArgs: "--gid 1001 testgroup"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalPlatformLike := utils.PlatformLike
+			utils.SetPlatformLike(tt.platform)
+			t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+			mock := common.NewMockCommandExecutor(t)
+			mock.SetResult(tt.createCmd+" "+tt.createArgs, 0, "Group created", nil)
+			handler := newTestGroupHandler(mock) // AbsentGroupLookup -> create path
+
+			args := &common.CommandArgs{Groupname: "testgroup", GID: 1001}
+			exitCode, output, err := handler.Execute(context.Background(), "addgroup", args)
+			if err != nil || exitCode != 0 {
+				t.Fatalf("Execute() exitCode=%d err=%v output=%q", exitCode, err, output)
+			}
+			if !mock.Invoked(tt.createCmd) {
+				t.Errorf("expected %s to be invoked; got %+v", tt.createCmd, mock.GetExecutedCommands())
+			}
+		})
+	}
+}
+
+// TestGroupHandler_AddGroup_Idempotent covers the exists/conflict/lookup-error
+// matrix (issue #344, M8).
+func TestGroupHandler_AddGroup_Idempotent(t *testing.T) {
+	t.Run("exists with matching gid -> skip create, success", func(t *testing.T) {
+		originalPlatformLike := utils.PlatformLike
+		utils.SetPlatformLike("debian")
+		t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+		mock := common.NewMockCommandExecutor(t)
+		handler := newTestGroupHandler(mock)
+		handler.lookupGroup = common.ExistingGroupLookup("1001")
+
+		exitCode, output, err := handler.Execute(context.Background(), "addgroup", &common.CommandArgs{Groupname: "testgroup", GID: 1001})
+		if err != nil || exitCode != 0 {
+			t.Fatalf("Execute() exitCode=%d err=%v output=%q", exitCode, err, output)
+		}
+		if mock.Invoked("/usr/sbin/addgroup") {
+			t.Error("addgroup must be skipped when the group already exists with matching gid")
+		}
+		if !strings.Contains(output, "already exists with GID 1001") {
+			t.Errorf("expected an 'already exists' message, got: %q", output)
+		}
+	})
+
+	t.Run("exists with different gid -> conflict surfaced", func(t *testing.T) {
+		originalPlatformLike := utils.PlatformLike
+		utils.SetPlatformLike("debian")
+		t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+		mock := common.NewMockCommandExecutor(t)
+		handler := newTestGroupHandler(mock)
+		handler.lookupGroup = common.ExistingGroupLookup("9999")
+
+		exitCode, output, _ := handler.Execute(context.Background(), "addgroup", &common.CommandArgs{Groupname: "testgroup", GID: 1001})
+		if exitCode == 0 {
+			t.Fatalf("expected non-zero exit for gid conflict, got 0 (output=%q)", output)
+		}
+		if !strings.Contains(output, "already exists with gid 9999") || !strings.Contains(output, "requested gid 1001") {
+			t.Errorf("conflict message must name both gids, got: %q", output)
+		}
+		if mock.Invoked("/usr/sbin/addgroup") {
+			t.Error("addgroup must not run on a gid conflict")
+		}
+	})
+
+	t.Run("lookup error -> fail loud, no create", func(t *testing.T) {
+		originalPlatformLike := utils.PlatformLike
+		utils.SetPlatformLike("debian")
+		t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+		mock := common.NewMockCommandExecutor(t)
+		handler := newTestGroupHandler(mock)
+		handler.lookupGroup = func(string) (*user.Group, error) {
+			return nil, errors.New("getgrnam_r: I/O error")
+		}
+
+		exitCode, output, _ := handler.Execute(context.Background(), "addgroup", &common.CommandArgs{Groupname: "testgroup", GID: 1001})
+		if exitCode == 0 {
+			t.Fatalf("expected non-zero exit when the lookup itself fails, got 0 (output=%q)", output)
+		}
+		if !strings.Contains(output, "unable to verify") {
+			t.Errorf("expected an 'unable to verify' message, got: %q", output)
+		}
+		if mock.Invoked("/usr/sbin/addgroup") {
+			t.Error("addgroup must not run when existence cannot be verified")
+		}
+	})
+}
+
+// TestGroupHandler_AddGroup_SecondaryNet verifies the create-time reconcile:
+// absent at the gate, create fails, then a re-verify (plus an "already exists"
+// tertiary fallback for NSS-backed groups / gid-in-use collisions the pure-Go
+// resolver cannot see) decides the outcome.
+func TestGroupHandler_AddGroup_SecondaryNet(t *testing.T) {
+	const createCmd = "/usr/sbin/addgroup --gid 1001 testgroup"
+
+	tests := []struct {
+		name         string
+		createOutput string
+		reverifyGID  string
+		reverifyErr  error
+		wantExitZero bool
+		wantMsgPart  string
+	}{
+		{name: "raced local create, matching gid -> success", createOutput: "addgroup: group already exists", reverifyGID: "1001", wantExitZero: true},
+		{name: "raced local create, different gid -> conflict", createOutput: "addgroup: group already exists", reverifyGID: "2002", wantExitZero: false, wantMsgPart: "already exists with gid 2002"},
+		{name: "NSS-backed/gid-collision, absent at reverify but create says already exists -> tolerated", createOutput: "groupadd: GID '1001' already exists", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: true},
+		{name: "genuine failure, absent and not already-exists -> surfaced", createOutput: "addgroup: cannot open /etc/group", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: false, wantMsgPart: "cannot open"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalPlatformLike := utils.PlatformLike
+			utils.SetPlatformLike("debian")
+			t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+			mock := common.NewMockCommandExecutor(t)
+			mock.SetResult(createCmd, 1, tt.createOutput, errors.New("exit status 1"))
+			handler := newTestGroupHandler(mock)
+
+			calls := 0
+			handler.lookupGroup = func(name string) (*user.Group, error) {
+				calls++
+				if calls == 1 {
+					return nil, user.UnknownGroupError("absent") // gate: absent -> create attempted
+				}
+				if tt.reverifyErr != nil {
+					return nil, tt.reverifyErr
+				}
+				return &user.Group{Name: name, Gid: tt.reverifyGID}, nil
+			}
+
+			exitCode, output, _ := handler.Execute(context.Background(), "addgroup", &common.CommandArgs{Groupname: "testgroup", GID: 1001})
+			if !mock.Invoked("/usr/sbin/addgroup") {
+				t.Fatal("addgroup should have been attempted after an absent gate lookup")
+			}
+			if tt.wantExitZero && exitCode != 0 {
+				t.Fatalf("expected idempotent success (exit 0), got %d (output=%q)", exitCode, output)
+			}
+			if !tt.wantExitZero && exitCode == 0 {
+				t.Fatalf("expected non-zero exit, got 0 (output=%q)", output)
+			}
+			if tt.wantMsgPart != "" && !strings.Contains(output, tt.wantMsgPart) {
+				t.Errorf("expected output to contain %q, got: %q", tt.wantMsgPart, output)
+			}
+		})
 	}
 }

--- a/pkg/executor/handlers/group/group_test.go
+++ b/pkg/executor/handlers/group/group_test.go
@@ -252,6 +252,29 @@ func TestGroupHandler_AddGroup_Idempotent(t *testing.T) {
 	})
 }
 
+// TestGroupHandler_AddGroup_NumericNameGidCollisionSurfaced guards the tertiary
+// net against a numeric group name aliasing a gid-in-use message: when the
+// requested name is "1001" and gid 1001 is owned by a DIFFERENT group, groupadd
+// prints "GID '1001' already exists" (naming the gid, not "group '1001'"). The
+// requested name is never created, so this must be surfaced, not tolerated.
+func TestGroupHandler_AddGroup_NumericNameGidCollisionSurfaced(t *testing.T) {
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("rhel")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+	mock := common.NewMockCommandExecutor(t)
+	mock.SetResult("/usr/sbin/groupadd --gid 1001 1001", 1, "groupadd: GID '1001' already exists", errors.New("exit status 4"))
+	handler := newTestGroupHandler(mock) // AbsentGroupLookup: gate + reconcile both see the name as absent
+
+	exitCode, output, _ := handler.Execute(context.Background(), "addgroup", &common.CommandArgs{Groupname: "1001", GID: 1001})
+	if exitCode == 0 {
+		t.Fatalf("a gid-in-use collision by a different group must be surfaced even when the requested name is numeric; got 0 (output=%q)", output)
+	}
+	if !strings.Contains(output, "GID '1001'") {
+		t.Errorf("expected the original gid-collision failure to surface, got: %q", output)
+	}
+}
+
 // TestGroupHandler_AddGroup_SecondaryNet verifies the create-time reconcile:
 // absent at the gate, create fails, then a re-verify (plus an "already exists"
 // tertiary fallback for NSS-backed groups / gid-in-use collisions the pure-Go

--- a/pkg/executor/handlers/group/group_test.go
+++ b/pkg/executor/handlers/group/group_test.go
@@ -267,9 +267,9 @@ func TestGroupHandler_AddGroup_SecondaryNet(t *testing.T) {
 		wantExitZero bool
 		wantMsgPart  string
 	}{
-		{name: "raced local create, matching gid -> success", createOutput: "addgroup: group already exists", reverifyGID: "1001", wantExitZero: true},
+		{name: "raced local create, matching gid -> success", createOutput: "addgroup: group already exists", reverifyGID: "1001", wantExitZero: true, wantMsgPart: "already exists"},
 		{name: "raced local create, different gid -> conflict", createOutput: "addgroup: group already exists", reverifyGID: "2002", wantExitZero: false, wantMsgPart: "already exists with gid 2002"},
-		{name: "NSS-backed same name, absent at reverify but create names this group -> tolerated", createOutput: "addgroup: group 'testgroup' already exists", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: true},
+		{name: "NSS-backed same name, absent at reverify but create names this group -> tolerated", createOutput: "addgroup: group 'testgroup' already exists", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: true, wantMsgPart: "already exists"},
 		{name: "gid-in-use by a different name, absent at reverify -> surfaced (not masked)", createOutput: "groupadd: GID '1001' already exists", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: false, wantMsgPart: "GID '1001'"},
 		{name: "genuine failure, absent and not already-exists -> surfaced", createOutput: "addgroup: cannot open /etc/group", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: false, wantMsgPart: "cannot open"},
 	}

--- a/pkg/executor/handlers/group/group_test.go
+++ b/pkg/executor/handlers/group/group_test.go
@@ -269,7 +269,8 @@ func TestGroupHandler_AddGroup_SecondaryNet(t *testing.T) {
 	}{
 		{name: "raced local create, matching gid -> success", createOutput: "addgroup: group already exists", reverifyGID: "1001", wantExitZero: true},
 		{name: "raced local create, different gid -> conflict", createOutput: "addgroup: group already exists", reverifyGID: "2002", wantExitZero: false, wantMsgPart: "already exists with gid 2002"},
-		{name: "NSS-backed/gid-collision, absent at reverify but create says already exists -> tolerated", createOutput: "groupadd: GID '1001' already exists", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: true},
+		{name: "NSS-backed same name, absent at reverify but create names this group -> tolerated", createOutput: "addgroup: group 'testgroup' already exists", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: true},
+		{name: "gid-in-use by a different name, absent at reverify -> surfaced (not masked)", createOutput: "groupadd: GID '1001' already exists", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: false, wantMsgPart: "GID '1001'"},
 		{name: "genuine failure, absent and not already-exists -> surfaced", createOutput: "addgroup: cannot open /etc/group", reverifyErr: user.UnknownGroupError("absent"), wantExitZero: false, wantMsgPart: "cannot open"},
 	}
 

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -124,10 +124,6 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 		Str("home", data.HomeDirectory).
 		Msg("Adding user")
 
-	var exitCode int
-	var output string
-	var err error
-
 	// The omit*Flag booleans govern *flag emission* on adduser/useradd,
 	// NOT whether the underlying entity exists. When a flag is omitted:
 	//   - omitUIDFlag  → OS auto-assigns a uid (the user still gets a uid).
@@ -242,15 +238,15 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 				return code, out, gerr
 			}
 			if needCreate {
-				exitCode, output, err = h.Executor.Run(
+				code, out, gerr = h.Executor.Run(
 					ctx,
 					"/usr/sbin/groupadd",
 					"--gid", strconv.FormatUint(data.GID, 10),
 					data.Groupname,
 				)
-				exitCode, output, err = common.ReconcileGroupCreate(h.lookupGroup, data.Groupname, data.GID, exitCode, output, err)
-				if exitCode != 0 {
-					return exitCode, output, err
+				code, out, gerr = common.ReconcileGroupCreate(h.lookupGroup, data.Groupname, data.GID, code, out, gerr)
+				if code != 0 {
+					return code, out, gerr
 				}
 			}
 		}
@@ -317,13 +313,12 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 	log.Info().
 		Str("username", data.Username).
 		Bool("alreadyExisted", userExists).
-		Int("exitCode", exitCode).
 		Msg("User provisioning completed")
 
 	if userExists {
-		return exitCode, fmt.Sprintf("User '%s' already exists", data.Username), nil
+		return 0, fmt.Sprintf("User '%s' already exists", data.Username), nil
 	}
-	return exitCode, fmt.Sprintf("User '%s' added successfully", data.Username), nil
+	return 0, fmt.Sprintf("User '%s' added successfully", data.Username), nil
 }
 
 // runUserCreate runs the platform create command (adduser/useradd) and applies

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -310,7 +310,11 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 	if len(data.Groups) > 0 && h.groupService != nil {
 		if err := h.groupService.AddUserToGroups(ctx, data.Username, data.Groups); err != nil {
 			log.Warn().Err(err).Msg("Failed to add user to additional groups")
-			return 0, fmt.Sprintf("User '%s' created but failed to add to groups: %v", data.Username, err), nil
+			state := "created"
+			if userExists {
+				state = "already exists"
+			}
+			return 0, fmt.Sprintf("User '%s' %s but failed to add to groups: %v", data.Username, state, err), nil
 		}
 	}
 

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -19,6 +19,11 @@ type UserHandler struct {
 	*common.BaseHandler
 	groupService services.GroupService
 	syncManager  common.SystemInfoManager
+	// lookupUser / lookupGroup verify existence before creating (idempotency
+	// gate). They default to os/user-backed implementations and are overridden
+	// in tests. See pkg/executor/handlers/common/lookup.go.
+	lookupUser  common.UserLookupFunc
+	lookupGroup common.GroupLookupFunc
 }
 
 // NewUserHandler creates a new user handler
@@ -35,6 +40,8 @@ func NewUserHandler(cmdExecutor common.CommandExecutor, groupService services.Gr
 		),
 		groupService: groupService,
 		syncManager:  syncManager,
+		lookupUser:   common.DefaultUserLookup,
+		lookupGroup:  common.DefaultGroupLookup,
 	}
 	return h
 }
@@ -166,65 +173,111 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 		}
 	}
 
+	// Idempotency gate (M8): verify by lookup whether the user already exists
+	// before attempting creation, so re-provisioning an already-present account
+	// is a no-op instead of a hard adduser/useradd "already exists" failure
+	// (the #344 root cause). The lookup is the PRIMARY decision; a create-time
+	// secondary net (below) covers TOCTOU races and NSS-backed names invisible
+	// to the CGO_ENABLED=0 pure-Go resolver.
+	//
+	// A same-name/different-uid account is real drift and is surfaced as a
+	// failure, never masked. When the uid is omitted (service account, OS
+	// auto-assigns), name presence alone marks the account as provisioned.
+	existing, userExists, lookupErr := common.UserExists(h.lookupUser, data.Username)
+	if lookupErr != nil {
+		// We cannot confirm the current state; do not blind-create over a
+		// possibly-shadowed entry. Fail loud so the drift is visible.
+		return 1, fmt.Sprintf("unable to verify whether user %q exists: %v", data.Username, lookupErr), lookupErr
+	}
+	if userExists && !omitUIDFlag {
+		existingUID, perr := strconv.ParseUint(existing.Uid, 10, 64)
+		if perr != nil {
+			return 1, fmt.Sprintf("user %q exists but its uid %q is not a valid number; refusing to modify an existing account", data.Username, existing.Uid), nil
+		}
+		if existingUID != data.UID {
+			return 1, common.UserUIDConflictMessage(data.Username, existingUID, data.UID), nil
+		}
+	}
+
 	switch utils.PlatformLike {
 	case "debian":
-		cmdArgs := []string{}
-		if !omitHomeFlag {
-			cmdArgs = append(cmdArgs, "--home", data.HomeDirectory)
-		}
-		cmdArgs = append(cmdArgs, "--shell", data.Shell)
-		if !omitUIDFlag {
-			cmdArgs = append(cmdArgs, "--uid", strconv.FormatUint(data.UID, 10))
-		}
-		switch {
-		case omitGIDFlag && data.Groupname != "":
-			// Service-account path: set primary group by name so the user
-			// joins `Groupname` regardless of USERGROUPS settings.
-			cmdArgs = append(cmdArgs, "--ingroup", data.Groupname)
-		case !omitGIDFlag:
-			cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
-		}
-		cmdArgs = append(cmdArgs, "--gecos", data.Comment, "--disabled-password", data.Username)
-		exitCode, output, err = h.Executor.Run(ctx, "/usr/sbin/adduser", cmdArgs...)
-		if exitCode != 0 {
-			return exitCode, output, err
-		}
-	case "rhel":
-		// Create primary group with the explicit GID for IAM User payloads.
-		// Service-account payloads (omitGIDFlag=true) already ran `groupadd -f`
-		// above and will use `--gid <Groupname>` below.
-		if !omitGIDFlag {
-			exitCode, output, err = h.Executor.Run(
-				ctx,
-				"/usr/sbin/groupadd",
-				"--gid", strconv.FormatUint(data.GID, 10),
-				data.Groupname,
-			)
-			// Ignore if group already exists
-			if exitCode != 0 && !strings.Contains(output, "already exists") {
+		if !userExists {
+			cmdArgs := []string{}
+			if !omitHomeFlag {
+				cmdArgs = append(cmdArgs, "--home", data.HomeDirectory)
+			}
+			cmdArgs = append(cmdArgs, "--shell", data.Shell)
+			if !omitUIDFlag {
+				cmdArgs = append(cmdArgs, "--uid", strconv.FormatUint(data.UID, 10))
+			}
+			switch {
+			case omitGIDFlag && data.Groupname != "":
+				// Service-account path: set primary group by name so the user
+				// joins `Groupname` regardless of USERGROUPS settings.
+				cmdArgs = append(cmdArgs, "--ingroup", data.Groupname)
+			case !omitGIDFlag:
+				cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
+			}
+			cmdArgs = append(cmdArgs, "--gecos", data.Comment, "--disabled-password", data.Username)
+			exitCode, output, err = h.Executor.Run(ctx, "/usr/sbin/adduser", cmdArgs...)
+			// Secondary net: a raced or LDAP/SSSD-backed account (invisible to
+			// the pure-Go lookup above) may cause a non-zero "already exists".
+			// Re-verify and treat a matching account as idempotent success.
+			exitCode, output, err = common.ReconcileUserCreate(h.lookupUser, data.Username, data.UID, !omitUIDFlag, exitCode, output, err)
+			if exitCode != 0 {
 				return exitCode, output, err
 			}
 		}
+	case "rhel":
+		// Ensure the primary group exists with the explicit GID for IAM User
+		// payloads. Service-account payloads (omitGIDFlag=true) already ran
+		// `groupadd -f` above and will use `--gid <Groupname>` below.
+		//
+		// This runs whether or not the user exists—it is an idempotent
+		// "ensure", gated by the same lookup rule as standalone addgroup (A-3
+		// consistency): a matching gid skips creation, a different gid surfaces
+		// a conflict, and creation keeps a lookup-reverify secondary net.
+		if !omitGIDFlag {
+			needCreate, code, out, gerr := common.ClassifyGroupForCreate(h.lookupGroup, data.Groupname, data.GID)
+			if code != 0 {
+				return code, out, gerr
+			}
+			if needCreate {
+				exitCode, output, err = h.Executor.Run(
+					ctx,
+					"/usr/sbin/groupadd",
+					"--gid", strconv.FormatUint(data.GID, 10),
+					data.Groupname,
+				)
+				exitCode, output, err = common.ReconcileGroupCreate(h.lookupGroup, data.Groupname, data.GID, exitCode, output, err)
+				if exitCode != 0 {
+					return exitCode, output, err
+				}
+			}
+		}
 
-		cmdArgs := []string{}
-		if !omitHomeFlag {
-			cmdArgs = append(cmdArgs, "--home-dir", data.HomeDirectory)
-		}
-		cmdArgs = append(cmdArgs, "--shell", data.Shell)
-		if !omitUIDFlag {
-			cmdArgs = append(cmdArgs, "--uid", strconv.FormatUint(data.UID, 10))
-		}
-		switch {
-		case omitGIDFlag && data.Groupname != "":
-			// Service-account path: useradd accepts a group name for --gid.
-			cmdArgs = append(cmdArgs, "--gid", data.Groupname)
-		case !omitGIDFlag:
-			cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
-		}
-		cmdArgs = append(cmdArgs, "--comment", data.Comment, "--create-home", data.Username)
-		exitCode, output, err = h.Executor.Run(ctx, "/usr/sbin/useradd", cmdArgs...)
-		if exitCode != 0 {
-			return exitCode, output, err
+		if !userExists {
+			cmdArgs := []string{}
+			if !omitHomeFlag {
+				cmdArgs = append(cmdArgs, "--home-dir", data.HomeDirectory)
+			}
+			cmdArgs = append(cmdArgs, "--shell", data.Shell)
+			if !omitUIDFlag {
+				cmdArgs = append(cmdArgs, "--uid", strconv.FormatUint(data.UID, 10))
+			}
+			switch {
+			case omitGIDFlag && data.Groupname != "":
+				// Service-account path: useradd accepts a group name for --gid.
+				cmdArgs = append(cmdArgs, "--gid", data.Groupname)
+			case !omitGIDFlag:
+				cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
+			}
+			cmdArgs = append(cmdArgs, "--comment", data.Comment, "--create-home", data.Username)
+			exitCode, output, err = h.Executor.Run(ctx, "/usr/sbin/useradd", cmdArgs...)
+			exitCode, output, err = common.ReconcileUserCreate(h.lookupUser, data.Username, data.UID, !omitUIDFlag, exitCode, output, err)
+			if exitCode != 0 {
+				return exitCode, output, err
+			}
 		}
 	default:
 		return 1, fmt.Sprintf("Platform '%s' not supported for user management", utils.PlatformLike), nil
@@ -251,9 +304,13 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 
 	log.Info().
 		Str("username", data.Username).
+		Bool("alreadyExisted", userExists).
 		Int("exitCode", exitCode).
-		Msg("User added successfully")
+		Msg("User provisioning completed")
 
+	if userExists {
+		return exitCode, fmt.Sprintf("User '%s' already exists; ensured group membership and permissions", data.Username), nil
+	}
 	return exitCode, fmt.Sprintf("User '%s' added successfully", data.Username), nil
 }
 

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -309,7 +309,7 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 		Msg("User provisioning completed")
 
 	if userExists {
-		return exitCode, fmt.Sprintf("User '%s' already exists; ensured group membership and permissions", data.Username), nil
+		return exitCode, fmt.Sprintf("User '%s' already exists", data.Username), nil
 	}
 	return exitCode, fmt.Sprintf("User '%s' added successfully", data.Username), nil
 }

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -219,13 +219,19 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 				cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
 			}
 			cmdArgs = append(cmdArgs, "--gecos", data.Comment, "--disabled-password", data.Username)
-			exitCode, output, err = h.Executor.Run(ctx, "/usr/sbin/adduser", cmdArgs...)
+			createCode, createOut, createErr := h.Executor.Run(ctx, "/usr/sbin/adduser", cmdArgs...)
 			// Secondary net: a raced or LDAP/SSSD-backed account (invisible to
 			// the pure-Go lookup above) may cause a non-zero "already exists".
 			// Re-verify and treat a matching account as idempotent success.
-			exitCode, output, err = common.ReconcileUserCreate(h.lookupUser, data.Username, data.UID, !omitUIDFlag, exitCode, output, err)
+			exitCode, output, err = common.ReconcileUserCreate(h.lookupUser, data.Username, data.UID, !omitUIDFlag, createCode, createOut, createErr)
 			if exitCode != 0 {
 				return exitCode, output, err
+			}
+			// A non-zero create that reconciled to success means the account
+			// already existed (raced or NSS-backed); report it as such rather
+			// than "added".
+			if createCode != 0 {
+				userExists = true
 			}
 		}
 	case "rhel":
@@ -273,10 +279,16 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 				cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
 			}
 			cmdArgs = append(cmdArgs, "--comment", data.Comment, "--create-home", data.Username)
-			exitCode, output, err = h.Executor.Run(ctx, "/usr/sbin/useradd", cmdArgs...)
-			exitCode, output, err = common.ReconcileUserCreate(h.lookupUser, data.Username, data.UID, !omitUIDFlag, exitCode, output, err)
+			createCode, createOut, createErr := h.Executor.Run(ctx, "/usr/sbin/useradd", cmdArgs...)
+			exitCode, output, err = common.ReconcileUserCreate(h.lookupUser, data.Username, data.UID, !omitUIDFlag, createCode, createOut, createErr)
 			if exitCode != 0 {
 				return exitCode, output, err
+			}
+			// A non-zero create that reconciled to success means the account
+			// already existed (raced or NSS-backed); report it as such rather
+			// than "added".
+			if createCode != 0 {
+				userExists = true
 			}
 		}
 	default:

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -219,18 +219,11 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 				cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
 			}
 			cmdArgs = append(cmdArgs, "--gecos", data.Comment, "--disabled-password", data.Username)
-			createCode, createOut, createErr := h.Executor.Run(ctx, "/usr/sbin/adduser", cmdArgs...)
-			// Secondary net: a raced or LDAP/SSSD-backed account (invisible to
-			// the pure-Go lookup above) may cause a non-zero "already exists".
-			// Re-verify and treat a matching account as idempotent success.
-			exitCode, output, err = common.ReconcileUserCreate(h.lookupUser, data.Username, data.UID, !omitUIDFlag, createCode, createOut, createErr)
-			if exitCode != 0 {
-				return exitCode, output, err
+			existed, code, out, cerr := h.runUserCreate(ctx, "/usr/sbin/adduser", cmdArgs, data, !omitUIDFlag)
+			if code != 0 {
+				return code, out, cerr
 			}
-			// A non-zero create that reconciled to success means the account
-			// already existed (raced or NSS-backed); report it as such rather
-			// than "added".
-			if createCode != 0 {
+			if existed {
 				userExists = true
 			}
 		}
@@ -279,15 +272,11 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 				cmdArgs = append(cmdArgs, "--gid", strconv.FormatUint(data.GID, 10))
 			}
 			cmdArgs = append(cmdArgs, "--comment", data.Comment, "--create-home", data.Username)
-			createCode, createOut, createErr := h.Executor.Run(ctx, "/usr/sbin/useradd", cmdArgs...)
-			exitCode, output, err = common.ReconcileUserCreate(h.lookupUser, data.Username, data.UID, !omitUIDFlag, createCode, createOut, createErr)
-			if exitCode != 0 {
-				return exitCode, output, err
+			existed, code, out, cerr := h.runUserCreate(ctx, "/usr/sbin/useradd", cmdArgs, data, !omitUIDFlag)
+			if code != 0 {
+				return code, out, cerr
 			}
-			// A non-zero create that reconciled to success means the account
-			// already existed (raced or NSS-backed); report it as such rather
-			// than "added".
-			if createCode != 0 {
+			if existed {
 				userExists = true
 			}
 		}
@@ -296,10 +285,17 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 	}
 
 	// Set home directory permissions if specified.
+	//
+	// Only for a freshly-created account (!userExists). We do not chmod an
+	// existing user's home: it matches the "don't modify an existing account"
+	// contract (we also don't usermod -g), and it avoids a root chmod that would
+	// follow a symlink an existing—possibly hostile—local user could plant at
+	// their home path.
+	//
 	// Skip when HomeDirectory was omitted (OS default path), since the caller
 	// didn't specify a target and we would otherwise chmod an empty path.
 	// codeql[go/path-injection]: Intentional - Admin-specified home directory permission
-	if data.HomeDirectory != "" && data.HomeDirectoryPermission != "" && data.HomeDirectoryPermission != "0755" {
+	if !userExists && data.HomeDirectory != "" && data.HomeDirectoryPermission != "" && data.HomeDirectoryPermission != "0755" {
 		mode, err := strconv.ParseUint(data.HomeDirectoryPermission, 8, 32)
 		if err == nil {
 			_ = os.Chmod(data.HomeDirectory, os.FileMode(mode)) // lgtm[go/path-injection]
@@ -328,6 +324,28 @@ func (h *UserHandler) handleAddUser(ctx context.Context, args *common.CommandArg
 		return exitCode, fmt.Sprintf("User '%s' already exists", data.Username), nil
 	}
 	return exitCode, fmt.Sprintf("User '%s' added successfully", data.Username), nil
+}
+
+// runUserCreate runs the platform create command (adduser/useradd) and applies
+// the create-time reconcile net, so both platform branches share one copy of
+// the "create then reconcile" contract. It returns:
+//   - existed=true when a non-zero create was reconciled to idempotent success
+//     (the account already existed: a raced or NSS/LDAP-backed name); the caller
+//     should treat the user as pre-existing.
+//   - code!=0 when the create genuinely failed—the caller must return
+//     (code, out, err) unchanged.
+//
+// On success (code==0) the caller continues to the idempotent ensure steps.
+func (h *UserHandler) runUserCreate(ctx context.Context, tool string, cmdArgs []string, data UserData, uidRequested bool) (existed bool, code int, out string, err error) {
+	createCode, createOut, createErr := h.Executor.Run(ctx, tool, cmdArgs...)
+	// Secondary net: a raced or LDAP/SSSD-backed account (invisible to the
+	// pure-Go lookup) may cause a non-zero "already exists". Re-verify and treat
+	// a matching account as idempotent success.
+	code, out, err = common.ReconcileUserCreate(h.lookupUser, data.Username, data.UID, uidRequested, createCode, createOut, createErr)
+	if code != 0 {
+		return false, code, out, err
+	}
+	return createCode != 0, 0, out, err
 }
 
 // backupHomeDirectory backs up the user's home directory before deletion

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/user"
 	"strings"
 	"testing"
 
@@ -28,6 +29,17 @@ type MockGroupService struct {
 func (m *MockGroupService) AddUserToGroups(ctx context.Context, username string, gids []uint64) error {
 	m.AddUserToGroupsCalled = true
 	return m.AddUserToGroupsError
+}
+
+// newTestUserHandler builds a UserHandler whose user/group lookups report
+// absent by default (via the shared fakes in common/testing.go), so the create
+// path runs deterministically and hermetically. Individual tests override
+// h.lookupUser / h.lookupGroup to exercise the exists/conflict matrix.
+func newTestUserHandler(exec common.CommandExecutor, gs *MockGroupService) *UserHandler {
+	h := NewUserHandler(exec, gs, nil)
+	h.lookupUser = common.AbsentUserLookup
+	h.lookupGroup = common.AbsentGroupLookup
+	return h
 }
 
 func TestUserHandler_Execute(t *testing.T) {
@@ -145,7 +157,7 @@ func TestUserHandler_Execute(t *testing.T) {
 				tt.setupMock(mock)
 			}
 
-			handler := NewUserHandler(mock, tt.groupService, nil)
+			handler := newTestUserHandler(mock, tt.groupService)
 			ctx := context.Background()
 
 			exitCode, output, err := handler.Execute(ctx, tt.cmd, tt.args)
@@ -213,7 +225,7 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 			})
 
 			mock := common.NewMockCommandExecutor(t)
-			handler := NewUserHandler(mock, &MockGroupService{}, nil)
+			handler := newTestUserHandler(mock, &MockGroupService{})
 
 			exitCode, _, err := handler.Execute(context.Background(), "adduser", baseArgs)
 			if err != nil {
@@ -313,7 +325,7 @@ func TestUserHandler_AddUser_ServiceAccountWithExplicitUID(t *testing.T) {
 	})
 
 	mock := common.NewMockCommandExecutor(t)
-	handler := NewUserHandler(mock, &MockGroupService{}, nil)
+	handler := newTestUserHandler(mock, &MockGroupService{})
 
 	args := &common.CommandArgs{
 		Username:         "explicit-svc",
@@ -375,7 +387,7 @@ func TestUserHandler_AddUser_ServiceAccountGroupaddFails(t *testing.T) {
 	mock := common.NewMockCommandExecutor(t)
 	mock.SetResult("/usr/sbin/groupadd -f alpacon", 4, "groupadd: cannot lock /etc/group; try again later", errors.New("groupadd failed"))
 
-	handler := NewUserHandler(mock, &MockGroupService{}, nil)
+	handler := newTestUserHandler(mock, &MockGroupService{})
 
 	args := &common.CommandArgs{
 		Username:         "gitlab-runner",
@@ -408,7 +420,7 @@ func TestUserHandler_AddUser_RhelWithUID(t *testing.T) {
 	})
 
 	mock := common.NewMockCommandExecutor(t)
-	handler := NewUserHandler(mock, &MockGroupService{}, nil)
+	handler := newTestUserHandler(mock, &MockGroupService{})
 
 	args := &common.CommandArgs{
 		Username:      "john",
@@ -457,7 +469,7 @@ func TestUserHandler_AddUser_RhelWithUID(t *testing.T) {
 }
 
 func TestUserHandler_Validate(t *testing.T) {
-	handler := NewUserHandler(common.NewMockCommandExecutor(t), &MockGroupService{}, nil)
+	handler := newTestUserHandler(common.NewMockCommandExecutor(t), &MockGroupService{})
 
 	tests := []struct {
 		name    string
@@ -610,7 +622,7 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 				tt.setupMock(mock)
 			}
 
-			handler := NewUserHandler(mock, tt.groupService, nil)
+			handler := newTestUserHandler(mock, tt.groupService)
 			ctx := context.Background()
 
 			args := &common.CommandArgs{
@@ -640,4 +652,429 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestUserHandler_AddUser_Idempotent_ExistingUserSkipsCreate verifies that when
+// the user already exists with a matching (or omitted) uid, adduser/useradd is
+// NOT invoked, the command still succeeds, and the idempotent ensure step
+// (AddUserToGroups) still runs so groups converge (issue #344, M8).
+func TestUserHandler_AddUser_Idempotent_ExistingUserSkipsCreate(t *testing.T) {
+	tests := []struct {
+		name        string
+		platform    string
+		createCmd   string
+		groupExists bool // whether the RHEL primary group already exists
+	}{
+		{name: "debian existing user", platform: "debian", createCmd: "/usr/sbin/adduser"},
+		{name: "rhel existing user, group exists", platform: "rhel", createCmd: "/usr/sbin/useradd", groupExists: true},
+		{name: "rhel existing user, group absent still ensured", platform: "rhel", createCmd: "/usr/sbin/useradd", groupExists: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalPlatformLike := utils.PlatformLike
+			utils.SetPlatformLike(tt.platform)
+			t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+			mock := common.NewMockCommandExecutor(t)
+			gs := &MockGroupService{}
+			handler := newTestUserHandler(mock, gs)
+			handler.lookupUser = common.ExistingUserLookup("1001") // present, uid matches request
+			if tt.groupExists {
+				handler.lookupGroup = common.ExistingGroupLookup("1001")
+			} // else default AbsentGroupLookup
+
+			args := &common.CommandArgs{
+				Username:      "testuser",
+				UID:           1001,
+				GID:           1001,
+				Comment:       "Test User",
+				HomeDirectory: "/home/testuser",
+				Shell:         "/bin/bash",
+				Groupname:     "testgroup",
+				Groups:        []uint64{1002, 1003},
+			}
+
+			exitCode, output, err := handler.Execute(context.Background(), "adduser", args)
+			if err != nil {
+				t.Fatalf("Execute() unexpected error: %v", err)
+			}
+			if exitCode != 0 {
+				t.Fatalf("Execute() exitCode = %d, want 0 (output=%q)", exitCode, output)
+			}
+
+			if mock.Invoked(tt.createCmd) {
+				t.Errorf("%s must NOT be invoked when the user already exists; got %+v", tt.createCmd, mock.GetExecutedCommands())
+			}
+			// RHEL ensures the primary group; when it already exists, groupadd is skipped.
+			if tt.platform == "rhel" {
+				sawGroupadd := mock.Invoked("/usr/sbin/groupadd")
+				if tt.groupExists && sawGroupadd {
+					t.Errorf("groupadd must be skipped when the group already exists with matching gid; got %+v", mock.GetExecutedCommands())
+				}
+				if !tt.groupExists && !sawGroupadd {
+					t.Errorf("groupadd must run to ensure the primary group exists; got %+v", mock.GetExecutedCommands())
+				}
+			}
+			if !gs.AddUserToGroupsCalled {
+				t.Error("AddUserToGroups must still run for an existing user so groups converge")
+			}
+		})
+	}
+}
+
+// TestUserHandler_AddUser_Idempotent_UIDConflict verifies that a same-name
+// user with a DIFFERENT uid is surfaced as a failure (real drift), never
+// masked, and that no create command runs.
+func TestUserHandler_AddUser_Idempotent_UIDConflict(t *testing.T) {
+	for _, platform := range []string{"debian", "rhel"} {
+		t.Run(platform, func(t *testing.T) {
+			originalPlatformLike := utils.PlatformLike
+			utils.SetPlatformLike(platform)
+			t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+			mock := common.NewMockCommandExecutor(t)
+			handler := newTestUserHandler(mock, &MockGroupService{})
+			handler.lookupUser = common.ExistingUserLookup("9999") // present but uid != requested
+
+			args := &common.CommandArgs{
+				Username:      "testuser",
+				UID:           1001,
+				GID:           1001,
+				Comment:       "Test User",
+				HomeDirectory: "/home/testuser",
+				Shell:         "/bin/bash",
+				Groupname:     "testgroup",
+			}
+
+			exitCode, output, _ := handler.Execute(context.Background(), "adduser", args)
+			if exitCode == 0 {
+				t.Fatalf("expected non-zero exit for uid conflict, got 0 (output=%q)", output)
+			}
+			if !strings.Contains(output, "already exists with uid 9999") || !strings.Contains(output, "requested uid 1001") {
+				t.Errorf("conflict message must name both uids, got: %q", output)
+			}
+			if mock.Invoked("/usr/sbin/adduser") || mock.Invoked("/usr/sbin/useradd") {
+				t.Errorf("no create command may run on a uid conflict; got %+v", mock.GetExecutedCommands())
+			}
+		})
+	}
+}
+
+// TestUserHandler_AddUser_Idempotent_ServiceAccountNameExists verifies that a
+// service account (uid omitted, OS auto-assigns) treats name presence alone as
+// "already provisioned" — no uid comparison, no useradd, success — AND that the
+// load-bearing `groupadd -f` primary-group bootstrap STILL runs for the existing
+// account (design intent #3: needed for utils.Demote(ValidateGroup=true)).
+func TestUserHandler_AddUser_Idempotent_ServiceAccountNameExists(t *testing.T) {
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("rhel")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+	mock := common.NewMockCommandExecutor(t)
+	handler := newTestUserHandler(mock, &MockGroupService{})
+	handler.lookupUser = common.ExistingUserLookup("4321") // any uid; must not be compared
+
+	args := &common.CommandArgs{
+		Username:         "gitlab-runner",
+		Comment:          "GitLab Runner,,,,(alpacon-app)abc",
+		Shell:            "/usr/sbin/nologin",
+		Groupname:        "alpacon",
+		IsServiceAccount: true,
+	}
+
+	exitCode, output, err := handler.Execute(context.Background(), "adduser", args)
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("Execute() exitCode = %d, want 0 (output=%q)", exitCode, output)
+	}
+	if mock.Invoked("/usr/sbin/useradd") {
+		t.Error("useradd must not run when the service account already exists by name")
+	}
+	// Load-bearing invariant: the `groupadd -f <Groupname>` bootstrap must run
+	// even for an already-present service account, or the named primary group is
+	// not ensured and Demote(ValidateGroup=true) breaks at websh runtime.
+	sawGroupaddDashF := false
+	for _, c := range mock.GetExecutedCommands() {
+		if c.Name == "/usr/sbin/groupadd" && len(c.Args) >= 2 && c.Args[0] == "-f" && c.Args[1] == "alpacon" {
+			sawGroupaddDashF = true
+		}
+	}
+	if !sawGroupaddDashF {
+		t.Errorf("`groupadd -f alpacon` must still run for an existing service account; got %+v", mock.GetExecutedCommands())
+	}
+}
+
+// TestUserHandler_AddUser_Idempotent_LookupError verifies that a lookup error
+// other than "not found" fails loud instead of blind-creating over a possibly
+// shadowed entry.
+func TestUserHandler_AddUser_Idempotent_LookupError(t *testing.T) {
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("debian")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+	mock := common.NewMockCommandExecutor(t)
+	handler := newTestUserHandler(mock, &MockGroupService{})
+	handler.lookupUser = func(string) (*user.User, error) {
+		return nil, errors.New("getpwnam_r: connection refused")
+	}
+
+	args := &common.CommandArgs{
+		Username:      "testuser",
+		UID:           1001,
+		GID:           1001,
+		Comment:       "Test User",
+		HomeDirectory: "/home/testuser",
+		Shell:         "/bin/bash",
+		Groupname:     "testgroup",
+	}
+
+	exitCode, output, _ := handler.Execute(context.Background(), "adduser", args)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit when the lookup itself fails, got 0 (output=%q)", output)
+	}
+	if !strings.Contains(output, "unable to verify") {
+		t.Errorf("expected an 'unable to verify' message, got: %q", output)
+	}
+	if mock.Invoked("/usr/sbin/adduser") {
+		t.Error("adduser must not run when existence cannot be verified")
+	}
+}
+
+// TestUserHandler_AddUser_SecondaryNet verifies the create-time reconcile net on
+// the Debian adduser call site: when the up-front lookup reports absent but the
+// create fails, a re-verify (plus an "already exists" tertiary fallback for
+// NSS/LDAP names the pure-Go resolver cannot see) decides the outcome.
+func TestUserHandler_AddUser_SecondaryNet(t *testing.T) {
+	const adduserCmd = "/usr/sbin/adduser --home /home/testuser --shell /bin/bash --uid 1001 --gid 1001 --gecos Test User --disabled-password testuser"
+	args := &common.CommandArgs{
+		Username:      "testuser",
+		UID:           1001,
+		GID:           1001,
+		Comment:       "Test User",
+		HomeDirectory: "/home/testuser",
+		Shell:         "/bin/bash",
+		Groupname:     "testgroup",
+	}
+
+	tests := []struct {
+		name         string
+		createOutput string
+		reverifyUID  string // uid returned on the second (reconcile) lookup; "" with reverifyErr means still-absent
+		reverifyErr  error  // if set, reverify reports the user still not found
+		wantExitZero bool
+		wantMsgPart  string
+	}{
+		{name: "raced local create, matching uid -> idempotent success", createOutput: "adduser: user already exists", reverifyUID: "1001", wantExitZero: true},
+		{name: "raced local create, different uid -> conflict surfaced", createOutput: "adduser: user already exists", reverifyUID: "2002", wantExitZero: false, wantMsgPart: "already exists with uid 2002"},
+		{name: "NSS-backed, absent at reverify but create says already exists -> tolerated", createOutput: "adduser: user 'testuser' already exists", reverifyErr: user.UnknownUserError("absent"), wantExitZero: true},
+		{name: "genuine failure, absent and not already-exists -> surfaced", createOutput: "adduser: cannot create home directory", reverifyErr: user.UnknownUserError("absent"), wantExitZero: false, wantMsgPart: "cannot create home directory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalPlatformLike := utils.PlatformLike
+			utils.SetPlatformLike("debian")
+			t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+			mock := common.NewMockCommandExecutor(t)
+			mock.SetResult(adduserCmd, 1, tt.createOutput, errors.New("exit status 1"))
+			handler := newTestUserHandler(mock, &MockGroupService{})
+
+			calls := 0
+			handler.lookupUser = func(name string) (*user.User, error) {
+				calls++
+				if calls == 1 {
+					return nil, user.UnknownUserError("absent") // gate: absent -> create attempted
+				}
+				if tt.reverifyErr != nil {
+					return nil, tt.reverifyErr
+				}
+				return &user.User{Username: name, Uid: tt.reverifyUID}, nil
+			}
+
+			exitCode, output, _ := handler.Execute(context.Background(), "adduser", args)
+			if !mock.Invoked("/usr/sbin/adduser") {
+				t.Fatal("adduser should have been attempted after an absent gate lookup")
+			}
+			if tt.wantExitZero && exitCode != 0 {
+				t.Fatalf("expected idempotent success (exit 0), got %d (output=%q)", exitCode, output)
+			}
+			if !tt.wantExitZero && exitCode == 0 {
+				t.Fatalf("expected non-zero exit, got 0 (output=%q)", output)
+			}
+			if tt.wantMsgPart != "" && !strings.Contains(output, tt.wantMsgPart) {
+				t.Errorf("expected output to contain %q, got: %q", tt.wantMsgPart, output)
+			}
+		})
+	}
+}
+
+// TestUserHandler_AddUser_Rhel_SecondaryNet exercises the reconcile net at the
+// RHEL call sites (user.go useradd and primary-group groupadd), which the Debian
+// test above does not reach. These sites have distinct argument wiring, so a
+// copy-paste defect there would otherwise be uncaught (masking drift on RHEL).
+func TestUserHandler_AddUser_Rhel_SecondaryNet(t *testing.T) {
+	// A simple comment keeps the useradd command key predictable.
+	baseArgs := func() *common.CommandArgs {
+		return &common.CommandArgs{
+			Username:      "john",
+			UID:           5001,
+			GID:           5001,
+			Comment:       "John",
+			HomeDirectory: "/home/john",
+			Shell:         "/bin/bash",
+			Groupname:     "alpacon",
+		}
+	}
+	const useraddCmd = "/usr/sbin/useradd --home-dir /home/john --shell /bin/bash --uid 5001 --gid 5001 --comment John --create-home john"
+	const groupaddCmd = "/usr/sbin/groupadd --gid 5001 alpacon"
+
+	t.Run("useradd reconcile: raced matching uid -> idempotent success", func(t *testing.T) {
+		originalPlatformLike := utils.PlatformLike
+		utils.SetPlatformLike("rhel")
+		t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+		mock := common.NewMockCommandExecutor(t)
+		mock.SetResult(useraddCmd, 1, "useradd: user 'john' already exists", errors.New("exit status 9"))
+		handler := newTestUserHandler(mock, &MockGroupService{})
+		handler.lookupGroup = common.ExistingGroupLookup("5001") // group present -> groupadd skipped
+
+		calls := 0
+		handler.lookupUser = func(name string) (*user.User, error) {
+			calls++
+			if calls == 1 {
+				return nil, user.UnknownUserError("absent") // gate
+			}
+			return &user.User{Username: name, Uid: "5001"}, nil // reverify: matches
+		}
+
+		exitCode, output, _ := handler.Execute(context.Background(), "adduser", baseArgs())
+		if !mock.Invoked("/usr/sbin/useradd") {
+			t.Fatal("useradd should have been attempted")
+		}
+		if exitCode != 0 {
+			t.Fatalf("expected idempotent success, got %d (output=%q)", exitCode, output)
+		}
+	})
+
+	t.Run("useradd reconcile: raced different uid -> conflict surfaced", func(t *testing.T) {
+		originalPlatformLike := utils.PlatformLike
+		utils.SetPlatformLike("rhel")
+		t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+		mock := common.NewMockCommandExecutor(t)
+		mock.SetResult(useraddCmd, 1, "useradd: user 'john' already exists", errors.New("exit status 9"))
+		handler := newTestUserHandler(mock, &MockGroupService{})
+		handler.lookupGroup = common.ExistingGroupLookup("5001")
+
+		calls := 0
+		handler.lookupUser = func(name string) (*user.User, error) {
+			calls++
+			if calls == 1 {
+				return nil, user.UnknownUserError("absent")
+			}
+			return &user.User{Username: name, Uid: "6006"}, nil // reverify: uid mismatch
+		}
+
+		exitCode, output, _ := handler.Execute(context.Background(), "adduser", baseArgs())
+		if exitCode == 0 {
+			t.Fatalf("expected conflict (non-zero), got 0 (output=%q)", output)
+		}
+		if !strings.Contains(output, "already exists with uid 6006") {
+			t.Errorf("expected uid conflict message, got: %q", output)
+		}
+	})
+
+	t.Run("primary-group groupadd reconcile: raced NSS group -> tolerated, useradd proceeds", func(t *testing.T) {
+		originalPlatformLike := utils.PlatformLike
+		utils.SetPlatformLike("rhel")
+		t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+		mock := common.NewMockCommandExecutor(t)
+		mock.SetResult(groupaddCmd, 1, "groupadd: group 'alpacon' already exists", errors.New("exit status 9"))
+		handler := newTestUserHandler(mock, &MockGroupService{}) // absentUser -> useradd runs
+
+		gcalls := 0
+		handler.lookupGroup = func(name string) (*user.Group, error) {
+			gcalls++
+			if gcalls == 1 {
+				return nil, user.UnknownGroupError("absent") // gate: absent -> groupadd attempted
+			}
+			return &user.Group{Name: name, Gid: "5001"}, nil // reverify: present, gid matches
+		}
+
+		exitCode, output, err := handler.Execute(context.Background(), "adduser", baseArgs())
+		if err != nil || exitCode != 0 {
+			t.Fatalf("expected groupadd reconcile to tolerate; got exitCode=%d err=%v output=%q", exitCode, err, output)
+		}
+		if !mock.Invoked("/usr/sbin/groupadd") {
+			t.Fatal("groupadd should have been attempted after an absent gate lookup")
+		}
+		if !mock.Invoked("/usr/sbin/useradd") {
+			t.Error("useradd must still run after the primary group is reconciled")
+		}
+	})
+}
+
+// TestUserHandler_AddUser_Rhel_PrimaryGroupGate verifies the RHEL primary-group
+// groupadd is gated by the same lookup rule as standalone addgroup (A-3
+// consistency): existing+match skips groupadd, existing+mismatch surfaces a
+// conflict before useradd runs.
+func TestUserHandler_AddUser_Rhel_PrimaryGroupGate(t *testing.T) {
+	baseArgs := func() *common.CommandArgs {
+		return &common.CommandArgs{
+			Username:      "john",
+			UID:           5001,
+			GID:           5001,
+			Comment:       "John,,,,(alpacon)uuid",
+			HomeDirectory: "/home/john",
+			Shell:         "/bin/bash",
+			Groupname:     "alpacon",
+		}
+	}
+
+	t.Run("group exists with matching gid -> groupadd skipped, useradd runs", func(t *testing.T) {
+		originalPlatformLike := utils.PlatformLike
+		utils.SetPlatformLike("rhel")
+		t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+		mock := common.NewMockCommandExecutor(t)
+		handler := newTestUserHandler(mock, &MockGroupService{}) // absentUser -> useradd runs
+		handler.lookupGroup = common.ExistingGroupLookup("5001")
+
+		exitCode, output, err := handler.Execute(context.Background(), "adduser", baseArgs())
+		if err != nil || exitCode != 0 {
+			t.Fatalf("Execute() exitCode=%d err=%v output=%q", exitCode, err, output)
+		}
+		if mock.Invoked("/usr/sbin/groupadd") {
+			t.Errorf("groupadd must be skipped when the group already exists with matching gid; got %+v", mock.GetExecutedCommands())
+		}
+		if !mock.Invoked("/usr/sbin/useradd") {
+			t.Error("useradd must still run to create the absent user")
+		}
+	})
+
+	t.Run("group exists with different gid -> conflict before useradd", func(t *testing.T) {
+		originalPlatformLike := utils.PlatformLike
+		utils.SetPlatformLike("rhel")
+		t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+		mock := common.NewMockCommandExecutor(t)
+		handler := newTestUserHandler(mock, &MockGroupService{})
+		handler.lookupGroup = common.ExistingGroupLookup("7777")
+
+		exitCode, output, _ := handler.Execute(context.Background(), "adduser", baseArgs())
+		if exitCode == 0 {
+			t.Fatalf("expected non-zero exit for group gid conflict, got 0 (output=%q)", output)
+		}
+		if !strings.Contains(output, "already exists with gid 7777") {
+			t.Errorf("expected group conflict message, got: %q", output)
+		}
+		if mock.Invoked("/usr/sbin/useradd") {
+			t.Error("useradd must not run when the primary group gid conflicts")
+		}
+	})
 }

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -1082,3 +1082,45 @@ func TestUserHandler_AddUser_Rhel_PrimaryGroupGate(t *testing.T) {
 		}
 	})
 }
+
+// TestUserHandler_AddUser_ExistingUser_GroupAddSoftFailMessage verifies the
+// AddUserToGroups soft-failure message reflects that the user already existed
+// (not "created") on the re-provision path.
+func TestUserHandler_AddUser_ExistingUser_GroupAddSoftFailMessage(t *testing.T) {
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("debian")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+	mock := common.NewMockCommandExecutor(t)
+	gs := &MockGroupService{AddUserToGroupsError: errors.New("usermod failed")}
+	handler := newTestUserHandler(mock, gs)
+	handler.lookupUser = common.ExistingUserLookup("1001") // user already exists
+
+	args := &common.CommandArgs{
+		Username:      "testuser",
+		UID:           1001,
+		GID:           1001,
+		Comment:       "Test User",
+		HomeDirectory: "/home/testuser",
+		Shell:         "/bin/bash",
+		Groupname:     "testgroup",
+		Groups:        []uint64{1002},
+	}
+
+	exitCode, output, err := handler.Execute(context.Background(), "adduser", args)
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("group-add soft failure must keep exit 0, got %d (output=%q)", exitCode, output)
+	}
+	if !gs.AddUserToGroupsCalled {
+		t.Error("AddUserToGroups should have been called for an existing user")
+	}
+	if strings.Contains(output, "created") || !strings.Contains(output, "already exists but failed to add to groups") {
+		t.Errorf("soft-failure message should say the user already exists, not 'created'; got: %q", output)
+	}
+	if mock.Invoked("/usr/sbin/adduser") {
+		t.Error("adduser must not run for an existing user")
+	}
+}

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -702,6 +702,11 @@ func TestUserHandler_AddUser_Idempotent_ExistingUserSkipsCreate(t *testing.T) {
 			if exitCode != 0 {
 				t.Fatalf("Execute() exitCode = %d, want 0 (output=%q)", exitCode, output)
 			}
+			// The gate-detected idempotent path must report "already exists",
+			// not the misleading "added successfully" (this is the crux #344 path).
+			if !strings.Contains(output, "already exists") || strings.Contains(output, "added successfully") {
+				t.Errorf("existing-user path should report 'already exists', got: %q", output)
+			}
 
 			if mock.Invoked(tt.createCmd) {
 				t.Errorf("%s must NOT be invoked when the user already exists; got %+v", tt.createCmd, mock.GetExecutedCommands())

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -867,9 +867,9 @@ func TestUserHandler_AddUser_SecondaryNet(t *testing.T) {
 		wantExitZero bool
 		wantMsgPart  string
 	}{
-		{name: "raced local create, matching uid -> idempotent success", createOutput: "adduser: user already exists", reverifyUID: "1001", wantExitZero: true},
+		{name: "raced local create, matching uid -> idempotent success", createOutput: "adduser: user already exists", reverifyUID: "1001", wantExitZero: true, wantMsgPart: "already exists"},
 		{name: "raced local create, different uid -> conflict surfaced", createOutput: "adduser: user already exists", reverifyUID: "2002", wantExitZero: false, wantMsgPart: "already exists with uid 2002"},
-		{name: "NSS-backed same name, absent at reverify but create names this user -> tolerated", createOutput: "adduser: user 'testuser' already exists", reverifyErr: user.UnknownUserError("absent"), wantExitZero: true},
+		{name: "NSS-backed same name, absent at reverify but create names this user -> tolerated", createOutput: "adduser: user 'testuser' already exists", reverifyErr: user.UnknownUserError("absent"), wantExitZero: true, wantMsgPart: "already exists"},
 		{name: "uid-in-use by a different name, absent at reverify -> surfaced (not masked)", createOutput: "adduser: UID '1001' already exists", reverifyErr: user.UnknownUserError("absent"), wantExitZero: false, wantMsgPart: "UID '1001'"},
 		{name: "genuine failure, absent and not already-exists -> surfaced", createOutput: "adduser: cannot create home directory", reverifyErr: user.UnknownUserError("absent"), wantExitZero: false, wantMsgPart: "cannot create home directory"},
 	}
@@ -958,6 +958,9 @@ func TestUserHandler_AddUser_Rhel_SecondaryNet(t *testing.T) {
 		}
 		if exitCode != 0 {
 			t.Fatalf("expected idempotent success, got %d (output=%q)", exitCode, output)
+		}
+		if !strings.Contains(output, "already exists") {
+			t.Errorf("reconciled-success path should report 'already exists', got: %q", output)
 		}
 	})
 

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -869,7 +869,8 @@ func TestUserHandler_AddUser_SecondaryNet(t *testing.T) {
 	}{
 		{name: "raced local create, matching uid -> idempotent success", createOutput: "adduser: user already exists", reverifyUID: "1001", wantExitZero: true},
 		{name: "raced local create, different uid -> conflict surfaced", createOutput: "adduser: user already exists", reverifyUID: "2002", wantExitZero: false, wantMsgPart: "already exists with uid 2002"},
-		{name: "NSS-backed, absent at reverify but create says already exists -> tolerated", createOutput: "adduser: user 'testuser' already exists", reverifyErr: user.UnknownUserError("absent"), wantExitZero: true},
+		{name: "NSS-backed same name, absent at reverify but create names this user -> tolerated", createOutput: "adduser: user 'testuser' already exists", reverifyErr: user.UnknownUserError("absent"), wantExitZero: true},
+		{name: "uid-in-use by a different name, absent at reverify -> surfaced (not masked)", createOutput: "adduser: UID '1001' already exists", reverifyErr: user.UnknownUserError("absent"), wantExitZero: false, wantMsgPart: "UID '1001'"},
 		{name: "genuine failure, absent and not already-exists -> surfaced", createOutput: "adduser: cannot create home directory", reverifyErr: user.UnknownUserError("absent"), wantExitZero: false, wantMsgPart: "cannot create home directory"},
 	}
 


### PR DESCRIPTION
## Summary

Makes OS user/group provisioning **idempotent** so re-provisioning an already-present user/group is a no-op success instead of a hard failure. This closes the most common cause of failed Websh opens (#344): re-provisioning made `adduser`/`useradd`/`addgroup`/`groupadd` exit non-zero ("already exists"), the handler returned failure, the console cancelled `openpty`, and the session timed out.

This covers the **IAM-user path and standalone `addgroup`**. The service-account half was already handled in #283.

## Root cause

- `handleAddUser` returned failure on any non-zero `adduser`/`useradd` exit (non-idempotent).
- `handleAddGroup` did the same for `addgroup`/`groupadd`, and was inconsistent with the user handler.
- The only existing tolerance (RHEL primary-group `groupadd`) matched `"already exists"` in output — locale-fragile and blind to real GID drift.

Triggers in the wild: manual `useradd` history, a prior crash mid-provision, DB↔reality drift, or the alpacon-server `prepare_user` race (B-6).

## Approach — lookup verification, not string matching

Verify existence with `os/user` **before** creating, and distinguish two cases that must never be conflated:

- **Same name, same identity** (or a uid-omitted service account) → already provisioned → skip creation, still run the ensure steps (home permissions, supplementary groups). Idempotent success.
- **Same name, different uid/gid** → real drift → surface a clear conflict, **never masked**.

### Layered decision (identity-verifiable first)

1. **Gate (primary):** `os/user` lookup before create — matching identity skips, conflicting identity fails, a non-"not-found" lookup error fails loud (no blind-create over a possibly shadowed entry).
2. **Reconcile re-lookup (secondary):** on a non-zero create, re-lookup to absorb a TOCTOU race that landed a local entry between the gate and the create, and to verify identity.
3. **`"already exists"` fallback (tertiary):** best-effort tolerance for NSS/LDAP/SSSD-backed names, used only as a last resort where identity cannot be verified.

> **Why the tertiary net exists:** the release binary is `CGO_ENABLED=0`, so `os/user` uses the pure-Go resolver that reads `/etc/passwd`/`/etc/group` only and never consults NSS. Local entries (the common #344 case) are fully covered by the gate; directory-backed names are invisible to the resolver, so the NSS-aware create tool's "already exists" is the only signal available. This restores the pre-existing tolerance the RHEL path used to have, without letting it mask verifiable local conflicts.

## What changed

- **`common/lookup.go` (new):** injectable `UserLookupFunc`/`GroupLookupFunc` (defaulted to `os/user`, overridable in tests), `UserExists`/`GroupExists` classifiers, a shared `ClassifyGroupForCreate` gate used by both handlers (A-3 consistency), `ReconcileUserCreate`/`ReconcileGroupCreate`, and centralized conflict messages.
- **`user.go`:** `handleAddUser` gate + create reconcile; the RHEL primary-group `groupadd` now uses the same lookup gate (replacing the string suppression); the service-account `groupadd -f` bootstrap still runs for existing accounts so the named primary group stays ensured.
- **`group.go`:** `handleAddGroup` gate + reconcile, sharing `ClassifyGroupForCreate`.
- **`common/testing.go`:** shared lookup fakes + `MockCommandExecutor.Invoked` helper.
- The injection seam is unexported function fields defaulted in the constructors — **constructor signatures are unchanged**.

## Testing

Full matrix for both handlers across Debian and RHEL (`go test ./pkg/executor/handlers/... -p 1`, all pass):

- existing user/group with matching id → skip create, success, ensure steps still run;
- existing with different uid/gid → conflict surfaced, no create command;
- service account exists → skip, and `groupadd -f` still runs (load-bearing invariant locked);
- lookup error → fail loud, no create;
- secondary/tertiary nets: raced local (match → success / mismatch → conflict), NSS-backed ("already exists" → tolerated), genuine failure (surfaced) — covering the Debian `adduser` and the RHEL `useradd` and primary-group `groupadd` call sites.

```
gofmt -l                                  → clean
go vet ./...                              → clean
go build ./cmd/alpamon                    → OK
CGO_ENABLED=0 GOOS=linux go build ./...   → OK (release parity)
go test ./pkg/executor/handlers/... -p 1  → all pass
```

## Deployment note

Unlike alpacon-server changes, this requires an **agent release** (alpamon version tag) rolled out to servers before it takes effect. In the meantime, server-side B-6 mitigation reduces duplicate emissions.

Closes #344
