### PR TITLE
fix(firewall): map dports in batch firewall rule conversion

### DIFF
--- a/internal/protocol/command.go
+++ b/internal/protocol/command.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
 )
@@ -249,10 +250,11 @@ func (c *CommandData) ToArgs() *common.CommandArgs {
 						rule.DPorts = append(rule.DPorts, int(n))
 					case string:
 						// Not every sender emits numbers: the snapshot-restore
-						// payload carries dports as strings. Dropping one leaves
-						// the rule with no port match, which opens every port on
-						// the protocol.
-						if port, err := strconv.Atoi(n); err == nil {
+						// payload carries dports as strings, split from a stored
+						// "80, 443" without trimming. Dropping an element leaves
+						// the rule short a port, or with no port match at all,
+						// which opens every port on the protocol.
+						if port, err := strconv.Atoi(strings.TrimSpace(n)); err == nil {
 							rule.DPorts = append(rule.DPorts, port)
 						}
 					}

--- a/internal/protocol/command.go
+++ b/internal/protocol/command.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"strconv"
 
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
 )
@@ -243,8 +244,17 @@ func (c *CommandData) ToArgs() *common.CommandArgs {
 			}
 			if v, ok := ruleMap["dports"].([]any); ok {
 				for _, p := range v {
-					if n, ok := p.(float64); ok {
+					switch n := p.(type) {
+					case float64:
 						rule.DPorts = append(rule.DPorts, int(n))
+					case string:
+						// Not every sender emits numbers: the snapshot-restore
+						// payload carries dports as strings. Dropping one leaves
+						// the rule with no port match, which opens every port on
+						// the protocol.
+						if port, err := strconv.Atoi(n); err == nil {
+							rule.DPorts = append(rule.DPorts, port)
+						}
 					}
 				}
 			}

--- a/internal/protocol/command.go
+++ b/internal/protocol/command.go
@@ -241,6 +241,13 @@ func (c *CommandData) ToArgs() *common.CommandArgs {
 			if v, ok := ruleMap["port_end"].(float64); ok {
 				rule.PortEnd = int(v)
 			}
+			if v, ok := ruleMap["dports"].([]any); ok {
+				for _, p := range v {
+					if n, ok := p.(float64); ok {
+						rule.DPorts = append(rule.DPorts, int(n))
+					}
+				}
+			}
 			if v, ok := ruleMap["icmp_type"].(string); ok {
 				rule.ICMPType = v
 			}

--- a/internal/protocol/command_test.go
+++ b/internal/protocol/command_test.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"testing"
 
+	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,17 +45,28 @@ func TestParseCommandData_PackageProxyAbsent(t *testing.T) {
 	}
 }
 
-// TestParseCommandData_BatchRuleDPorts pins the batch rule conversion: a rule
-// carrying dports must reach CommandArgs with its ports intact. Dropping them
-// installs a rule with no port match at all, which opens every port on the
-// protocol instead of the two the console shows.
-func TestParseCommandData_BatchRuleDPorts(t *testing.T) {
+// TestParseCommandData_BatchRuleFields pins the batch rule conversion, which is
+// the only place a firewall rule field is converted: the handler reads nothing
+// off CommandArgs but ChainName, ChainNames, OldRuleID, Operation, RuleID and
+// Rules. Every field is asserted at once so a future drop fails here whichever
+// field it is. dports matters most: dropping it installs a rule with no port
+// match at all, which opens every port on the protocol instead of the two the
+// console shows.
+func TestParseCommandData_BatchRuleFields(t *testing.T) {
 	cmd := &Command{
 		ID:    "fw-batch-1",
 		Shell: "internal",
 		Line:  "batch",
 		Data: `{"chain_name": "ALPACON_INPUT", "operation": "batch", "rules": [
-			{"chain": "INPUT", "protocol": "tcp", "dports": [80, 443], "target": "ACCEPT"},
+			{
+				"chain_name": "ALPACON_INPUT", "method": "insert", "chain": "INPUT",
+				"protocol": "tcp", "port_start": 8000, "port_end": 8010,
+				"dports": [80, 443], "icmp_type": "echo-request",
+				"source": "10.0.0.0/8", "destination": "192.168.0.1",
+				"target": "ACCEPT", "description": "web", "priority": 10,
+				"rule_type": "alpacon", "rule_id": "rule-1", "old_rule_id": "rule-0",
+				"operation": "add"
+			},
 			{"chain": "INPUT", "protocol": "tcp", "port_start": 8000, "port_end": 8010, "target": "ACCEPT"}
 		]}`,
 	}
@@ -65,10 +77,51 @@ func TestParseCommandData_BatchRuleDPorts(t *testing.T) {
 	args := data.ToArgs()
 	require.Len(t, args.Rules, 2)
 
-	assert.Equal(t, []int{80, 443}, args.Rules[0].DPorts)
-	assert.Zero(t, args.Rules[0].PortStart)
+	assert.Equal(t, common.FirewallRule{
+		ChainName:   "ALPACON_INPUT",
+		Method:      "insert",
+		Chain:       "INPUT",
+		Protocol:    "tcp",
+		PortStart:   8000,
+		PortEnd:     8010,
+		DPorts:      []int{80, 443},
+		ICMPType:    "echo-request",
+		Source:      "10.0.0.0/8",
+		Destination: "192.168.0.1",
+		Target:      "ACCEPT",
+		Description: "web",
+		Priority:    10,
+		RuleType:    "alpacon",
+		RuleID:      "rule-1",
+		OldRuleID:   "rule-0",
+		Operation:   "add",
+	}, args.Rules[0])
 
+	// A dports rule must not contaminate a neighbouring range rule.
 	assert.Empty(t, args.Rules[1].DPorts)
 	assert.Equal(t, 8000, args.Rules[1].PortStart)
 	assert.Equal(t, 8010, args.Rules[1].PortEnd)
+}
+
+// TestParseCommandData_BatchRuleDPortsAsStrings covers senders that emit dports
+// as strings rather than numbers, which the snapshot-restore payload does.
+func TestParseCommandData_BatchRuleDPortsAsStrings(t *testing.T) {
+	cmd := &Command{
+		ID:    "fw-batch-2",
+		Shell: "internal",
+		Line:  "batch",
+		Data: `{"chain_name": "ALPACON_INPUT", "operation": "batch", "rules": [
+			{"chain": "INPUT", "protocol": "tcp", "dports": ["80", "443"], "target": "ACCEPT"},
+			{"chain": "INPUT", "protocol": "tcp", "dports": ["80", "not-a-port"], "target": "ACCEPT"}
+		]}`,
+	}
+
+	data, err := cmd.ParseCommandData()
+	require.NoError(t, err)
+
+	args := data.ToArgs()
+	require.Len(t, args.Rules, 2)
+
+	assert.Equal(t, []int{80, 443}, args.Rules[0].DPorts)
+	assert.Equal(t, []int{80}, args.Rules[1].DPorts)
 }

--- a/internal/protocol/command_test.go
+++ b/internal/protocol/command_test.go
@@ -104,7 +104,9 @@ func TestParseCommandData_BatchRuleFields(t *testing.T) {
 }
 
 // TestParseCommandData_BatchRuleDPortsAsStrings covers senders that emit dports
-// as strings rather than numbers, which the snapshot-restore payload does.
+// as strings rather than numbers, which the snapshot-restore payload does. Its
+// elements can carry a leading space: the server stores dports verbatim, so a
+// rule entered as "80, 443" is split into ["80", " 443"] on restore.
 func TestParseCommandData_BatchRuleDPortsAsStrings(t *testing.T) {
 	cmd := &Command{
 		ID:    "fw-batch-2",
@@ -112,7 +114,8 @@ func TestParseCommandData_BatchRuleDPortsAsStrings(t *testing.T) {
 		Line:  "batch",
 		Data: `{"chain_name": "ALPACON_INPUT", "operation": "batch", "rules": [
 			{"chain": "INPUT", "protocol": "tcp", "dports": ["80", "443"], "target": "ACCEPT"},
-			{"chain": "INPUT", "protocol": "tcp", "dports": ["80", "not-a-port"], "target": "ACCEPT"}
+			{"chain": "INPUT", "protocol": "tcp", "dports": ["80", "not-a-port"], "target": "ACCEPT"},
+			{"chain": "INPUT", "protocol": "tcp", "dports": ["80", " 443"], "target": "ACCEPT"}
 		]}`,
 	}
 
@@ -120,8 +123,9 @@ func TestParseCommandData_BatchRuleDPortsAsStrings(t *testing.T) {
 	require.NoError(t, err)
 
 	args := data.ToArgs()
-	require.Len(t, args.Rules, 2)
+	require.Len(t, args.Rules, 3)
 
 	assert.Equal(t, []int{80, 443}, args.Rules[0].DPorts)
 	assert.Equal(t, []int{80}, args.Rules[1].DPorts)
+	assert.Equal(t, []int{80, 443}, args.Rules[2].DPorts)
 }

--- a/internal/protocol/command_test.go
+++ b/internal/protocol/command_test.go
@@ -43,3 +43,32 @@ func TestParseCommandData_PackageProxyAbsent(t *testing.T) {
 		})
 	}
 }
+
+// TestParseCommandData_BatchRuleDPorts pins the batch rule conversion: a rule
+// carrying dports must reach CommandArgs with its ports intact. Dropping them
+// installs a rule with no port match at all, which opens every port on the
+// protocol instead of the two the console shows.
+func TestParseCommandData_BatchRuleDPorts(t *testing.T) {
+	cmd := &Command{
+		ID:    "fw-batch-1",
+		Shell: "internal",
+		Line:  "batch",
+		Data: `{"chain_name": "ALPACON_INPUT", "operation": "batch", "rules": [
+			{"chain": "INPUT", "protocol": "tcp", "dports": [80, 443], "target": "ACCEPT"},
+			{"chain": "INPUT", "protocol": "tcp", "port_start": 8000, "port_end": 8010, "target": "ACCEPT"}
+		]}`,
+	}
+
+	data, err := cmd.ParseCommandData()
+	require.NoError(t, err)
+
+	args := data.ToArgs()
+	require.Len(t, args.Rules, 2)
+
+	assert.Equal(t, []int{80, 443}, args.Rules[0].DPorts)
+	assert.Zero(t, args.Rules[0].PortStart)
+
+	assert.Empty(t, args.Rules[1].DPorts)
+	assert.Equal(t, 8000, args.Rules[1].PortStart)
+	assert.Equal(t, 8010, args.Rules[1].PortEnd)
+}


### PR DESCRIPTION
## Summary

Fixes a field dropped in the batch firewall rule conversion: `CommandData.ToArgs()` never mapped `dports` when converting the `rules` array (`[]map[string]any`) into `common.FirewallRule`, so multi-port rules reached the backend with no port match at all.

## Problem

`dports` was the only one of the 17 `FirewallRule` fields not mapped in the rules-array conversion. A rule created in the console as "allow tcp 80, 443" arrived at the agent with an empty `DPorts`, and the iptables backend simply omits the port match in that case:

```
# intended                                                 # actual (before this fix)
-A INPUT -p tcp -m multiport --dports 80,443 -j ACCEPT  →  -A INPUT -p tcp -j ACCEPT
```

The console shows two ports while the installed rule opens every port on the protocol. `ValidateRule` does not require any port to be present, so the broken rule passed validation silently.

This loop is not one conversion path among several — it is the sole conversion boundary for every firewall rule field. The handler reads nothing off `CommandArgs` except `ChainName`, `ChainNames`, `OldRuleID`, `Operation`, `RuleID` and `Rules`, so the top-level `args.DPorts` / `args.Protocol` / etc. copied at `command.go:164-198` have no reader anywhere in `pkg/executor/handlers/firewall/`. Anything dropped in this loop reaches no backend at all.

## Fix

Add the missing `dports` mapping to the rules conversion loop in `ToArgs()`. JSON numbers unmarshal as `float64`, so numeric elements are asserted as `float64` and converted to `int`, matching the existing `port_start`/`port_end` pattern in the same function. String elements fall back to `strconv.Atoi(strings.TrimSpace(...))`, so a sender that emits `["80", "443"]` — or `["80", " 443"]` — no longer lands in the exact failure this PR fixes through a different door.

Cross-repo contract check: every current server-side sender (batch, add/update, reorder) builds the payload via `FirewallRule.get_arguments()`, which emits `'dports': rule.get_dports_list()` as a list of ints, already stripped. The snapshot-restore path in `firewall/operations.py:261-263` instead builds `'dports': rule_data.get('dports', '').split(',')`, a list of strings split without stripping. Those elements can carry a leading space: `validate_dports` (`firewall/api/serializers.py:278-292`) strips each part for validation but stores `value` verbatim, so a rule entered as "80, 443" is snapshotted as that string and restored as `["80", " 443"]`. Hence the `TrimSpace` — without it the fallback would drop `" 443"` and install the rule one port short, a quieter version of the failure it was added to prevent.

That path is unreachable today because it carries `operation: 'restore'`, which is not among alpamon's firewall sub-operations (`common/types.go:58-63` has only batch, flush, delete, add, update) and is rejected as an unknown operation. The fallback means the day someone adds a `restore` case, that payload does not go live silently portless.

## Tests

- `TestParseCommandData_BatchRuleFields`: a payload populating all 17 rule fields, asserted against a fully populated `common.FirewallRule` in a single `assert.Equal`, so a future drop fails here whichever field it is. A second range rule pins that a `dports` rule does not contaminate its neighbour.
- `TestParseCommandData_BatchRuleDPortsAsStrings`: string `dports` are converted (`["80", "443"]` → `[80 443]`), a space-padded element survives (`["80", " 443"]` → `[80 443]`, the shape restore actually produces), and an unparseable element is skipped rather than poisoning the rule (`["80", "not-a-port"]` → `[80]`).
- Both fail when `internal/protocol/command.go` alone is reverted to the base commit. Dropping only the `TrimSpace` fails the padded case with `expected: []int{80, 443} / actual: []int{80}`.
- `go build ./...`, `go vet ./...`, `gofmt -l .` and `go test ./... -p 1` are clean.

## E2E verification

Verified the full path with a local stack (alpacon-server + celery worker/beat + backhaul-server + proxy-server, all run natively) and a Lima VM (ubuntu 26.04, arm64) running this branch's build as the agent: firewall API (alpacax workspace) → `apply_security_group_task` → Redis Stream → backhaul → alpamon (WebSocket) → iptables.

Batch apply with a dports rule ("8080,9090") plus a range rule (7000-7010):

```
-A INPUT -p tcp -m multiport --dports 8080,9090 -m comment --comment "rule_id:...,type:alpacon" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 7000:7010 -m comment --comment "rule_id:...,type:alpacon" -j ACCEPT
```

Command result: `{"success":true,"applied_rules":2,"rolled_back":false}`

Update apply after PATCHing dports to "8080,9090,9443":

```
-A INPUT -p tcp -m multiport --dports 8080,9090,9443 -m comment --comment "rule_id:...,type:alpacon" -j ACCEPT
```

Since every operation flows through the same conversion loop (`args.Rules[i]`), this exercises the boundary that batch, single add/update and reorder all share. The range rule stayed untouched by dports in both runs.

## Follow-up (not in this PR)

`CommandData.Rules` is `[]map[string]any` and this loop is its only consumer in the tree. All 17 `json` tags on `common.FirewallRule` already match the wire keys the loop asserts by hand, so typing the field as `[]common.FirewallRule` would hand the mapping to `encoding/json`, delete the loop, and make this bug class impossible rather than merely fixed. Left out because strict unmarshaling turns a type mismatch into a hard `ParseCommandData` error instead of a silent skip — arguably the better behavior, but a behavior change well beyond a field-mapping fix.

The server's iptables and nftables adapters also emit `backend`, `table` and `family`, which have no field on `common.FirewallRule`. They do not bite: neither `iptables.go` nor `nftables.go` ever emits a `-t <table>` flag, so alpamon always works on the default table. That is an unimplemented feature rather than a drop this PR should fix.
