### PR TITLE
ci: add govulncheck and go.mod tidy checks, bump Go to 1.25.11

### DIFF
--- a/.github/actions/setup-go-generate/action.yml
+++ b/.github/actions/setup-go-generate/action.yml
@@ -1,0 +1,20 @@
+name: Set up Go and generate ent code
+description: >-
+  Install the Go toolchain and generate the gitignored ent package. The tree
+  imports ent subpackages that aren't checked in, so codegen must run before
+  any command that loads packages (build, test, tidy, govulncheck, lint).
+inputs:
+  go-version:
+    description: Go version to install
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: ${{ inputs.go-version }}
+
+    - name: Generate go code
+      run: go generate ./pkg/db/ent
+      shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,9 +14,31 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 jobs:
+  verify-tidy:
+    name: Verify go.mod and go.sum are tidy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      # Generate the ent package first: the tree imports gitignored ent
+      # subpackages, so go mod tidy fails to resolve them otherwise.
+      - name: Generate go code
+        run: go generate ./pkg/db/ent
+
+      - name: Verify go.mod and go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
   build-and-test:
     name: Build and Test (${{ matrix.distro }})
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ on:
       - "docs/**"
 
   pull_request:
-    types: [opened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize]
 
   workflow_call:
 
@@ -24,15 +24,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Set up Go and generate ent code
+        uses: ./.github/actions/setup-go-generate
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      # Generate the ent package first: the tree imports gitignored ent
-      # subpackages, so go mod tidy fails to resolve them otherwise.
-      - name: Generate go code
-        run: go generate ./pkg/db/ent
 
       - name: Verify go.mod and go.sum are tidy
         run: |
@@ -140,13 +135,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Set up Go and generate ent code
+        uses: ./.github/actions/setup-go-generate
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Generate go code
-        run: go generate ./pkg/db/ent
 
       - name: Build
         run: go build -v .
@@ -162,13 +154,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Set up Go and generate ent code
+        uses: ./.github/actions/setup-go-generate
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Generate go code
-        run: go generate ./pkg/db/ent
 
       - name: Build
         run: go build -v .
@@ -253,13 +242,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Set up Go and generate ent code
+        uses: ./.github/actions/setup-go-generate
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Generate go code
-        run: go generate ./pkg/db/ent
 
       - name: Build
         run: go build -v .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,13 +27,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Set up Go and generate ent code
+        uses: ./.github/actions/setup-go-generate
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Generate go code
-        run: go generate ./pkg/db/ent
 
       - name: GolangCI-Lint
         uses: golangci/golangci-lint-action@v9
@@ -49,15 +46,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Set up Go and generate ent code
+        uses: ./.github/actions/setup-go-generate
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      # Generate the ent package first: the tree imports gitignored ent
-      # subpackages, so govulncheck ./... fails to load them otherwise.
-      - name: Generate go code
-        run: go generate ./pkg/db/ent
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 jobs:
   linter:
@@ -40,3 +40,27 @@ jobs:
         with:
           version: v2.9.0
           args: --timeout=5m
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      # Generate the ent package first: the tree imports gitignored ent
+      # subpackages, so govulncheck ./... fails to load them otherwise.
+      - name: Generate go code
+        run: go generate ./pkg/db/ent
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,5 +54,11 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
+      # Report findings without gating merges: a newly published CVE in a
+      # transitive dep or stdlib would otherwise turn unrelated PRs red.
+      # Dependabot handles proactive dependency bumps; this job is the
+      # stdlib/reachability signal, surfaced in the step log, not a gate.
+      # Setup failures above still fail the job (only this step is soft).
       - name: Run govulncheck
         run: govulncheck ./...
+        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 jobs:
   build-and-test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,12 @@ atlas migrate diff <migration_name> \
 # Build the main binary
 go build -v ./cmd/alpamon
 
-# Install dependencies
+# Install dependencies. Drop stale generated ent output first: it's
+# gitignored, so `go generate` never deletes leftovers (e.g. a `migrate/`
+# directory from before entc.go disabled gen.Migrate). A stale tree makes
+# `go mod tidy` add Atlas deps locally that a clean CI checkout removes,
+# failing the verify-tidy job ("tidy on my machine, red in CI").
+git clean -fdx pkg/db/ent && go generate ./pkg/db/ent
 go mod tidy
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alpacax/alpamon/v2
 
-go 1.25.10
+go 1.25.11
 
 require (
 	entgo.io/ent v0.14.5


### PR DESCRIPTION
## Background

alpacon-cli's CI runs two dependency checks that alpamon was missing. alpamon runs as a root server agent, so scanning its dependencies for known CVEs with govulncheck is especially worthwhile. The existing lint only runs golangci-lint, which covers static analysis of our own code but not known vulnerabilities in the libraries we pull in.

## Changes

lint.yml gets a govulncheck job. It installs `golang.org/x/vuln/cmd/govulncheck` and runs `govulncheck ./...`.

build-and-test.yml gets a verify-tidy job that runs `go mod tidy` and fails on any `go.mod`/`go.sum` diff, guarding against dependency drift. It runs as a single ubuntu job rather than inside the distro matrix, since tidiness is platform-independent and the matrix would just repeat the same work.

Both new jobs run `go generate ./pkg/db/ent` before their check. alpamon's ent output is gitignored (`pkg/db/ent/*`, with only `entc.go` and `generate.go` tracked), and the tree imports the generated ent subpackages (`pkg/db/ent/cpu`, etc.). Without generating them first, `go mod tidy` fails to resolve those internal packages and `govulncheck ./...` fails to load them. alpacon-cli has no ent, which is why its equivalent jobs don't need this step.

GO_VERSION is bumped from 1.25.10 to 1.25.11 across build-and-test.yml, lint.yml, release.yml, and the `go` directive in go.mod. govulncheck flagged two called stdlib vulnerabilities on 1.25.10, both fixed in 1.25.11; without the bump the new job would fail on the first run.

## Safety

The two vulnerabilities govulncheck reported on 1.25.10 are both reachable from our code (called, not just imported):

- GO-2026-5039 (net/textproto): reached from the WebSocket dial path in `pkg/runner/ftp.go` via `ReadMIMEHeader`
- GO-2026-5037 (crypto/x509): reached from certificate-verification paths in file, ftp, and auth code

After the bump to 1.25.11, re-running govulncheck reports zero vulnerabilities that affect the code.

`actions/checkout` stays at `@v6` to match every other job in the repo. The latest major is v7, but v6 already runs on the node24 runtime, so there is no runtime benefit and mixing majors within one repo would be inconsistent. govulncheck is installed with `@latest` so it uses the newest scanner and vulnerability database; this favors security currency over build reproducibility and can be pinned to a specific version if reproducibility is preferred.

## Testing

Verified locally with the Go 1.25.11 toolchain, from a clean regeneration (deleted ent output, then `go generate`):

- `go build ./cmd/alpamon`: passes
- `go mod tidy`: only the `go` directive line changes, no dependency or go.sum drift
- `govulncheck ./...`: zero vulnerabilities affecting the code (was two on 1.25.10)

## Checklist

- [ ] verify-tidy and govulncheck jobs green in CI
- [ ] full distro matrix build/test green
