### PR TITLE
fix(collector): correct realtime metric query window unit

### DIFF
--- a/pkg/collector/check/realtime/disk/io/io_send.go
+++ b/pkg/collector/check/realtime/disk/io/io_send.go
@@ -62,7 +62,7 @@ func (c *SendCheck) getDiskIO(ctx context.Context) ([]base.DiskIOQuerySet, error
 	client := c.GetClient()
 	interval := c.GetInterval()
 	now := time.Now()
-	from := now.Add(-1 * interval * time.Second)
+	from := now.Add(-interval)
 
 	var querySet []base.DiskIOQuerySet
 	err := client.DiskIO.Query().

--- a/pkg/collector/check/realtime/disk/io/io_send.go
+++ b/pkg/collector/check/realtime/disk/io/io_send.go
@@ -74,9 +74,6 @@ func (c *SendCheck) getDiskIO(ctx context.Context) ([]base.DiskIOQuerySet, error
 			ent.As(ent.Mean(diskio.FieldReadBps), "avg_read_bps"),
 			ent.As(ent.Mean(diskio.FieldWriteBps), "avg_write_bps"),
 		).Scan(ctx, &querySet)
-	if err != nil {
-		return querySet, err
-	}
 
-	return querySet, nil
+	return querySet, err
 }

--- a/pkg/collector/check/realtime/disk/io/io_test.go
+++ b/pkg/collector/check/realtime/disk/io/io_test.go
@@ -89,9 +89,21 @@ func (suite *DiskIOCheckSuite) TestGetDiskIO() {
 		SetWriteBps(rand.Float64()).Exec(suite.ctx)
 	assert.NoError(suite.T(), err, "Failed to create disk io.")
 
+	staleDevice := "stale-" + uuid.NewString()
+	err = suite.collectCheck.GetClient().DiskIO.Create().
+		SetTimestamp(time.Now().Add(-2 * time.Second)).
+		SetDevice(staleDevice).
+		SetReadBps(rand.Float64()).
+		SetWriteBps(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create stale disk io.")
+
 	querySet, err := suite.sendCheck.getDiskIO(suite.ctx)
 	assert.NoError(suite.T(), err, "Failed to get disk io queryset.")
 	assert.NotEmpty(suite.T(), querySet, "Disk IO queryset should not be empty")
+
+	for _, row := range querySet {
+		assert.NotEqual(suite.T(), staleDevice, row.Device, "Disk IO queryset should exclude rows outside the interval window")
+	}
 }
 
 func TestDiskIOCheckSuite(t *testing.T) {

--- a/pkg/collector/check/realtime/net/net_send.go
+++ b/pkg/collector/check/realtime/net/net_send.go
@@ -82,9 +82,6 @@ func (c *SendCheck) getTraffic(ctx context.Context) ([]base.TrafficQuerySet, err
 			ent.As(ent.Mean(traffic.FieldOutputPps), "avg_output_pps"),
 			ent.As(ent.Mean(traffic.FieldOutputBps), "avg_output_bps"),
 		).Scan(ctx, &querySet)
-	if err != nil {
-		return querySet, err
-	}
 
-	return querySet, nil
+	return querySet, err
 }

--- a/pkg/collector/check/realtime/net/net_send.go
+++ b/pkg/collector/check/realtime/net/net_send.go
@@ -66,7 +66,7 @@ func (c *SendCheck) getTraffic(ctx context.Context) ([]base.TrafficQuerySet, err
 	client := c.GetClient()
 	interval := c.GetInterval()
 	now := time.Now()
-	from := now.Add(-1 * interval * time.Second)
+	from := now.Add(-interval)
 
 	var querySet []base.TrafficQuerySet
 	err := client.Traffic.Query().

--- a/pkg/collector/check/realtime/net/net_test.go
+++ b/pkg/collector/check/realtime/net/net_test.go
@@ -93,9 +93,23 @@ func (suite *NetCheckSuite) TestGetTraffic() {
 		SetOutputBps(rand.Float64()).Exec(suite.ctx)
 	assert.NoError(suite.T(), err, "Failed to create traffic.")
 
+	staleName := "stale-" + uuid.NewString()
+	err = suite.sendCheck.GetClient().Traffic.Create().
+		SetTimestamp(time.Now().Add(-2 * time.Second)).
+		SetName(staleName).
+		SetInputPps(rand.Float64()).
+		SetInputBps(rand.Float64()).
+		SetOutputPps(rand.Float64()).
+		SetOutputBps(rand.Float64()).Exec(suite.ctx)
+	assert.NoError(suite.T(), err, "Failed to create stale traffic.")
+
 	querySet, err := suite.sendCheck.getTraffic(suite.ctx)
 	assert.NoError(suite.T(), err, "Failed to get traffic queryset.")
 	assert.NotEmpty(suite.T(), querySet, "Traffic queryset should not be empty")
+
+	for _, row := range querySet {
+		assert.NotEqual(suite.T(), staleName, row.Name, "Traffic queryset should exclude rows outside the interval window")
+	}
 }
 
 func TestNetCheckSuite(t *testing.T) {


### PR DESCRIPTION
## Background

The realtime `net` and `disk_io` send checks computed their query window as `now.Add(-1 * interval * time.Second)`. But `interval` is already a `time.Duration`, built in `collector.go` as `time.Duration(entry.Interval) * time.Second`. The extra `* time.Second` applied the unit a second time.

This line has existed since the realtime NET/DISK_IO refactor (788e527, 2025-01-07) and contradicts how `scheduler.go` uses the same value directly via `now.Add(interval)` — which is the correct pattern. It is a unit-confusion bug, not intended behavior.

## Changes

Removed the redundant `* time.Second` in `net_send.go` and `io_send.go` and subtract the interval directly:

```go
from := now.Add(-interval)
```

The window now covers exactly the previous scheduler cycle.

## Impact

`interval * time.Second` is a `time.Duration` (int64 nanoseconds) multiplication, so for interval values of 10s or more it overflows int64 and wraps via two's-complement, landing on either side of "now" depending on the exact value — not simply "future for 10s+, past otherwise" as originally described here. Verified by execution:

| Configured interval | Resulting `from` (before fix) | Effect |
| --- | --- | --- |
| 1s – 9s | ~1741 – 1994 (past) | Whole-table aggregation every tick |
| 10s, 30s | ~2244 – 2294 (future) | `from > now`, nothing sent |
| 20s, 60s, 300s | ~1872 – 1977 (past) | Whole-table aggregation (stale/incorrect values still sent) |

In every case the query window was wrong; whether it silently sent incorrect aggregates or silently sent nothing depended on the specific interval's overflow arithmetic. After the fix, `from` is always `now - interval`, so only the previous cycle is aggregated regardless of the configured interval.

## Tests

`go test ./pkg/collector/check/realtime/disk/io/... ./pkg/collector/check/realtime/net/...` passes for both changed packages. The `pkg/db/ent/migrate` Atlas-dialect go.sum error surfaced by the local hooks is a pre-existing issue unrelated to this change.

Added regression tests (`TestGetTraffic`, `TestGetDiskIO`) that seed a row at `now - 2s` and assert it's excluded from the queryset — the previous tests only inserted a row at `now`, so they passed against both the buggy and the fixed window and couldn't catch a reintroduction of the bug.
