### PR TITLE
fix(runner): harden Websh PTY WebSocket recovery against deadlock, races, and leaks

### DIFF
--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -170,9 +170,8 @@ func (pc *PtyClient) runRecoveryLoop(ctx context.Context, cancel context.CancelF
 			return
 		case <-recoveryChan:
 			log.Debug().Msg("Attempting to reconnect Websh channel...")
-			err := pc.recovery(ctx)
-			pc.isRecovering.Store(false)
-			if err != nil {
+			if err := pc.recovery(ctx); err != nil {
+				pc.isRecovering.Store(false)
 				cancel()
 				return
 			}
@@ -188,10 +187,11 @@ func (pc *PtyClient) awaitRecovery() <-chan struct{} {
 	return pc.recoveryDone
 }
 
-// completeRecovery wakes every awaitRecovery waiter by closing recoveryDone and installing a fresh channel.
+// completeRecovery clears isRecovering and wakes every waiter under recoveryMu in one step, so no waiter can observe the flag cleared against the about-to-be-replaced channel.
 func (pc *PtyClient) completeRecovery() {
 	pc.recoveryMu.Lock()
 	defer pc.recoveryMu.Unlock()
+	pc.isRecovering.Store(false)
 	close(pc.recoveryDone)
 	pc.recoveryDone = make(chan struct{})
 }
@@ -214,11 +214,17 @@ func (pc *PtyClient) swapConn(conn *websocket.Conn) *websocket.Conn {
 
 // waitForRecovery requests a reconnect for the conn that errored—unless recovery already replaced it—and blocks until it completes; false means the session ended.
 func (pc *PtyClient) waitForRecovery(ctx context.Context, conn *websocket.Conn, recoveryChan chan struct{}) bool {
-	recovered := pc.awaitRecovery()
-	if pc.getConn() != conn {
+	// Snapshot the completion channel, the conn check, and the single-flight CAS under one lock so completeRecovery cannot interleave and wake this waiter on a stale channel generation.
+	pc.recoveryMu.Lock()
+	if pc.conn != conn {
+		pc.recoveryMu.Unlock()
 		return true
 	}
-	if pc.isRecovering.CompareAndSwap(false, true) {
+	recovered := pc.recoveryDone
+	request := pc.isRecovering.CompareAndSwap(false, true)
+	pc.recoveryMu.Unlock()
+
+	if request {
 		recoveryChan <- struct{}{}
 	}
 	select {

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -171,7 +171,7 @@ func (pc *PtyClient) runRecoveryLoop(ctx context.Context, cancel context.CancelF
 		case <-recoveryChan:
 			log.Debug().Msg("Attempting to reconnect Websh channel...")
 			if err := pc.recovery(ctx); err != nil {
-				pc.isRecovering.Store(false)
+				pc.clearRecovering()
 				cancel()
 				return
 			}
@@ -180,14 +180,14 @@ func (pc *PtyClient) runRecoveryLoop(ctx context.Context, cancel context.CancelF
 	}
 }
 
-// awaitRecovery returns the channel closed on the next completed recovery; snapshot it before requesting recovery so a completion in between cannot be missed.
-func (pc *PtyClient) awaitRecovery() <-chan struct{} {
+// clearRecovering releases single-flight without waking waiters; the caller cancels the session, so waiters exit via ctx.Done instead.
+func (pc *PtyClient) clearRecovering() {
 	pc.recoveryMu.Lock()
 	defer pc.recoveryMu.Unlock()
-	return pc.recoveryDone
+	pc.isRecovering.Store(false)
 }
 
-// completeRecovery clears isRecovering and wakes every waiter under recoveryMu in one step, so no waiter can observe the flag cleared against the about-to-be-replaced channel.
+// completeRecovery does flag-clear, close and rotate in one recoveryMu step so no waiter can observe the flag cleared against the about-to-be-replaced channel.
 func (pc *PtyClient) completeRecovery() {
 	pc.recoveryMu.Lock()
 	defer pc.recoveryMu.Unlock()
@@ -203,7 +203,7 @@ func (pc *PtyClient) getConn() *websocket.Conn {
 	return pc.conn
 }
 
-// swapConn installs the recovered connection and returns the replaced one so the caller can close it.
+// swapConn returns the replaced conn; the caller must close it.
 func (pc *PtyClient) swapConn(conn *websocket.Conn) *websocket.Conn {
 	pc.recoveryMu.Lock()
 	defer pc.recoveryMu.Unlock()

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -45,6 +46,8 @@ type PtyClient struct {
 	wsToPty       chan []byte
 	ptyToWs       chan []byte
 	isRecovering  atomic.Bool // default : false
+	recoveryMu    sync.Mutex
+	recoveryDone  chan struct{} // closed on each completed recovery, then replaced
 	manager       *TerminalManager
 }
 
@@ -75,6 +78,7 @@ func NewPtyClient(data protocol.CommandData, apiSession *scheduler.Session, mana
 		sessionID:     data.SessionID,
 		wsToPty:       make(chan []byte, bufferSize),
 		ptyToWs:       make(chan []byte, bufferSize),
+		recoveryDone:  make(chan struct{}),
 		manager:       manager,
 	}
 }
@@ -148,40 +152,91 @@ func (pc *PtyClient) RunPtyBackground() {
 	defer cancel()
 
 	recoveryChan := make(chan struct{}, 1)
-	recoveredWsChan := make(chan struct{}, 1)
-	recoveredPtyChan := make(chan struct{}, 1)
 
 	go pc.readFromPty(ctx, cancel)
-	go pc.writeToWebsocket(ctx, cancel, recoveryChan, recoveredPtyChan)
+	go pc.writeToWebsocket(ctx, cancel, recoveryChan)
 
-	go pc.readFromWebsocket(ctx, cancel, recoveryChan, recoveredWsChan)
+	go pc.readFromWebsocket(ctx, cancel, recoveryChan)
 	go pc.writeToPty(ctx, cancel)
 
+	pc.runRecoveryLoop(ctx, cancel, recoveryChan)
+}
+
+// runRecoveryLoop serializes recovery attempts; completion is broadcast by closing recoveryDone so sides that were not waiting cannot stall the next cycle.
+func (pc *PtyClient) runRecoveryLoop(ctx context.Context, cancel context.CancelFunc, recoveryChan chan struct{}) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-recoveryChan:
 			log.Debug().Msg("Attempting to reconnect Websh channel...")
-			err = pc.recovery()
+			err := pc.recovery(ctx)
 			pc.isRecovering.Store(false)
 			if err != nil {
 				cancel()
 				return
 			}
-			recoveredWsChan <- struct{}{}
-			recoveredPtyChan <- struct{}{}
+			pc.completeRecovery()
 		}
 	}
 }
 
-func (pc *PtyClient) readFromWebsocket(ctx context.Context, cancel context.CancelFunc, recoveryChan, recoveredChan chan struct{}) {
+// awaitRecovery returns the channel closed on the next completed recovery; snapshot it before requesting recovery so a completion in between cannot be missed.
+func (pc *PtyClient) awaitRecovery() <-chan struct{} {
+	pc.recoveryMu.Lock()
+	defer pc.recoveryMu.Unlock()
+	return pc.recoveryDone
+}
+
+// completeRecovery wakes every awaitRecovery waiter by closing recoveryDone and installing a fresh channel.
+func (pc *PtyClient) completeRecovery() {
+	pc.recoveryMu.Lock()
+	defer pc.recoveryMu.Unlock()
+	close(pc.recoveryDone)
+	pc.recoveryDone = make(chan struct{})
+}
+
+// getConn reads pc.conn under recoveryMu because recovery replaces it while the read/write goroutines are still running.
+func (pc *PtyClient) getConn() *websocket.Conn {
+	pc.recoveryMu.Lock()
+	defer pc.recoveryMu.Unlock()
+	return pc.conn
+}
+
+// swapConn installs the recovered connection and returns the replaced one so the caller can close it.
+func (pc *PtyClient) swapConn(conn *websocket.Conn) *websocket.Conn {
+	pc.recoveryMu.Lock()
+	defer pc.recoveryMu.Unlock()
+	old := pc.conn
+	pc.conn = conn
+	return old
+}
+
+// waitForRecovery requests a reconnect for the conn that errored—unless recovery already replaced it—and blocks until it completes; false means the session ended.
+func (pc *PtyClient) waitForRecovery(ctx context.Context, conn *websocket.Conn, recoveryChan chan struct{}) bool {
+	recovered := pc.awaitRecovery()
+	if pc.getConn() != conn {
+		return true
+	}
+	if pc.isRecovering.CompareAndSwap(false, true) {
+		recoveryChan <- struct{}{}
+	}
+	select {
+	case <-recovered:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (pc *PtyClient) readFromWebsocket(ctx context.Context, cancel context.CancelFunc, recoveryChan chan struct{}) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			_, msg, err := pc.conn.ReadMessage()
+			conn := pc.getConn()
+			_, msg, err := conn.ReadMessage()
 			if err != nil {
 				if ctx.Err() != nil {
 					return
@@ -192,17 +247,16 @@ func (pc *PtyClient) readFromWebsocket(ctx context.Context, cancel context.Cance
 					return
 				}
 
-				if pc.isRecovering.CompareAndSwap(false, true) {
-					recoveryChan <- struct{}{}
-				}
-				select {
-				case <-recoveredChan:
-					continue
-				case <-ctx.Done():
+				if !pc.waitForRecovery(ctx, conn, recoveryChan) {
 					return
 				}
+				continue
 			}
-			pc.wsToPty <- msg
+			select {
+			case pc.wsToPty <- msg:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }
@@ -234,18 +288,23 @@ func (pc *PtyClient) readFromPty(ctx context.Context, cancel context.CancelFunc)
 				cancel()
 				return
 			}
-			pc.ptyToWs <- append([]byte(nil), buf[:n]...)
+			select {
+			case pc.ptyToWs <- append([]byte(nil), buf[:n]...):
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }
 
-func (pc *PtyClient) writeToWebsocket(ctx context.Context, cancel context.CancelFunc, recoveryChan, recoveredChan chan struct{}) {
+func (pc *PtyClient) writeToWebsocket(ctx context.Context, cancel context.CancelFunc, recoveryChan chan struct{}) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case msg := <-pc.ptyToWs:
-			err := pc.conn.WriteMessage(websocket.BinaryMessage, msg)
+			conn := pc.getConn()
+			err := conn.WriteMessage(websocket.BinaryMessage, msg)
 			if err != nil {
 				if ctx.Err() != nil {
 					return
@@ -256,13 +315,7 @@ func (pc *PtyClient) writeToWebsocket(ctx context.Context, cancel context.Cancel
 					return
 				}
 
-				if pc.isRecovering.CompareAndSwap(false, true) {
-					recoveryChan <- struct{}{}
-				}
-				select {
-				case <-recoveredChan:
-					continue
-				case <-ctx.Done():
+				if !pc.waitForRecovery(ctx, conn, recoveryChan) {
 					return
 				}
 			}
@@ -338,18 +391,18 @@ func (pc *PtyClient) close() {
 		_ = pc.cmd.Wait()
 	}
 
-	if pc.conn != nil {
-		err := pc.conn.WriteControl(
+	if conn := pc.getConn(); conn != nil {
+		err := conn.WriteControl(
 			websocket.CloseMessage,
 			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 			time.Now().Add(5*time.Second),
 		)
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to write close message to Websh channel.")
-			return
 		}
 
-		err = pc.conn.Close()
+		// Close the connection even if the close handshake failed; a broken connection must not leak its fd.
+		err = conn.Close()
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to close Websh channel.")
 		}
@@ -359,10 +412,9 @@ func (pc *PtyClient) close() {
 }
 
 // recovery reconnects the WebSocket while keeping the PTY session alive.
-// Note: recovery doesn't close the existing conn explicitly to avoid breaking the session.
-// The goal is to replace a broken connection, not perform a graceful shutdown.
-func (pc *PtyClient) recovery() error {
-	ctx, cancel := context.WithTimeout(context.Background(), maxRecoveryTimeout)
+func (pc *PtyClient) recovery(ctx context.Context) error {
+	// Derive from the session context so cancellation aborts the retry loop instead of blocking teardown for up to maxRecoveryTimeout.
+	ctx, cancel := context.WithTimeout(ctx, maxRecoveryTimeout)
 	defer cancel()
 
 	b := &retry.ExponentialBackoff{
@@ -409,7 +461,10 @@ func (pc *PtyClient) recovery() error {
 			return err
 		}
 
-		pc.conn = conn
+		// Close the replaced conn: its fd would leak otherwise, and a reader still blocked on a silently dead conn must be forced onto the new one.
+		if old := pc.swapConn(conn); old != nil {
+			_ = old.Close()
+		}
 		log.Debug().Msg("Websh reconnected successfully.")
 		return nil
 	})

--- a/pkg/runner/pty_recovery_test.go
+++ b/pkg/runner/pty_recovery_test.go
@@ -1,0 +1,266 @@
+//go:build !windows
+
+package runner
+
+// Regression tests for issue #351: repeated Websh reconnects must not deadlock when only one side waits for recovery, and close() must release the connection even when the close handshake fails.
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alpacax/alpamon/v2/pkg/config"
+	"github.com/alpacax/alpamon/v2/pkg/scheduler"
+	"github.com/gorilla/websocket"
+)
+
+// wshServer is a local Websh test double: a WebSocket endpoint plus the pty-channels recovery API, with server-side handles to kill connections.
+type wshServer struct {
+	ts            *httptest.Server
+	mu            sync.Mutex
+	conns         []*websocket.Conn
+	recoveryPosts atomic.Int32
+}
+
+func newWshServer(t *testing.T) *wshServer {
+	t.Helper()
+	s := &wshServer{}
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws/pty", func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		s.mu.Lock()
+		s.conns = append(s.conns, c)
+		s.mu.Unlock()
+	})
+	mux.HandleFunc(reconnectPtyWebsocketURL, func(w http.ResponseWriter, r *http.Request) {
+		s.recoveryPosts.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"websocket_url": "/ws/pty"}`))
+	})
+
+	s.ts = httptest.NewServer(mux)
+	t.Cleanup(s.ts.Close)
+
+	prevServerURL := config.GlobalSettings.ServerURL
+	config.GlobalSettings.ServerURL = s.ts.URL
+	t.Cleanup(func() { config.GlobalSettings.ServerURL = prevServerURL })
+
+	return s
+}
+
+func (s *wshServer) wsURL() string {
+	return strings.Replace(s.ts.URL, "http", "ws", 1) + "/ws/pty"
+}
+
+// killConn abruptly closes the n-th (0-based) server-side connection, simulating a network drop without a close handshake.
+func (s *wshServer) killConn(t *testing.T, n int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		s.mu.Lock()
+		if len(s.conns) > n {
+			c := s.conns[n]
+			s.mu.Unlock()
+			_ = c.UnderlyingConn().Close()
+			return
+		}
+		s.mu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatalf("server-side connection #%d never appeared", n)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// newTestPtyClient returns a PtyClient connected to the test server, without a PTY or shell process (WebSocket recovery does not need them).
+func newTestPtyClient(t *testing.T, s *wshServer) *PtyClient {
+	t.Helper()
+	dialer := websocket.Dialer{}
+	conn, _, err := dialer.Dial(s.wsURL(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &PtyClient{
+		conn:         conn,
+		apiSession:   &scheduler.Session{BaseURL: s.ts.URL, Client: s.ts.Client()},
+		sessionID:    "test-session",
+		wsToPty:      make(chan []byte, bufferSize),
+		ptyToWs:      make(chan []byte, bufferSize),
+		recoveryDone: make(chan struct{}),
+		manager:      NewTerminalManager(),
+	}
+}
+
+func waitRecovered(t *testing.T, done <-chan struct{}, cycle int) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("recovery #%d did not complete: coordinator deadlocked", cycle)
+	}
+}
+
+// TestPtyRecovery_ReadSideOnly reproduces the issue #351 deadlock: only the read side waits for recovery; before the fix the second reconnect blocked on the stale per-side completion signal.
+func TestPtyRecovery_ReadSideOnly(t *testing.T) {
+	s := newWshServer(t)
+	pc := newTestPtyClient(t, s)
+	defer pc.close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	recoveryChan := make(chan struct{}, 1)
+	go pc.readFromWebsocket(ctx, cancel, recoveryChan)
+	// writeToWebsocket is intentionally not started: nothing consumes a write-side completion signal.
+	go pc.runRecoveryLoop(ctx, cancel, recoveryChan)
+
+	for cycle := 0; cycle < 3; cycle++ {
+		done := pc.awaitRecovery()
+		s.killConn(t, cycle)
+		waitRecovered(t, done, cycle+1)
+	}
+}
+
+// TestPtyRecovery_WriteSideOnly is the mirror case: only the write side detects errors and waits for recovery.
+func TestPtyRecovery_WriteSideOnly(t *testing.T) {
+	s := newWshServer(t)
+	pc := newTestPtyClient(t, s)
+	defer pc.close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	recoveryChan := make(chan struct{}, 1)
+	go pc.writeToWebsocket(ctx, cancel, recoveryChan)
+	go pc.runRecoveryLoop(ctx, cancel, recoveryChan)
+
+	for cycle := 0; cycle < 3; cycle++ {
+		done := pc.awaitRecovery()
+		s.killConn(t, cycle)
+		// Keep feeding PTY output until the write side hits the broken connection (the first writes may still land in the OS buffer).
+		deadline := time.After(10 * time.Second)
+	feed:
+		for {
+			select {
+			case <-done:
+				break feed
+			case pc.ptyToWs <- []byte("output"):
+			case <-deadline:
+				t.Fatalf("recovery #%d did not complete: coordinator deadlocked", cycle+1)
+			}
+		}
+	}
+}
+
+// TestPtyRecovery_StormNoGoroutineLeak runs repeated reconnects with both sides active and verifies that goroutines do not accumulate and teardown completes.
+func TestPtyRecovery_StormNoGoroutineLeak(t *testing.T) {
+	s := newWshServer(t)
+
+	baseline := runtime.NumGoroutine()
+
+	pc := newTestPtyClient(t, s)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	recoveryChan := make(chan struct{}, 1)
+	go pc.readFromWebsocket(ctx, cancel, recoveryChan)
+	go pc.writeToWebsocket(ctx, cancel, recoveryChan)
+	go pc.runRecoveryLoop(ctx, cancel, recoveryChan)
+
+	const cycles = 5
+	for cycle := 0; cycle < cycles; cycle++ {
+		done := pc.awaitRecovery()
+		s.killConn(t, cycle)
+		waitRecovered(t, done, cycle+1)
+	}
+
+	if got := s.recoveryPosts.Load(); got < cycles {
+		t.Fatalf("expected at least %d recovery posts, got %d", cycles, got)
+	}
+
+	// Tear down the session; close() unblocks the reader on the live conn.
+	cancel()
+	pc.close()
+
+	// Drop test-infra keep-alive connections (recovery POSTs) so their transport goroutines do not distort the leak check.
+	s.ts.Client().Transport.(*http.Transport).CloseIdleConnections()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+2 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	t.Fatalf("goroutines grew after reconnect storm: baseline=%d now=%d\n%s", baseline, runtime.NumGoroutine(), buf[:n])
+}
+
+// trackedConn wraps a net.Conn to force write failures and observe Close.
+type trackedConn struct {
+	net.Conn
+	failWrites atomic.Bool
+	closed     atomic.Bool
+}
+
+func (c *trackedConn) Write(b []byte) (int, error) {
+	if c.failWrites.Load() {
+		return 0, errors.New("simulated write failure")
+	}
+	return c.Conn.Write(b)
+}
+
+func (c *trackedConn) Close() error {
+	c.closed.Store(true)
+	return c.Conn.Close()
+}
+
+// TestPtyClose_ClosesConnAfterWriteControlFailure verifies that close() releases the WebSocket connection even when the close handshake fails.
+func TestPtyClose_ClosesConnAfterWriteControlFailure(t *testing.T) {
+	s := newWshServer(t)
+
+	var tracked *trackedConn
+	dialer := websocket.Dialer{
+		NetDial: func(network, addr string) (net.Conn, error) {
+			c, err := net.Dial(network, addr)
+			if err != nil {
+				return nil, err
+			}
+			tracked = &trackedConn{Conn: c}
+			return tracked, nil
+		},
+	}
+	conn, _, err := dialer.Dial(s.wsURL(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pc := &PtyClient{
+		conn:      conn,
+		sessionID: "close-test",
+		manager:   NewTerminalManager(),
+	}
+
+	tracked.failWrites.Store(true)
+	pc.close()
+
+	if !tracked.closed.Load() {
+		t.Fatal("close() did not close the websocket connection after WriteControl failure")
+	}
+}

--- a/pkg/runner/pty_recovery_test.go
+++ b/pkg/runner/pty_recovery_test.go
@@ -105,6 +105,13 @@ func newTestPtyClient(t *testing.T, s *wshServer) *PtyClient {
 	}
 }
 
+// awaitRecovery snapshots the channel the next completed recovery closes; call it before dropping the conn or the completion lands on a generation the test never observed. Production waiters snapshot inline in waitForRecovery instead, sharing one recoveryMu critical section with the conn check and the CAS.
+func (pc *PtyClient) awaitRecovery() <-chan struct{} {
+	pc.recoveryMu.Lock()
+	defer pc.recoveryMu.Unlock()
+	return pc.recoveryDone
+}
+
 func waitRecovered(t *testing.T, done <-chan struct{}, cycle int) {
 	t.Helper()
 	select {
@@ -166,7 +173,6 @@ func TestPtyRecovery_WriteSideOnly(t *testing.T) {
 	}
 }
 
-// TestPtyRecovery_StormNoGoroutineLeak runs repeated reconnects with both sides active and verifies that goroutines do not accumulate and teardown completes.
 func TestPtyRecovery_StormNoGoroutineLeak(t *testing.T) {
 	s := newWshServer(t)
 
@@ -193,7 +199,7 @@ func TestPtyRecovery_StormNoGoroutineLeak(t *testing.T) {
 		t.Fatalf("expected at least %d recovery posts, got %d", cycles, got)
 	}
 
-	// Tear down the session; close() unblocks the reader on the live conn.
+	// close() unblocks the reader still parked on the live conn.
 	cancel()
 	pc.close()
 
@@ -212,7 +218,6 @@ func TestPtyRecovery_StormNoGoroutineLeak(t *testing.T) {
 	t.Fatalf("goroutines grew after reconnect storm: baseline=%d now=%d\n%s", baseline, runtime.NumGoroutine(), buf[:n])
 }
 
-// trackedConn wraps a net.Conn to force write failures and observe Close.
 type trackedConn struct {
 	net.Conn
 	failWrites atomic.Bool
@@ -231,7 +236,6 @@ func (c *trackedConn) Close() error {
 	return c.Conn.Close()
 }
 
-// TestPtyClose_ClosesConnAfterWriteControlFailure verifies that close() releases the WebSocket connection even when the close handshake fails.
 func TestPtyClose_ClosesConnAfterWriteControlFailure(t *testing.T) {
 	s := newWshServer(t)
 


### PR DESCRIPTION
## Background

Repeated Websh reconnects could deadlock the PTY recovery loop. Recovery completion was signalled through two per-side buffered channels (one for the read side, one for the write side), and both were written on every recovery cycle regardless of whether that side was waiting. When only one side detected the drop (for example the write side is idle draining `ptyToWs` because no PTY output is pending), the unconsumed signal for the other side stayed in its buffered channel and satisfied the wait on the next reconnect before that reconnect had actually completed, blocking the loop.

While fixing this I reviewed the surrounding recovery/teardown lifecycle and found several adjacent issues in the same code path (an unsynchronized `pc.conn`, a leaked connection on every reconnect, and teardown that could stall for up to a minute), so this PR addresses them together.

## Changes

Recovery signalling: replace the two per-side buffered channels with a single `recoveryDone` channel that is closed on each completed recovery and then replaced. Closing broadcasts to every waiter at once, so a side that was not waiting cannot leave a stale signal. Callers snapshot the channel via `awaitRecovery` before requesting recovery, so a completion that lands between the request and the wait is not missed.

Connection lifecycle:
- Guard `pc.conn` behind `recoveryMu` via `getConn`/`swapConn`. Previously `recovery()` reassigned the field with no lock while the read and write goroutines still dereferenced it, which is a data race under `-race`.
- `recovery()` now closes the connection it replaces. Before, the old fd leaked on every reconnect, and a reader blocked on a silently dead connection never moved to the new one.
- Derive `recovery()`'s timeout context from the session context instead of `context.Background()`, so cancellation aborts the retry loop instead of delaying `close()` (kill shell, remove PID mapping, unregister) for up to `maxRecoveryTimeout`.
- `close()` now closes the connection even when the close handshake write (`WriteControl`) fails, so a broken connection does not leak its fd.

Refactor: fold the duplicated read/write recovery blocks into a single `waitForRecovery` helper. It also compares the current connection against the one that errored and skips requesting recovery when another side already replaced it, which narrows the window for a redundant reconnect.

## Safety

This code is concurrent (four bridge goroutines plus the recovery loop), so the notable invariant is: `pc.conn` must only be read through `getConn` and written through `swapConn` while the bridge goroutines are running. One behavior is intentionally unchanged: when a `WriteMessage` fails mid-send, the in-flight PTY output chunk is dropped rather than retried after reconnect (terminal output can lose a chunk on reconnect; terminal input is never lost). This matches the previous behavior and avoids a loss-vs-duplicate-output tradeoff; it is called out here rather than silently changed.

## Testing

- `go test ./pkg/runner/ -race -p 1` passes, including four new regression tests driven by a local Websh test double that abruptly drops connections without a close handshake:
  - `ReadSideOnly` / `WriteSideOnly` reproduce the single-side deadlock (both blocked on the second reconnect before the fix).
  - `StormNoGoroutineLeak` verifies goroutines do not accumulate across repeated reconnects and teardown completes.
  - `ClosesConnAfterWriteControlFailure` verifies `close()` releases the connection when the handshake write fails.
- Deployed the built binary to a test server and confirmed the service starts and re-establishes its control/backhaul WebSocket connections.

## Checklist

- [x] Tests pass under the race detector
- [x] No cross-repo/API/schema/proto impact (agent-internal change only)
- [x] Behavior change (write-side reconnect output loss unchanged) documented above

Closes #351
