### PR TITLE
feat(pty): accept optional shell parameter in openpty command

### DIFF
--- a/pkg/executor/handlers/terminal/terminal.go
+++ b/pkg/executor/handlers/terminal/terminal.go
@@ -115,6 +115,7 @@ func (h *TerminalHandler) handleOpenPTY(args *common.CommandArgs) (int, string, 
 		Username:      args.Username,
 		Groupname:     args.Groupname,
 		HomeDirectory: args.HomeDirectory,
+		Shell:         args.Shell,
 		Rows:          uint16(args.Rows),
 		Cols:          uint16(args.Cols),
 	}
@@ -124,6 +125,7 @@ func (h *TerminalHandler) handleOpenPTY(args *common.CommandArgs) (int, string, 
 		Str("username", data.Username).
 		Uint16("rows", data.Rows).
 		Uint16("cols", data.Cols).
+		Str("shell", data.Shell).
 		Msg("Opening PTY terminal")
 
 	ptyClient := runner.NewPtyClient(data, h.apiSession, h.manager)

--- a/pkg/runner/commit_darwin.go
+++ b/pkg/runner/commit_darwin.go
@@ -1,8 +1,6 @@
 package runner
 
 import (
-	"bufio"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -11,32 +9,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// loadValidShells reads /etc/shells on macOS (which exists and follows the same format as Linux).
+// loadValidShells returns the host's valid login shells from /etc/shells,
+// falling back to the common macOS defaults when the file is unavailable.
 func loadValidShells() []string {
-	const shellsFilePath = "/etc/shells"
-	var shells []string
-
-	file, err := os.Open(shellsFilePath)
-	if err != nil {
-		log.Debug().Err(err).Msg("Failed to open /etc/shells, using defaults")
+	shells := utils.LoadValidShells()
+	if len(shells) == 0 {
 		return []string{"/bin/bash", "/bin/zsh", "/bin/sh"}
 	}
-	defer func() { _ = file.Close() }()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		shells = append(shells, line)
-	}
-
-	if err := scanner.Err(); err != nil {
-		log.Debug().Err(err).Msg("Error reading /etc/shells")
-		return []string{"/bin/bash", "/bin/zsh", "/bin/sh"}
-	}
-
 	return shells
 }
 

--- a/pkg/runner/commit_darwin.go
+++ b/pkg/runner/commit_darwin.go
@@ -10,7 +10,7 @@ import (
 )
 
 // loadValidShells returns the host's valid login shells from /etc/shells,
-// falling back to the common macOS defaults when the file is unavailable.
+// falling back to the common macOS defaults when the list is empty or unavailable.
 func loadValidShells() []string {
 	shells := utils.LoadValidShells()
 	if len(shells) == 0 {

--- a/pkg/runner/commit_linux.go
+++ b/pkg/runner/commit_linux.go
@@ -6,42 +6,19 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"github.com/rs/zerolog/log"
 )
 
 const (
 	passwdFilePath = "/etc/passwd"
 	groupFilePath  = "/etc/group"
-	shellsFilePath = "/etc/shells"
 	shadowFilePath = "/etc/shadow"
 )
 
-// loadValidShells reads /etc/shells and returns the list of valid login shells
+// loadValidShells returns the host's valid login shells from /etc/shells.
 func loadValidShells() []string {
-	var shells []string
-
-	file, err := os.Open(shellsFilePath)
-	if err != nil {
-		log.Debug().Err(err).Msg("Failed to open /etc/shells, skipping shell validation")
-		return nil
-	}
-	defer func() { _ = file.Close() }()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		shells = append(shells, line)
-	}
-
-	if err := scanner.Err(); err != nil {
-		log.Debug().Err(err).Msg("Error reading /etc/shells")
-		return nil
-	}
-
-	return shells
+	return utils.LoadValidShells()
 }
 
 // loadShadowData reads /etc/shadow and returns expiration info by username

--- a/pkg/runner/commit_linux.go
+++ b/pkg/runner/commit_linux.go
@@ -16,7 +16,6 @@ const (
 	shadowFilePath = "/etc/shadow"
 )
 
-// loadValidShells returns the host's valid login shells from /etc/shells.
 func loadValidShells() []string {
 	return utils.LoadValidShells()
 }

--- a/pkg/runner/commit_windows.go
+++ b/pkg/runner/commit_windows.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Windows has no /etc/shells equivalent; this fixed list is both the reported
+// ValidShells and the openpty allowlist, so the server round-trips these exact bare names.
 func loadValidShells() []string {
 	return []string{"powershell.exe", "cmd.exe", "pwsh.exe"}
 }

--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -6,7 +6,6 @@ import (
 
 func getDefaultEnv() map[string]string {
 	env := make(map[string]string)
-	env["SHELL"] = utils.DefaultShell()
 	env["TERM"] = "xterm-256color"
 	env["LS_COLORS"] = utils.DefaultLSColors
 	env["LANG"] = "en_US.UTF-8"

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -39,6 +39,7 @@ type PtyClient struct {
 	username      string
 	groupname     string
 	homeDirectory string
+	shell         string
 	sessionID     string
 	wsToPty       chan []byte
 	ptyToWs       chan []byte
@@ -69,6 +70,7 @@ func NewPtyClient(data protocol.CommandData, apiSession *scheduler.Session, mana
 		username:      data.Username,
 		groupname:     data.Groupname,
 		homeDirectory: data.HomeDirectory,
+		shell:         data.Shell,
 		sessionID:     data.SessionID,
 		wsToPty:       make(chan []byte, bufferSize),
 		ptyToWs:       make(chan []byte, bufferSize),
@@ -92,7 +94,8 @@ func (pc *PtyClient) initializePtySession() error {
 		return fmt.Errorf("failed to connect Websh server: %w", err)
 	}
 
-	pc.cmd = exec.Command(utils.DefaultShell(), utils.DefaultShellArgs()...)
+	shell, args := resolveShell(pc.shell, loadValidShells())
+	pc.cmd = exec.Command(shell, args...)
 	uid, gid, groupIds, env, err := pc.getPtyUserAndEnv()
 	if err != nil {
 		return fmt.Errorf("failed to get user/env: %w", err)

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -96,6 +97,9 @@ func (pc *PtyClient) initializePtySession() error {
 
 	shell, args := resolveShell(pc.shell, loadValidShells())
 	pc.cmd = exec.Command(shell, args...)
+	// login(1) convention: a leading "-" in argv[0] makes any shell a login
+	// shell, so profile files are sourced without shell-specific -l flags.
+	pc.cmd.Args[0] = "-" + filepath.Base(shell)
 	uid, gid, groupIds, env, err := pc.getPtyUserAndEnv()
 	if err != nil {
 		return fmt.Errorf("failed to get user/env: %w", err)

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -100,6 +100,7 @@ func (pc *PtyClient) initializePtySession() error {
 	if err != nil {
 		return fmt.Errorf("failed to get user/env: %w", err)
 	}
+	env["SHELL"] = shell
 	if err = pc.setPtyCmdSysProcAttrAndEnv(uid, gid, groupIds, env); err != nil {
 		return fmt.Errorf("failed to set process credentials: %w", err)
 	}

--- a/pkg/runner/pty_shell.go
+++ b/pkg/runner/pty_shell.go
@@ -14,7 +14,7 @@ import (
 // bash/zsh/powershell-specific and break other shells (dash, tcsh, cmd.exe).
 func resolveShell(requested string, validShells []string) (shell string, args []string) {
 	if requested != "" {
-		if shellAllowed(requested, validShells) {
+		if shellAllowed(requested, validShells, runtime.GOOS == "windows") {
 			return requested, nil
 		}
 		log.Warn().Str("requested", requested).
@@ -23,10 +23,9 @@ func resolveShell(requested string, validShells []string) (shell string, args []
 	return utils.DefaultShell(), utils.DefaultShellArgs()
 }
 
-// shellAllowed matches case-insensitively on Windows, where executable
-// names are case-insensitive; exact paths elsewhere.
-func shellAllowed(requested string, validShells []string) bool {
-	if runtime.GOOS == "windows" {
+// caseInsensitive is set on Windows, where executable names are case-insensitive.
+func shellAllowed(requested string, validShells []string, caseInsensitive bool) bool {
+	if caseInsensitive {
 		return slices.ContainsFunc(validShells, func(s string) bool {
 			return strings.EqualFold(s, requested)
 		})

--- a/pkg/runner/pty_shell.go
+++ b/pkg/runner/pty_shell.go
@@ -1,25 +1,35 @@
 package runner
 
 import (
+	"runtime"
 	"slices"
+	"strings"
 
 	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"github.com/rs/zerolog/log"
 )
 
-// resolveShell picks the shell to launch for a PTY session. A non-empty
-// requested shell is used with no extra args when it appears in the host's
-// valid login shells; otherwise the platform default shell and its default
-// args are used. Requested shells run without DefaultShellArgs because those
-// flags (-il / -NoLogo) are bash/zsh/powershell-specific and break other
-// shells (dash, tcsh, cmd.exe).
-func resolveShell(requested string, valid []string) (shell string, args []string) {
+// resolveShell picks the shell to launch for a PTY session. A requested shell
+// runs without DefaultShellArgs because those flags (-il / -NoLogo) are
+// bash/zsh/powershell-specific and break other shells (dash, tcsh, cmd.exe).
+func resolveShell(requested string, validShells []string) (shell string, args []string) {
 	if requested != "" {
-		if slices.Contains(valid, requested) {
+		if shellAllowed(requested, validShells) {
 			return requested, nil
 		}
 		log.Warn().Str("requested", requested).
 			Msg("Requested shell not in valid shells; falling back to default.")
 	}
 	return utils.DefaultShell(), utils.DefaultShellArgs()
+}
+
+// shellAllowed matches case-insensitively on Windows, where executable
+// names are case-insensitive; exact paths elsewhere.
+func shellAllowed(requested string, validShells []string) bool {
+	if runtime.GOOS == "windows" {
+		return slices.ContainsFunc(validShells, func(s string) bool {
+			return strings.EqualFold(s, requested)
+		})
+	}
+	return slices.Contains(validShells, requested)
 }

--- a/pkg/runner/pty_shell.go
+++ b/pkg/runner/pty_shell.go
@@ -1,0 +1,25 @@
+package runner
+
+import (
+	"slices"
+
+	"github.com/alpacax/alpamon/v2/pkg/utils"
+	"github.com/rs/zerolog/log"
+)
+
+// resolveShell picks the shell to launch for a PTY session. A non-empty
+// requested shell is used with no extra args when it appears in the host's
+// valid login shells; otherwise the platform default shell and its default
+// args are used. Requested shells run without DefaultShellArgs because those
+// flags (-il / -NoLogo) are bash/zsh/powershell-specific and break other
+// shells (dash, tcsh, cmd.exe).
+func resolveShell(requested string, valid []string) (shell string, args []string) {
+	if requested != "" {
+		if slices.Contains(valid, requested) {
+			return requested, nil
+		}
+		log.Warn().Str("requested", requested).
+			Msg("Requested shell not in valid shells; falling back to default.")
+	}
+	return utils.DefaultShell(), utils.DefaultShellArgs()
+}

--- a/pkg/runner/pty_shell_test.go
+++ b/pkg/runner/pty_shell_test.go
@@ -1,0 +1,30 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/alpacax/alpamon/v2/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveShell(t *testing.T) {
+	valid := []string{"/custom/shell", "/bin/bash"}
+
+	t.Run("empty requested falls back to default", func(t *testing.T) {
+		shell, args := resolveShell("", valid)
+		assert.Equal(t, utils.DefaultShell(), shell)
+		assert.Equal(t, utils.DefaultShellArgs(), args)
+	})
+
+	t.Run("valid requested is used with no args", func(t *testing.T) {
+		shell, args := resolveShell("/custom/shell", valid)
+		assert.Equal(t, "/custom/shell", shell)
+		assert.Nil(t, args)
+	})
+
+	t.Run("invalid requested falls back to default", func(t *testing.T) {
+		shell, args := resolveShell("/not/listed", valid)
+		assert.Equal(t, utils.DefaultShell(), shell)
+		assert.Equal(t, utils.DefaultShellArgs(), args)
+	})
+}

--- a/pkg/runner/pty_shell_test.go
+++ b/pkg/runner/pty_shell_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/pkg/utils"
@@ -26,5 +27,16 @@ func TestResolveShell(t *testing.T) {
 		shell, args := resolveShell("/not/listed", valid)
 		assert.Equal(t, utils.DefaultShell(), shell)
 		assert.Equal(t, utils.DefaultShellArgs(), args)
+	})
+
+	t.Run("case-differing requested matches only on windows", func(t *testing.T) {
+		shell, args := resolveShell("/Custom/Shell", valid)
+		if runtime.GOOS == "windows" {
+			assert.Equal(t, "/Custom/Shell", shell)
+			assert.Nil(t, args)
+		} else {
+			assert.Equal(t, utils.DefaultShell(), shell)
+			assert.Equal(t, utils.DefaultShellArgs(), args)
+		}
 	})
 }

--- a/pkg/runner/pty_shell_test.go
+++ b/pkg/runner/pty_shell_test.go
@@ -1,7 +1,6 @@
 package runner
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/pkg/utils"
@@ -29,14 +28,18 @@ func TestResolveShell(t *testing.T) {
 		assert.Equal(t, utils.DefaultShellArgs(), args)
 	})
 
-	t.Run("case-differing requested matches only on windows", func(t *testing.T) {
-		shell, args := resolveShell("/Custom/Shell", valid)
-		if runtime.GOOS == "windows" {
-			assert.Equal(t, "/Custom/Shell", shell)
-			assert.Nil(t, args)
-		} else {
-			assert.Equal(t, utils.DefaultShell(), shell)
-			assert.Equal(t, utils.DefaultShellArgs(), args)
-		}
+}
+
+func TestShellAllowed(t *testing.T) {
+	valid := []string{"/custom/shell", "powershell.exe"}
+
+	t.Run("case-sensitive requires exact match", func(t *testing.T) {
+		assert.True(t, shellAllowed("/custom/shell", valid, false))
+		assert.False(t, shellAllowed("/Custom/Shell", valid, false))
+	})
+
+	t.Run("case-insensitive matches differing case", func(t *testing.T) {
+		assert.True(t, shellAllowed("PowerShell.EXE", valid, true))
+		assert.False(t, shellAllowed("cmd.exe", valid, true))
 	})
 }

--- a/pkg/runner/pty_windows.go
+++ b/pkg/runner/pty_windows.go
@@ -14,7 +14,6 @@ import (
 	"github.com/alpacax/alpamon/v2/internal/protocol"
 	"github.com/alpacax/alpamon/v2/pkg/config"
 	"github.com/alpacax/alpamon/v2/pkg/scheduler"
-	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog/log"
 )
@@ -36,6 +35,7 @@ type PtyClient struct {
 	username      string
 	groupname     string
 	homeDirectory string
+	shell         string
 	sessionID     string
 	wsToPty       chan []byte
 	ptyToWs       chan []byte
@@ -58,6 +58,7 @@ func NewPtyClient(data protocol.CommandData, apiSession *scheduler.Session, mana
 		username:      data.Username,
 		groupname:     data.Groupname,
 		homeDirectory: data.HomeDirectory,
+		shell:         data.Shell,
 		sessionID:     data.SessionID,
 		wsToPty:       make(chan []byte, bufferSize),
 		ptyToWs:       make(chan []byte, bufferSize),
@@ -131,8 +132,7 @@ func (pc *PtyClient) initializeSession() error {
 	}
 
 	// Build command line
-	shell := utils.DefaultShell()
-	args := utils.DefaultShellArgs()
+	shell, args := resolveShell(pc.shell, loadValidShells())
 	commandLine := shell
 	if len(args) > 0 {
 		commandLine = shell + " " + strings.Join(args, " ")

--- a/pkg/utils/shell_unix.go
+++ b/pkg/utils/shell_unix.go
@@ -19,7 +19,7 @@ func LoadValidShells() []string { return loadValidShellsFrom(validShellsFilePath
 func loadValidShellsFrom(path string) []string {
 	file, err := os.Open(path)
 	if err != nil {
-		log.Debug().Err(err).Msg("Failed to open /etc/shells, skipping shell validation")
+		log.Debug().Err(err).Str("path", path).Msg("Failed to open valid shells file, skipping shell validation")
 		return nil
 	}
 	defer func() { _ = file.Close() }()
@@ -34,7 +34,7 @@ func loadValidShellsFrom(path string) []string {
 		shells = append(shells, line)
 	}
 	if err := scanner.Err(); err != nil {
-		log.Debug().Err(err).Msg("Error reading /etc/shells")
+		log.Debug().Err(err).Str("path", path).Msg("Error reading valid shells file")
 		return nil
 	}
 	return shells

--- a/pkg/utils/shell_unix.go
+++ b/pkg/utils/shell_unix.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package utils
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+const validShellsFilePath = "/etc/shells"
+
+// LoadValidShells reads /etc/shells and returns the listed login shell paths.
+// Returns nil if the file cannot be read or parsed.
+func LoadValidShells() []string { return loadValidShellsFrom(validShellsFilePath) }
+
+func loadValidShellsFrom(path string) []string {
+	file, err := os.Open(path)
+	if err != nil {
+		log.Debug().Err(err).Msg("Failed to open /etc/shells, skipping shell validation")
+		return nil
+	}
+	defer func() { _ = file.Close() }()
+
+	var shells []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		shells = append(shells, line)
+	}
+	if err := scanner.Err(); err != nil {
+		log.Debug().Err(err).Msg("Error reading /etc/shells")
+		return nil
+	}
+	return shells
+}

--- a/pkg/utils/shell_unix_test.go
+++ b/pkg/utils/shell_unix_test.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadValidShellsFrom(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells")
+	content := "# comment line\n\n/bin/bash\n  /bin/zsh  \n/usr/bin/fish\n"
+	assert.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	shells := loadValidShellsFrom(path)
+
+	assert.Equal(t, []string{"/bin/bash", "/bin/zsh", "/usr/bin/fish"}, shells)
+	assert.NotContains(t, shells, "# comment line")
+}
+
+func TestLoadValidShellsFrom_NoPartialMatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells")
+	assert.NoError(t, os.WriteFile(path, []byte("/bin/bash2\n"), 0o644))
+
+	shells := loadValidShellsFrom(path)
+
+	assert.NotContains(t, shells, "/bin/bash")
+	assert.Equal(t, []string{"/bin/bash2"}, shells)
+}
+
+func TestLoadValidShellsFrom_MissingFile(t *testing.T) {
+	shells := loadValidShellsFrom(filepath.Join(t.TempDir(), "does-not-exist"))
+	assert.Nil(t, shells)
+}

--- a/pkg/utils/shell_unix_test.go
+++ b/pkg/utils/shell_unix_test.go
@@ -5,35 +5,44 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadValidShellsFrom(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "shells")
 	content := "# comment line\n\n/bin/bash\n  /bin/zsh  \n/usr/bin/fish\n"
-	assert.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write shells file: %v", err)
+	}
 
 	shells := loadValidShellsFrom(path)
 
-	assert.Equal(t, []string{"/bin/bash", "/bin/zsh", "/usr/bin/fish"}, shells)
-	assert.NotContains(t, shells, "# comment line")
+	want := []string{"/bin/bash", "/bin/zsh", "/usr/bin/fish"}
+	if !reflect.DeepEqual(shells, want) {
+		t.Errorf("expected %v, got %v", want, shells)
+	}
 }
 
 func TestLoadValidShellsFrom_NoPartialMatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "shells")
-	assert.NoError(t, os.WriteFile(path, []byte("/bin/bash2\n"), 0o644))
+	if err := os.WriteFile(path, []byte("/bin/bash2\n"), 0o644); err != nil {
+		t.Fatalf("failed to write shells file: %v", err)
+	}
 
 	shells := loadValidShellsFrom(path)
 
-	assert.NotContains(t, shells, "/bin/bash")
-	assert.Equal(t, []string{"/bin/bash2"}, shells)
+	want := []string{"/bin/bash2"}
+	if !reflect.DeepEqual(shells, want) {
+		t.Errorf("expected %v, got %v", want, shells)
+	}
 }
 
 func TestLoadValidShellsFrom_MissingFile(t *testing.T) {
 	shells := loadValidShellsFrom(filepath.Join(t.TempDir(), "does-not-exist"))
-	assert.Nil(t, shells)
+	if shells != nil {
+		t.Errorf("expected nil for missing file, got %v", shells)
+	}
 }

--- a/pkg/utils/shell_unix_test.go
+++ b/pkg/utils/shell_unix_test.go
@@ -40,6 +40,18 @@ func TestLoadValidShellsFrom_NoPartialMatch(t *testing.T) {
 	}
 }
 
+func TestLoadValidShellsFrom_CommentsAndBlankOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells")
+	if err := os.WriteFile(path, []byte("# only comments\n\n\t\n"), 0o644); err != nil {
+		t.Fatalf("failed to write shells file: %v", err)
+	}
+
+	if shells := loadValidShellsFrom(path); shells != nil {
+		t.Errorf("expected nil for comments/blank-only file, got %v", shells)
+	}
+}
+
 func TestLoadValidShellsFrom_MissingFile(t *testing.T) {
 	shells := loadValidShellsFrom(filepath.Join(t.TempDir(), "does-not-exist"))
 	if shells != nil {


### PR DESCRIPTION
## Background

Until now the `openpty` command always launched the shell via `utils.DefaultShell()`. There was no way for the server to select a per-user login shell. Following alpacax/alpamon#257, the `openpty` command now accepts an optional `shell` field sent by the server and, when it passes validation, starts the PTY session with that shell.

## What changed

The `shell` field is wired from the protocol through to PTY launch. `pkg/executor/handlers/terminal/terminal.go` passes the command argument's `Shell` into `CommandData`, and `PtyClient` resolves it via `resolveShell` when the session starts.

Behavior of `resolveShell` (`pkg/runner/pty_shell.go`):

- If `shell` is empty or absent, it uses `utils.DefaultShell()` + `utils.DefaultShellArgs()` exactly as before (backwards compatible).
- If `shell` matches the host's valid login shells exactly, it launches that shell with no extra args. The default args (`-il` / `-NoLogo`) are bash/zsh/powershell specific and would break dash, tcsh, and cmd.exe.
- If it is not in the list, it logs a warning and falls back to the default shell.

The valid-shell list is per platform. Unix reads `/etc/shells` (extracted into `utils.LoadValidShells`, consolidating the reader that was duplicated across `commit_linux.go` and `commit_darwin.go`); Windows uses the fixed list in `commit_windows.go` (powershell.exe, cmd.exe, pwsh.exe). Windows executable names are case-insensitive, so matching uses `strings.EqualFold` on that platform only.

The session's `SHELL` environment variable is now set to the resolved shell in `pkg/runner/pty.go`, and the static `SHELL` assignment in `getDefaultEnv` was removed.

On macOS, when `/etc/shells` is empty or unreadable, `loadValidShells` now returns the common default shells (/bin/bash, /bin/zsh, /bin/sh). Previously it returned nil, which rejected every requested shell.

## Safety

A server-provided shell value never passes through `sh -c`. Unix runs it via `exec.Command(shell, args...)` and Windows places it as a discrete token in the ConPTY command line, so shell-metacharacter injection is not possible. Validation is an exact-match whitelist against the per-platform valid-shell list, so an arbitrary path is always rejected and falls back to the default (not fail-open). The empty-list behavior differs by platform: on Linux the list comes straight from `/etc/shells`, so if it is missing or unreadable the list is empty and every requested shell is rejected; on macOS `/etc/shells` is less reliable, so `loadValidShells` falls back to a fixed set of trusted default shells (/bin/bash, /bin/zsh, /bin/sh); Windows uses a fixed list (powershell.exe, cmd.exe, pwsh.exe). In every case the accepted set is a trusted whitelist, never the caller's raw input.

## Testing

Unit tests:

- `pkg/runner/pty_shell_test.go`: covers the empty/valid/invalid branches of `resolveShell` plus the Windows-only case-insensitive match.
- `pkg/utils/shell_unix_test.go`: `/etc/shells` parsing (skips comments and blank lines, trims whitespace, no partial matches, nil on missing file).
- Cross-compiles on linux/darwin/windows, `go vet`, and the full test suite pass.

End-to-end verification:

Built this branch for linux/arm64, deployed it over the packaged binary on a live Ubuntu host, and opened real Websh sessions from the console. The shell the server sends is the target system user's login shell (`proc.models.SystemUser.shell` in alpacon-server, synced from `/etc/passwd`); it is not selectable per session. Each case changed the target user's login shell, restarted alpamon to force a re-sync, then opened a new Websh session.

| Case | Target user login shell | Expected | Observed |
| --- | --- | --- | --- |
| Valid non-default shell | `/usr/bin/dash` (in `/etc/shells`) | that shell launched, no `-il` | `echo $SHELL` -> `/usr/bin/dash`, `readlink /proc/$$/exe` -> `/usr/bin/dash`, `ps -p $$ -o comm=` -> `dash` |
| Default shell | `/bin/bash` (in `/etc/shells`) | bash launched without login args | `shopt -q login_shell` -> 1 (not a login shell), `$0` -> `/bin/bash` (not `-bash`), `echo $SHELL` -> `/bin/bash` |
| Invalid shell (fallback) | `/bin/dash` (not in `/etc/shells`) | fallback to default + warning | not reachable end-to-end, see note below |

Note on the invalid-shell fallback: it cannot be exercised through the real server. alpamon syncs each user's shell together with the `/etc/shells` list, and alpacon-server's `compute_login_enabled` (`proc/utils.py`) marks any user whose shell is not in `/etc/shells` as login-disabled. Such a session is rejected at creation with `system_user_access_denied` (`websh/mixins.py`) before any `openpty` command is sent, so the server only ever sends a shell that is already in `/etc/shells`. The `resolveShell` fallback branch remains as defense-in-depth (sync races, older alpamon, `/etc/shells` changed after a sync) and is covered by the unit tests above.

## Checklist

- [x] Both Unix and Windows paths implemented
- [x] Backwards compatible (existing behavior when shell is unset)
- [x] Confirmed no shell-metacharacter injection
- [x] Builds and tests pass on all three platforms
- [x] Verified end-to-end on a live host via Websh (valid and default shells)

Closes #257
