### PR TITLE
build: bump Go toolchain to 1.25.12 for stdlib vulnerability fixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   verify-tidy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   linter:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ go build -o alpamon ./cmd/alpamon         # native
 GOOS=windows GOARCH=amd64 go build ./cmd/alpamon   # Windows cross-compile
 ```
 
-Go 1.25.10+ is required. `GOPATH/bin` should be on `PATH`. The generated Ent code is gitignored, so run `go generate ./pkg/db/ent` (see below) before the first build.
+Go 1.25.12+ is required. `GOPATH/bin` should be on `PATH`. The generated Ent code is gitignored, so run `go generate ./pkg/db/ent` (see below) before the first build.
 
 ### Generate Ent schema code
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alpacax/alpamon/v2
 
-go 1.25.11
+go 1.25.12
 
 require (
 	entgo.io/ent v0.14.5


### PR DESCRIPTION
## Background

Running `govulncheck ./...` locally against the current toolchain (go1.25.11) reports two standard library vulnerabilities, both fixed in go1.25.12. Neither has a source-level workaround in alpamon: the vulnerable code is the standard library itself, so the fix is the toolchain version. This is the same situation as #354, which bumped 1.25.10 to 1.25.11 for two other stdlib findings.

## Changes

The `go` directive in go.mod goes from 1.25.11 to 1.25.12, and `GO_VERSION` goes to 1.25.12 in build-and-test.yml, lint.yml, and release.yml. All three workflows pass `GO_VERSION` into the `.github/actions/setup-go-generate` composite action, which forwards it verbatim to `actions/setup-go@v6`, so that action needs no change.

No `toolchain` directive is added. The repo pins the exact patch version in the `go` directive and has never carried a `toolchain` directive, so this follows the existing convention rather than introducing a second mechanism.

The README build-from-source floor goes from `Go 1.25.10+` to `Go 1.25.12+`. It was already stale before this change, stating a lower version than go.mod pinned (1.25.11), and building below 1.25.12 leaves both vulnerabilities in the resulting binary.

`Dockerfiles/**` are unchanged. All eight use the floating `FROM golang:1.25` tag, and Docker Hub currently resolves `golang:1.25` and `golang:1.25.12` to the same digest (`sha256:9669c2ed28435af1b8989acb9fd5235346a912016cc8b152b694a9a91dced0a6`), so the distro test images already build with 1.25.12 without a pin change.

## Safety

Both findings are in the Go standard library on go1.25.11, not in alpamon code or its dependencies.

- GO-2026-5856 (`crypto/tls`, Encrypted Client Hello privacy leak). Symbol level, meaning govulncheck found call paths that actually reach it. The four reported traces are `pkg/runner/ftp.go:80` (WebSocket dial into the TLS handshake), `pkg/runner/client.go:234` (WebSocket close writing a control frame), `pkg/executor/handlers/file/file_io_unix.go:25` (HTTP response body read), and `pkg/migrate/migrate.go:473` (HTTP client request).
- GO-2026-4970 (`os`, root escape via symlink plus trailing slash). Package level only: the package is imported, but govulncheck found no call path reaching the vulnerable symbol.

Re-running govulncheck on 1.25.12 reports zero symbol findings and zero package findings.

One finding remains and is deliberately out of scope: GO-2026-5932, reporting that `golang.org/x/crypto/openpgp` is unmaintained and unsafe by design. It is module level, meaning the module is required but the `openpgp` package is never imported, and it carries `Fixed in: N/A`, so no dependency bump resolves it.

## Testing

Verified locally on go1.25.12, from a clean ent regeneration (`git clean -fdx pkg/db/ent && go generate ./pkg/db/ent`), since the generated ent output is gitignored.

| Check | Result |
| --- | --- |
| `go build -v ./cmd/alpamon` | passes |
| `go test ./... -p 1` | exit 0, 45 packages ok, no failures |
| `go mod tidy` | no changes beyond the `go` directive; go.sum untouched |
| `govulncheck ./...` | 0 symbol and 0 package findings, down from 2; 1 module-level finding remains, see Safety |

## Checklist

- [ ] lint green in CI (golangci-lint, govulncheck)
- [ ] verify-tidy green in CI
- [ ] full distro matrix build and test green
