### PR TITLE
feat(system): route Windows upgrade through self-update

### DIFF
--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -180,7 +180,8 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 	case "rhel":
 		cmd = fmt.Sprintf("yum update -y %s", pkgList)
 	case "darwin", "windows":
-		// needAlpamon is always true here: needPam is always false on non-linux (pam unsupported; see pkg/utils/pam.go) and the switch is reached only when needAlpamon||needPam.
+		// needAlpamon is always true here: needPam is always false on non-linux
+		// (pam unsupported; see pkg/utils/pam.go) and the switch is reached only when needAlpamon||needPam.
 		return h.selfUpdate(ctx, latestVersion)
 	default:
 		return 1, fmt.Sprintf("Platform '%s' not supported.", utils.PlatformLike), nil

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -37,6 +37,7 @@ type SystemHandler struct {
 	pool            *pool.Pool
 	versionResolver common.VersionResolver
 	apiSession      common.APISession
+	selfUpdateFn    updater.SelfUpdateFunc // defaults to updater.SelfUpdate; tests inject a fake
 }
 
 // NewSystemHandler creates a new system handler.
@@ -65,6 +66,7 @@ func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClie
 		pool:            pool,
 		versionResolver: versionResolver,
 		apiSession:      apiSession,
+		selfUpdateFn:    updater.SelfUpdate,
 	}
 	return h
 }
@@ -177,10 +179,8 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 		cmd = fmt.Sprintf("apt-get update -y -o Acquire::Retries=3 && apt-get install --only-upgrade %s -y -o Acquire::Retries=3", pkgList)
 	case "rhel":
 		cmd = fmt.Sprintf("yum update -y %s", pkgList)
-	case "darwin":
-		if !needAlpamon {
-			return 0, fmt.Sprintf("Already up-to-date (alpamon: %s). alpamon-pam upgrade is not supported on macOS.", version.Version), nil
-		}
+	case "darwin", "windows":
+		// needAlpamon is always true here: needPam is always false on non-linux (pam unsupported; see pkg/utils/pam.go) and the switch is reached only when needAlpamon||needPam.
 		return h.selfUpdate(ctx, latestVersion)
 	default:
 		return 1, fmt.Sprintf("Platform '%s' not supported.", utils.PlatformLike), nil
@@ -196,7 +196,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 
 // selfUpdate downloads and replaces the binary from GitHub Releases, then triggers restart.
 func (h *SystemHandler) selfUpdate(ctx context.Context, latestVersion string) (int, string, error) {
-	if err := updater.SelfUpdate(ctx, latestVersion, updater.Options{}); err != nil {
+	if err := h.selfUpdateFn(ctx, latestVersion, updater.Options{}); err != nil {
 		return 1, fmt.Sprintf("Self-update failed: %v", err), err
 	}
 

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/alpacax/alpamon/v2/internal/pool"
 	"github.com/alpacax/alpamon/v2/pkg/agent"
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
+	"github.com/alpacax/alpamon/v2/pkg/updater"
+	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"github.com/alpacax/alpamon/v2/pkg/version"
 )
 
@@ -576,5 +578,55 @@ func TestSystemHandler_UnregisterFromConsole_DeleteError(t *testing.T) {
 
 	if mockSession.deleteCallCount() != 1 {
 		t.Fatalf("expected 1 Delete call, got %d", mockSession.deleteCallCount())
+	}
+}
+
+// TestSystemHandler_Upgrade_SelfUpdate: darwin and windows route handleUpgrade through selfUpdateFn instead of returning "not supported".
+func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
+	for _, platform := range []string{"darwin", "windows"} {
+		t.Run(platform, func(t *testing.T) {
+			mockExec := common.NewMockCommandExecutor(t)
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			mockVersions := &MockVersionResolver{
+				LatestVersion: "v9.9.9", // differs from version.Version ("dev") -> needAlpamon
+				PamVersion:    "",       // non-linux -> needPam always false anyway
+			}
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+
+			var called bool
+			var gotVersion string
+			handler.selfUpdateFn = func(_ context.Context, v string, _ updater.Options) error {
+				called = true
+				gotVersion = v
+				return nil
+			}
+
+			originalPlatformLike := utils.PlatformLike
+			utils.SetPlatformLike(platform)
+			t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+			exitCode, output, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !called {
+				t.Errorf("expected selfUpdateFn to be called on %s", platform)
+			}
+			if gotVersion != "v9.9.9" {
+				t.Errorf("expected self-update version v9.9.9, got %q", gotVersion)
+			}
+			if exitCode != 0 {
+				t.Errorf("expected exit code 0, got %d", exitCode)
+			}
+			if strings.Contains(output, "not supported") {
+				t.Errorf("%s should route to self-update, got %q", platform, output)
+			}
+		})
 	}
 }

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -43,6 +44,9 @@ func (o Options) baseURL() string {
 	}
 	return defaultReleaseBaseURL
 }
+
+// SelfUpdateFunc is the signature of SelfUpdate, held as a field so tests can inject a fake.
+type SelfUpdateFunc func(ctx context.Context, latestVersion string, opts Options) error
 
 // SelfUpdate downloads the latest binary from GitHub Releases,
 // verifies its checksum, and replaces the current binary.
@@ -319,12 +323,7 @@ func isMachO(magic []byte) bool {
 		return false
 	}
 	m := [4]byte{magic[0], magic[1], magic[2], magic[3]}
-	for _, v := range machoMagics {
-		if m == v {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(machoMagics, m)
 }
 
 // copyFile copies src to dst with the given permissions.

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -338,10 +338,7 @@ func TestDownloadFile_Oversize(t *testing.T) {
 		chunk := make([]byte, 32*1024)
 		remaining := int64(maxArchiveSize) + 1
 		for remaining > 0 {
-			n := int64(len(chunk))
-			if n > remaining {
-				n = remaining
-			}
+			n := min(int64(len(chunk)), remaining)
 			_, _ = w.Write(chunk[:n])
 			remaining -= n
 		}


### PR DESCRIPTION
## Background

alpamon installed on Windows could not run the upgrade command. The platform switch in `handleUpgrade` had no windows case, so it fell through to default and returned `Platform 'windows' not supported`. Meanwhile the self-update infrastructure in `pkg/updater` (MoveFileEx-based binary replacement, PE/COFF format validation, stale `.old` cleanup) already supported Windows, so only the wiring was missing.

## Changes

Merged windows into the existing darwin case in the `handleUpgrade` switch (`case "darwin", "windows":`) so both route to `selfUpdate`.

The "already up-to-date" early return that used to live in the darwin case was dead code. `handleUpgrade` already returns earlier at the `!needAlpamon && !needPam` guard (system.go:160), and `needPam` is always false on non-linux, so by the time the switch is reached `needAlpamon` is always true. Removed that dead code and documented the invariant with a comment instead.

Introduced a `selfUpdateFn` injection seam on `SystemHandler` (defaulting to `updater.SelfUpdate`) so the darwin/windows routing can be unit-tested without performing a real GitHub Releases download. The test swaps this field for a fake and verifies routing only, with no network access.

## Safety

`needPam` depends on `queryPamVersion()`, which always returns an empty string when `runtime.GOOS != "linux"`, so it is always false on non-linux. The switch dispatches on `utils.PlatformLike`, which in production is derived from `runtime.GOOS`, so `PlatformLike ∈ {darwin, windows}` guarantees `GOOS ≠ linux`. The darwin/windows case is therefore only reached when `needAlpamon == true`, and the up-to-date case is already handled by the guard before the switch.

## Deployment note

Windows agents registered before this change ships need a one-time manual `alpamon register` re-run on the server to pick up the self-update path. Newly registered agents need no action.

## Testing

- `TestSystemHandler_Upgrade_SelfUpdate` (darwin and windows subtests): verifies both platforms route through `selfUpdateFn` and do not return "not supported". Passing.
- `go build ./cmd/alpamon`, `go vet`, and `go test ./pkg/executor/handlers/system/ ./pkg/updater/ -p 1` all pass.
- CI: the `windows-latest` job already runs the full suite, so no workflow change is needed.

## Checklist

- [x] Unit tests added and passing
- [x] build / vet passing
- [ ] Communicate the manual re-registration step for existing Windows agents

Closes #367
