### PR TITLE
fix(db): enable SQLite foreign key enforcement

### DIFF
--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -20,11 +20,14 @@ func NewDBClientManager(path string) *DBClientManager {
 	}
 }
 
+func sqliteDSN(path string) string {
+	return fmt.Sprintf("file:%s?cache=shared&__pragma=foreign_keys(1)", path)
+}
+
 func (cm *DBClientManager) GetClient() (*ent.Client, error) {
 	var err error
 	cm.once.Do(func() {
-		url := fmt.Sprintf("file:%s?cache=shared&__pragma=foreign_keys(1)", cm.path)
-		cm.client, err = ent.Open("sqlite3", url)
+		cm.client, err = ent.Open("sqlite3", sqliteDSN(cm.path))
 	})
 	return cm.client, err
 }

--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -21,7 +21,7 @@ func NewDBClientManager(path string) *DBClientManager {
 }
 
 func sqliteDSN(path string) string {
-	return fmt.Sprintf("file:%s?cache=shared&__pragma=foreign_keys(1)", path)
+	return fmt.Sprintf("file:%s?cache=shared&_pragma=foreign_keys(1)", path)
 }
 
 func (cm *DBClientManager) GetClient() (*ent.Client, error) {

--- a/pkg/db/client_test.go
+++ b/pkg/db/client_test.go
@@ -1,0 +1,37 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLiteDSNEnablesForeignKeys(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	var foreignKeys int
+	err = conn.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&foreignKeys)
+	require.NoError(t, err)
+	require.Equal(t, 1, foreignKeys)
+
+	_, err = conn.ExecContext(ctx, "CREATE TABLE parents (id INTEGER PRIMARY KEY)")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "CREATE TABLE children (parent_id INTEGER REFERENCES parents(id))")
+	require.NoError(t, err)
+
+	_, err = conn.ExecContext(ctx, "INSERT INTO children (parent_id) VALUES (1)")
+	require.Error(t, err)
+}

--- a/pkg/db/client_test.go
+++ b/pkg/db/client_test.go
@@ -33,5 +33,5 @@ func TestSQLiteDSNEnablesForeignKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = conn.ExecContext(ctx, "INSERT INTO children (parent_id) VALUES (1)")
-	require.Error(t, err)
+	require.ErrorContains(t, err, "FOREIGN KEY constraint failed")
 }


### PR DESCRIPTION
## Background

The SQLite DSN parameter was written as `__pragma=foreign_keys(1)` with a double underscore. The glebarez/modernc driver treats this as an unknown query parameter and silently ignores it, so foreign key enforcement was never enabled at runtime. As a result, rows referencing non-existent parents were not rejected at the database level.

## Changes

Fixed the DSN parameter to `_pragma=foreign_keys(1)` so foreign key enforcement is actually turned on. The connection string was assembled inline inside `DBClientManager.GetClient`, which made it hard to verify independently, so it was first extracted into a `sqliteDSN` helper and then the typo was corrected. `cache=shared` and all other runtime behavior are unchanged.

Commits are split by intent: DSN extraction (refactor), typo fix (fix), regression test (test).

## Tests

Added `TestSQLiteDSNEnablesForeignKeys` in `pkg/db/client_test.go`. It pins a single connection, asserts `PRAGMA foreign_keys` returns `1`, and verifies that an INSERT referencing a non-existent parent is rejected with a `FOREIGN KEY constraint failed` error. The error message is matched specifically so an unrelated failure (renamed column, bad SQL) cannot make the test pass and hide disabled enforcement.

- `go test ./pkg/db -count=1` passes

## Checklist

- [x] Verified foreign key enforcement is actually enabled via test
- [x] Preserved existing connection string behavior (`cache=shared`)
- [ ] Reviewer confirmation

Closes #352
