### PR TITLE
ci(release): pin GoReleaser version to '~> v2' instead of latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,8 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          # Explicit v2 lock; also silences the per-run 'latest' warning.
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.release-publisher-token.outputs.token }}


### PR DESCRIPTION
## Background

The release workflow runs `goreleaser/goreleaser-action@v7` with `version: latest`, which emits a warning annotation on every release run:

```
You are using 'latest' as default version. Will lock to '~> v2'.
```

Reading the action's source (`src/github.ts`, `getRelease`), `latest` is already resolved to `~> v2` internally. There is no risk of an automatic jump to v3 today, and this change does not alter version resolution.

## Changes

Replace `version: latest` with `version: '~> v2'` in `.github/workflows/release.yml`.

- The "we build with GoReleaser v2" intent now lives in our workflow file instead of the action's internals. If a future action major moves its default lock to `~> v3`, our builds no longer silently follow.
- The `version === 'latest'` branch that emits the warning is no longer taken, so the annotation disappears.

Exact-version pinning (e.g. `v2.12.3`) would buy bit-reproducibility but adds a version-bump chore; left out of scope for this issue.

## Testing

- YAML parse verified.
- The workflow only runs on tag pushes, so the real check is the next release run: the warning annotation should be gone.

Closes #343
