### PR TITLE
fix: report correct broadcast address for 16-byte net.IP

### DIFF
--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -669,13 +669,14 @@ func getFlags(iface net.Interface) int {
 
 func calculateBroadcastAddress(ip net.IP, mask net.IPMask) string {
 	// only ipv4
-	if ip.To4() == nil || len(mask) != net.IPv4len {
+	v4 := ip.To4()
+	if v4 == nil || len(mask) != net.IPv4len {
 		return ""
 	}
 
-	broadcast := make(net.IP, len(ip.To4()))
-	for i := 0; i < len(ip.To4()); i++ {
-		broadcast[i] = ip[i] | ^mask[i]
+	broadcast := make(net.IP, net.IPv4len)
+	for i := range v4 {
+		broadcast[i] = v4[i] | ^mask[i]
 	}
 
 	return broadcast.String()

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -636,11 +636,12 @@ func getNetworkAddresses() ([]Address, error) {
 				ip = v.IP
 				mask = ip.DefaultMask()
 			}
-			if ip == nil || ip.To4() == nil {
+			v4 := ip.To4()
+			if v4 == nil {
 				continue
 			}
 			addresses = append(addresses, Address{
-				Address:       ip.To4().String(),
+				Address:       v4.String(),
 				Broadcast:     calculateBroadcastAddress(ip, mask),
 				InterfaceName: iface.Name,
 				Mask:          net.IP(mask).String(),
@@ -667,8 +668,10 @@ func getFlags(iface net.Interface) int {
 	return flags
 }
 
+// calculateBroadcastAddress returns the IPv4 directed broadcast for ip/mask.
+// It indexes ip.To4(), not ip: net.Interfaces() yields the 16-byte
+// IPv4-in-IPv6 form, where ip[0:4] is the ::ffff: prefix, not the address.
 func calculateBroadcastAddress(ip net.IP, mask net.IPMask) string {
-	// only ipv4
 	v4 := ip.To4()
 	if v4 == nil || len(mask) != net.IPv4len {
 		return ""

--- a/pkg/runner/commit_test.go
+++ b/pkg/runner/commit_test.go
@@ -152,6 +152,12 @@ func TestGetNetworkAddresses(t *testing.T) {
 		assert.NotEmpty(t, addr.Broadcast, "Broadcast address should not be empty.")
 		assert.NotEmpty(t, addr.InterfaceName, "Interface name should not be empty.")
 		assert.NotEmpty(t, addr.Mask, "Mask should not be empty.")
+
+		mask := net.IPMask(net.ParseIP(addr.Mask).To4())
+		ip := net.ParseIP(addr.Address)
+		bcast := net.ParseIP(addr.Broadcast)
+		assert.Equal(t, ip.Mask(mask), bcast.Mask(mask),
+			"Broadcast should be on the same network as the address.")
 	}
 }
 
@@ -166,10 +172,11 @@ func TestCalculateBroadcastAddress(t *testing.T) {
 		{name: "16-byte IP /24", ip: net.IPv4(192, 168, 1, 10), mask: net.CIDRMask(24, 32), want: "192.168.1.255"},
 		{name: "4-byte IP /24", ip: net.IPv4(192, 168, 1, 10).To4(), mask: net.CIDRMask(24, 32), want: "192.168.1.255"},
 		{name: "16-byte IP /8", ip: net.IPv4(127, 0, 0, 1), mask: net.CIDRMask(8, 32), want: "127.255.255.255"},
+		{name: "4-byte IP /8", ip: net.IPv4(127, 0, 0, 1).To4(), mask: net.CIDRMask(8, 32), want: "127.255.255.255"},
 		{name: "16-byte IP /16", ip: net.IPv4(172, 17, 0, 2), mask: net.CIDRMask(16, 32), want: "172.17.255.255"},
 		{name: "16-byte IP /32", ip: net.IPv4(10, 1, 0, 28), mask: net.CIDRMask(32, 32), want: "10.1.0.28"},
 		{name: "IPv6 address", ip: net.ParseIP("2001:db8::1"), mask: net.CIDRMask(24, 32), want: ""},
-		{name: "IPv6 mask", ip: net.IPv4(192, 168, 1, 10), mask: net.CIDRMask(64, 128), want: ""},
+		{name: "16-byte mask", ip: net.IPv4(192, 168, 1, 10), mask: net.CIDRMask(64, 128), want: ""},
 		{name: "nil mask", ip: net.IPv4(192, 168, 1, 10), mask: nil, want: ""},
 	}
 

--- a/pkg/runner/commit_test.go
+++ b/pkg/runner/commit_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"encoding/json"
+	"net"
 	"runtime"
 	"slices"
 	"strings"
@@ -151,6 +152,31 @@ func TestGetNetworkAddresses(t *testing.T) {
 		assert.NotEmpty(t, addr.Broadcast, "Broadcast address should not be empty.")
 		assert.NotEmpty(t, addr.InterfaceName, "Interface name should not be empty.")
 		assert.NotEmpty(t, addr.Mask, "Mask should not be empty.")
+	}
+}
+
+func TestCalculateBroadcastAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   net.IP
+		mask net.IPMask
+		want string
+	}{
+		// net.Interfaces() yields 16-byte IPv4-in-IPv6 IPs on all platforms
+		{name: "16-byte IP /24", ip: net.IPv4(192, 168, 1, 10), mask: net.CIDRMask(24, 32), want: "192.168.1.255"},
+		{name: "4-byte IP /24", ip: net.IPv4(192, 168, 1, 10).To4(), mask: net.CIDRMask(24, 32), want: "192.168.1.255"},
+		{name: "16-byte IP /8", ip: net.IPv4(127, 0, 0, 1), mask: net.CIDRMask(8, 32), want: "127.255.255.255"},
+		{name: "16-byte IP /16", ip: net.IPv4(172, 17, 0, 2), mask: net.CIDRMask(16, 32), want: "172.17.255.255"},
+		{name: "16-byte IP /32", ip: net.IPv4(10, 1, 0, 28), mask: net.CIDRMask(32, 32), want: "10.1.0.28"},
+		{name: "IPv6 address", ip: net.ParseIP("2001:db8::1"), mask: net.CIDRMask(24, 32), want: ""},
+		{name: "IPv6 mask", ip: net.IPv4(192, 168, 1, 10), mask: net.CIDRMask(64, 128), want: ""},
+		{name: "nil mask", ip: net.IPv4(192, 168, 1, 10), mask: nil, want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, calculateBroadcastAddress(tc.ip, tc.mask))
+		})
 	}
 }
 


### PR DESCRIPTION
## Background

`calculateBroadcastAddress` (`pkg/runner/commit.go:670`) used `ip.To4()` to check for IPv4 and to size its loop, but then indexed the original `ip` slice when reading the octets. `net.IP` stores the same IPv4 address in either a 4-byte or a 16-byte IPv4-in-IPv6 form, and in the latter `ip[0..3]` is the `::ffff:` prefix, not the address. The real octets live in `ip[12..15]`.

As a result the computed broadcast address was always the bitwise inverse of the mask. That value flows through `getNetworkAddresses` (`pkg/runner/commit.go:644`) into the `broadcast` field of the system-info commit sent to Alpacon.

Issue #372 was originally filed as darwin-only, but measurement showed it affects every supported platform. Go's stdlib builds interface addresses with `net.IPv4()` on all platforms (`interface_bsd.go`, `interface_linux.go:180`, `interface_windows.go:122`), and `net.IPv4()` always returns the 16-byte form. The issue title and body have been corrected accordingly.

Measured by extracting the pre-fix function verbatim:

| Environment | Interface | Input | Before | Correct |
|---|---|---|---|---|
| macOS | en0 | 10.1.0.24/24 | 0.0.0.255 | 10.1.0.255 |
| macOS | lo0 | 127.0.0.1/8 | 0.255.255.255 | 127.255.255.255 |
| Linux (golang:1.25) | eth0 | 172.17.0.2/16 | 0.0.255.255 | 172.17.255.255 |

Windows is affected by the same stdlib path, but this was confirmed by reading `interface_windows.go:122` rather than by measuring on a Windows host, so it is not listed in the table.

## Changes

Hoist `ip.To4()` into `v4` once and index that instead of the raw `ip`. Both the 4-byte and the 16-byte representation now produce the same result, and the repeated `To4()` call in the loop condition goes away.

The work is split into two commits so that each one is green on its own. The fix comes first, because landing the test first would leave a red commit.

- `9437311 fix(runner)`: the behavior fix in `pkg/runner/commit.go`
- `ad2ec1d test(runner)`: the regression test in `pkg/runner/commit_test.go`

The existing `TestGetNetworkAddresses` only asserted the field was non-empty via `assert.NotEmpty`, so it stayed green against the wrong `0.0.0.255`-style values and could not have caught this. A table test against the pure function was added instead (`pkg/runner/commit_test.go:158`). It pins the 16-byte and 4-byte inputs to the same expected broadcast and covers `/8`, `/16`, `/24`, `/32` masks plus the guard cases (IPv6 address, IPv6-length mask, nil mask). The `/8` and `/16` cases pin the addresses actually measured in the table above.

## Safety

The JSON shape and field set are unchanged; only the `broadcast` value is corrected, so there is no wire format change. The `Address` struct (`pkg/runner/commit_types.go`) was not touched.

Indexing is in bounds: `mask` is checked with `len(mask) != net.IPv4len` before the loop, and `v4` is always 4 bytes when non-nil, so both slices indexed in the loop are the same length.

One thing this PR cannot fix in code: broadcast values already stored in Alpacon for existing servers remain wrong until each server upgrades to this version and re-commits its system info. The bad values are identifiable in the data because they are always the inverted netmask (`0.0.0.255`, `0.0.255.255`, `0.255.255.255`, and so on).

Where the wrong value actually surfaced, traced through the downstream repos:

- alpacon-server stores it as `proc.InterfaceAddress.broadcast` (`proc/models.py`) and serves it from `/api/proc/addresses/` as well as nested under `/api/proc/interfaces/` via `InterfaceSerializer.addresses` (`proc/api/serializers.py`, `proc/api/urls.py`). Any direct API consumer has been reading the wrong value.
- `broadcast` is in `InterfaceAddressViewSet.filterset_fields` (`proc/api/views.py`), so filtering by a real broadcast address returned no rows, since every stored value was of the inverted-netmask form. This is the most concrete practical impact.
- The Django admin lists the column (`proc/admin.py`, `InterfaceAddressAdmin.list_display`), so it was visible to staff there.
- alpacon-web types the field (`src/types/server.ts`, `InfraServerNetworkIF.addresses[].broadcast`) and fetches it through `useInterfacesQuery` (`src/queries/Proc.ts`), but the only component consuming that type, `src/components/servers/detail/lists/NetworkInterfaceList.tsx`, renders just `address.address` and `netmask2CIDR(address.mask)`. Broadcast is not shown in the console UI, so there was no user-visible symptom to notice.
- alpacon-cli has no reference to the field.

The other `broadcast` occurrences in alpacon-web belong to the DHCP and IPAM subnet forms, which are user-entered values unrelated to this agent-reported field. This downstream trace is based on GitHub code search plus reading `NetworkInterfaceList.tsx` in full, so treat the "not rendered anywhere" conclusion as strong but not exhaustively proven.

## Tests

- `go test ./... -p 1` passes, 0 failures
- `go test ./pkg/runner -run TestCalculateBroadcastAddress -v` passes all 8 subtests
- The 4 sixteen-byte cases were confirmed to fail against the pre-fix code before the fix was applied
- `go vet ./pkg/runner` and `gofmt -l pkg/runner` clean
- `grep -rn 'ip\[i\]\|\.To4()\['` over the repo confirms no other occurrence of the same pattern
- gopls `modernize` analyzer reports 0 diagnostics for `pkg/runner`

## Checklist

- [x] Regression test added, verified failing before the fix and passing after
- [x] Both the 4-byte and 16-byte `net.IP` representations covered
- [x] No wire format or JSON field change
- [x] Full test suite, vet, and gofmt pass
- [x] Platform scope error in issue #372 corrected

Closes #372
