### PR TITLE
fix(runner): send exactly one sudo approval response per request

### DIFF
--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -3,18 +3,22 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
+	"slices"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/alpacax/alpamon/v2/internal/retry"
 	"github.com/alpacax/alpamon/v2/pkg/scheduler"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -58,6 +62,9 @@ func (s *SessionInfo) effectiveKind() string {
 
 type SudoRequest struct {
 	Connection net.Conn
+	// Request is kept whole so whoever finalizes it can answer with the fields
+	// the PAM client sent.
+	Request SudoApprovalRequest
 }
 
 type SudoApprovalRequest struct {
@@ -159,6 +166,10 @@ const (
 	authRetryInitialInterval = 1 * time.Second
 	authRetryMaxInterval     = 10 * time.Second
 	authRetryTimeout         = 25 * time.Second // Less than PAM 30s timeout
+	// authSocketWriteTimeout bounds every write to auth.sock. Session teardown and
+	// Command registration deny leftover requests inline, so a peer that stopped
+	// reading must not stall them.
+	authSocketWriteTimeout = 5 * time.Second
 	// emitConcurrencyLimit caps in-flight access-event emit goroutines.
 	emitConcurrencyLimit = 16
 	// authSocketReadBufferSize bounds a single auth.sock request. The largest
@@ -484,8 +495,13 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 
 	session.Requests[sudoApprovalReq.RequestID] = &SudoRequest{
 		Connection: unixConn,
+		Request:    sudoApprovalReq,
 	}
+	// Created under the registration's lock: a teardown in between would signal a
+	// channel that does not exist yet, leaving this goroutine to its full timeout.
+	completionChan := am.newCompletionChannelLocked(sudoApprovalReq.RequestID)
 	am.mu.Unlock()
+	defer am.removeCompletionChannel(sudoApprovalReq.RequestID)
 
 	log.Debug().
 		Str("request_id", sudoApprovalReq.RequestID).
@@ -494,15 +510,9 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 		Str("command_id", sudoApprovalReq.CommandID).
 		Msg("Alpacon user sudo request")
 
-	completionChan := am.newCompletionChannel(sudoApprovalReq.RequestID)
-
-	// Send Sudo Approval request to the alpacon-server with retry
 	if err := am.sendSudoRequestWithRetry(sudoApprovalReq); err != nil {
 		log.Error().Err(err).Msg("Failed to send sudo_approval request after retries")
-		am.sendSudoApprovalResponse(unixConn, sudoApprovalReq, false, "Communication error")
-		am.cleanupTimeoutRequest(sudoApprovalReq.RequestID, false, "Communication error")
-		am.removeCompletionChannel(sudoApprovalReq.RequestID)
-		_ = unixConn.Close()
+		am.finalizeRequest(sudoApprovalReq.RequestID, "Communication error")
 		return
 	}
 
@@ -514,21 +524,20 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 		// Response received and processed by HandleSudoApprovalResponse
 		log.Debug().Msgf("sudo_approval response received for request %s", sudoApprovalReq.RequestID)
 	case <-time.After(30 * time.Second):
-		// Prevent race condition: check if request still exists before cleanup
-		// (HandleSudoApprovalResponse may have already processed it)
+		// The take under am.mu is what settles the race; this check only keeps the
+		// timeout from warning about a request the response path already took.
 		if am.isRequestPending(sudoApprovalReq.RequestID) {
 			log.Warn().Msg("sudo_approval response timeout")
-			am.cleanupTimeoutRequest(sudoApprovalReq.RequestID, false, "Response timeout")
+			am.finalizeRequest(sudoApprovalReq.RequestID, "Response timeout")
 		} else {
 			log.Debug().Msgf("sudo_approval timeout triggered but request already handled: %s", sudoApprovalReq.RequestID)
 		}
 	case <-am.ctx.Done():
 		log.Debug().Msg("Context cancelled, cleaning up sudo_approval connection")
 		if am.isRequestPending(sudoApprovalReq.RequestID) {
-			am.cleanupTimeoutRequest(sudoApprovalReq.RequestID, false, "Service shutdown")
+			am.finalizeRequest(sudoApprovalReq.RequestID, "Service shutdown")
 		}
 	}
-	am.removeCompletionChannel(sudoApprovalReq.RequestID)
 }
 
 func (am *AuthManager) sendIsAlpconResponse(conn net.Conn, username, groupname string, pid, ppid int, isAlpconUser bool) {
@@ -547,6 +556,7 @@ func (am *AuthManager) sendIsAlpconResponse(conn net.Conn, username, groupname s
 		return
 	}
 
+	_ = conn.SetWriteDeadline(time.Now().Add(authSocketWriteTimeout))
 	_, err = conn.Write(responseJSON)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to send is_alpacon_response")
@@ -554,19 +564,21 @@ func (am *AuthManager) sendIsAlpconResponse(conn net.Conn, username, groupname s
 	}
 }
 
-// sendSudoApprovalResponse is used when there is something wrong sending the sudo approval request to the alpacon-server
-func (am *AuthManager) sendSudoApprovalResponse(conn net.Conn, sudo_approval_req SudoApprovalRequest, approved bool, reason string) {
+// sendSudoApprovalResponse writes the response alpamon itself decided on, for
+// every case the alpacon-server does not answer. Closing the connection is the
+// caller's job.
+func (am *AuthManager) sendSudoApprovalResponse(conn net.Conn, req SudoApprovalRequest, approved bool, reason string) {
 	response := SudoApprovalResponse{
 		Type:         "sudo_approval_response",
-		Username:     sudo_approval_req.Username,
-		Groupname:    sudo_approval_req.Groupname,
-		PID:          sudo_approval_req.PID,
-		PPID:         sudo_approval_req.PPID,
-		Command:      sudo_approval_req.Command,
-		IsAlpconUser: sudo_approval_req.IsAlpconUser,
-		SessionID:    sudo_approval_req.SessionID,
-		CommandID:    sudo_approval_req.CommandID,
-		RequestID:    sudo_approval_req.RequestID,
+		Username:     req.Username,
+		Groupname:    req.Groupname,
+		PID:          req.PID,
+		PPID:         req.PPID,
+		Command:      req.Command,
+		IsAlpconUser: req.IsAlpconUser,
+		SessionID:    req.SessionID,
+		CommandID:    req.CommandID,
+		RequestID:    req.RequestID,
 		Approved:     approved,
 		Reason:       reason,
 	}
@@ -577,28 +589,33 @@ func (am *AuthManager) sendSudoApprovalResponse(conn net.Conn, sudo_approval_req
 		return
 	}
 
+	_ = conn.SetWriteDeadline(time.Now().Add(authSocketWriteTimeout))
 	_, err = conn.Write(responseJSON)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to send sudo_approval_response")
-		return
+		logSudoResponseWriteError(err, req.RequestID)
 	}
 }
 
-// HandleSudoApprovalResponse is used to handle the sudo_approval response from the alpacon-server
+// logSudoResponseWriteError downgrades a client that is already gone to a
+// warning: by the time a denial reaches a torn-down session, sudo has usually
+// exited, and the write fails as a broken pipe, a reset, a closed socket, or
+// authSocketWriteTimeout expiring on a peer that stopped reading.
+func logSudoResponseWriteError(err error, requestID string) {
+	level := zerolog.ErrorLevel
+	if errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, net.ErrClosed) || errors.Is(err, os.ErrDeadlineExceeded) {
+		level = zerolog.WarnLevel
+	}
+	log.WithLevel(level).Err(err).Str("request_id", requestID).Msg("Failed to send sudo_approval_response")
+}
+
+// HandleSudoApprovalResponse owns the response and close for the request it
+// takes, the way finalizeRequest does for the paths alpamon answers itself.
 func (am *AuthManager) HandleSudoApprovalResponse(response SudoApprovalResponse) error {
 	log.Info().Str("request_id", response.RequestID).Bool("approved", response.Approved).Msg("Processing sudo_approval response")
 
 	am.mu.Lock()
-	var sudoRequest *SudoRequest
-
-	for _, session := range am.pidToSessionMap {
-		if req, exists := session.Requests[response.RequestID]; exists {
-			delete(session.Requests, response.RequestID)
-			sudoRequest = req
-			log.Debug().Msgf("Found Alpacon user request for ID: %s", response.RequestID)
-			break
-		}
-	}
+	sudoRequest := am.takeRequestLocked(response.RequestID)
 	am.mu.Unlock()
 
 	if sudoRequest == nil {
@@ -607,6 +624,9 @@ func (am *AuthManager) HandleSudoApprovalResponse(response SudoApprovalResponse)
 			log.Debug().Msgf("Session %s requests: %+v", session.SessionID, session.Requests)
 		}
 		am.mu.RUnlock()
+
+		// Routine after a timeout: the waiter already answered and deregistered.
+		log.Warn().Str("request_id", response.RequestID).Msg("No pending sudo_approval request for response")
 
 		return fmt.Errorf("no pending sudo_approval request found for request_id: %s", response.RequestID)
 	}
@@ -617,36 +637,37 @@ func (am *AuthManager) HandleSudoApprovalResponse(response SudoApprovalResponse)
 		return err
 	}
 
+	// The request is already deregistered, so nobody else can reclaim this
+	// connection, and the waiter has to be released whether the write landed or not.
+	_ = sudoRequest.Connection.SetWriteDeadline(time.Now().Add(authSocketWriteTimeout))
 	_, err = sudoRequest.Connection.Write(responseJSON)
+	_ = sudoRequest.Connection.Close()
+	am.signalCompletion(response.RequestID)
 	if err != nil {
-		if strings.Contains(err.Error(), "broken pipe") || strings.Contains(err.Error(), "EPIPE") {
-			log.Warn().Err(err).Str("request_id", response.RequestID).
-				Msg("Unix socket broken pipe - client disconnected (expected if timeout)")
-		} else {
-			log.Error().Err(err).Msg("Failed to send sudo_approval_response")
-		}
+		logSudoResponseWriteError(err, response.RequestID)
 		return err
 	}
-
-	_ = sudoRequest.Connection.Close()
-
-	// Signal completion to unblock the waiting goroutine
-	am.signalCompletion(response.RequestID)
 
 	log.Info().Str("request_id", response.RequestID).Bool("approved", response.Approved).Str("error_code", response.ErrorCode).Msg("SudoApprovalResponse processed successfully")
 	return nil
 }
 
-// AddPIDSessionMapping registers an entry for a Websh PTY session.
-// Kind and StartedAt are filled in when unset so callers don't have to
-// remember to populate them; CommandID is always cleared to keep the
-// websh/command fields mutually exclusive per entry.
+// AddPIDSessionMapping registers an entry for a Websh PTY session. Unset Kind,
+// Requests, StartedAt and PID are filled in; CommandID is always cleared to keep
+// the websh and command fields mutually exclusive per entry.
 func (am *AuthManager) AddPIDSessionMapping(pid int, session *SessionInfo) {
 	if session == nil {
 		return
 	}
+
+	am.mu.Lock()
+	// Filled in under the lock: re-registering the entry already installed for
+	// this pid writes fields a concurrent lookup is reading.
 	if session.Kind == "" {
 		session.Kind = TrackerKindWebsh
+	}
+	if session.Requests == nil {
+		session.Requests = make(map[string]*SudoRequest)
 	}
 	session.CommandID = ""
 	if session.StartedAt.IsZero() {
@@ -655,15 +676,33 @@ func (am *AuthManager) AddPIDSessionMapping(pid int, session *SessionInfo) {
 	if session.PID == 0 {
 		session.PID = pid
 	}
-	am.mu.Lock()
-	am.pidToSessionMap[pid] = session
+	replaced := am.putSessionLocked(pid, session)
 	am.mu.Unlock()
+
+	am.denyPendingRequests(replaced, "Session replaced")
+}
+
+// putSessionLocked installs the entry for pid and hands the pending requests of
+// the entry it displaces to the caller, who owns answering them—otherwise they
+// wait out the PAM client's own timeout. Callers must hold am.mu.
+func (am *AuthManager) putSessionLocked(pid int, session *SessionInfo) []*SudoRequest {
+	var replaced []*SudoRequest
+
+	if old, exists := am.pidToSessionMap[pid]; exists && old != session {
+		replaced = takePendingRequestsLocked(old)
+	}
+	am.pidToSessionMap[pid] = session
+
+	return replaced
 }
 
 func (am *AuthManager) RemovePIDSessionMapping(pid int) {
+	var pending []*SudoRequest
+
 	am.mu.Lock()
 	if session, exists := am.pidToSessionMap[pid]; exists {
 		delete(am.pidToSessionMap, pid)
+		pending = takePendingRequestsLocked(session)
 		log.Debug().
 			Int("pid", pid).
 			Str("kind", session.effectiveKind()).
@@ -672,16 +711,15 @@ func (am *AuthManager) RemovePIDSessionMapping(pid int) {
 			Msg("PID mapping removed")
 	}
 	am.mu.Unlock()
+
+	am.denyPendingRequests(pending, "Session ended")
 }
 
 // AddPIDCommandMapping registers the root pid of a deploy shell Command
-// execution so alpamon-pam can attribute a sudo call made inside the
-// Command (or any descendant) to the originating Command.ID. It must be
-// called before the child process can exec sudo to avoid a race where
-// sudo arrives at the PAM module before the tracker knows about the pid.
-//
-// Concurrency: multiple Commands run in parallel with distinct root pids,
-// so entries never collide. Safe to call from any goroutine.
+// execution so alpamon-pam can attribute a sudo call made inside the Command
+// (or any descendant) to the originating Command.ID. It must be called before
+// the child process can exec sudo, or sudo reaches the PAM module before the
+// tracker knows about the pid. Safe to call from any goroutine.
 func (am *AuthManager) AddPIDCommandMapping(pid int, commandID, username string) {
 	if pid <= 0 || commandID == "" {
 		return
@@ -695,8 +733,11 @@ func (am *AuthManager) AddPIDCommandMapping(pid int, commandID, username string)
 		Requests:  make(map[string]*SudoRequest),
 	}
 	am.mu.Lock()
-	am.pidToSessionMap[pid] = info
+	replaced := am.putSessionLocked(pid, info)
 	am.mu.Unlock()
+
+	am.denyPendingRequests(replaced, "Session replaced")
+
 	log.Debug().
 		Int("pid", pid).
 		Str("command_id", commandID).
@@ -713,11 +754,14 @@ func (am *AuthManager) RemovePIDCommandMapping(pid int, commandID string) {
 	if pid <= 0 || commandID == "" {
 		return
 	}
+	var pending []*SudoRequest
+
 	am.mu.Lock()
 	if existing, ok := am.pidToSessionMap[pid]; ok {
 		if existing.effectiveKind() == TrackerKindCommand &&
 			existing.CommandID == commandID {
 			delete(am.pidToSessionMap, pid)
+			pending = takePendingRequestsLocked(existing)
 			log.Debug().
 				Int("pid", pid).
 				Str("command_id", existing.CommandID).
@@ -725,11 +769,12 @@ func (am *AuthManager) RemovePIDCommandMapping(pid int, commandID string) {
 		}
 	}
 	am.mu.Unlock()
+
+	am.denyPendingRequests(pending, "Session ended")
 }
 
-// TrackerEntry is a read-only snapshot of a tracker entry, returned by
-// LookupPID for callers (e.g. tests) that need to inspect state without
-// taking the AuthManager's lock themselves.
+// TrackerEntry is a read-only snapshot of a tracker entry, returned by LookupPID
+// so callers can inspect state without taking the AuthManager's lock.
 type TrackerEntry struct {
 	Kind      string
 	SessionID string
@@ -776,13 +821,13 @@ func RegisterCommandPID(pid int, commandID, username string) func() {
 	return func() { am.RemovePIDCommandMapping(pid, commandID) }
 }
 
-// Capacity 1 is load-bearing: signalCompletion sends without blocking, so an
-// unbuffered channel drops the signal when the response beats the waiter's select.
-func (am *AuthManager) newCompletionChannel(requestID string) chan struct{} {
+// newCompletionChannelLocked registers the channel its waiter parks on. Capacity 1
+// is load-bearing: signalCompletion sends without blocking, so an unbuffered
+// channel drops a signal that beats the waiter's select. Callers must hold am.mu;
+// the channel has to appear in the same critical section as its request.
+func (am *AuthManager) newCompletionChannelLocked(requestID string) chan struct{} {
 	ch := make(chan struct{}, 1)
-	am.mu.Lock()
 	am.completionChannels[requestID] = ch
-	am.mu.Unlock()
 
 	return ch
 }
@@ -831,21 +876,59 @@ func (am *AuthManager) Stop() {
 	}
 }
 
-func (am *AuthManager) cleanupTimeoutRequest(requestID string, approved bool, reason string) {
+// finalizeRequest is the single owner of the final response and close for a
+// registered request: the PAM client parses everything it reads as one JSON
+// document, so a second response breaks it. Whoever removes the request from the
+// map under am.mu finalizes it, and nobody else may write to or close its
+// connection. It always denies—approvals arrive from the server and are answered
+// by HandleSudoApprovalResponse.
+func (am *AuthManager) finalizeRequest(requestID, reason string) {
 	am.mu.Lock()
+	req := am.takeRequestLocked(requestID)
+	am.mu.Unlock()
 
+	if req == nil {
+		log.Warn().Msgf("No pending sudo request to finalize: %s", requestID)
+		return
+	}
+
+	am.denyPendingRequests([]*SudoRequest{req}, reason)
+}
+
+// takeRequestLocked deregisters one request by id and hands its response and
+// close to the caller; takePendingRequestsLocked does the same for a whole
+// session. Deregistering nowhere else is what keeps a request from being answered
+// twice. Callers must hold am.mu.
+func (am *AuthManager) takeRequestLocked(requestID string) *SudoRequest {
 	for _, session := range am.pidToSessionMap {
 		if req, exists := session.Requests[requestID]; exists {
 			delete(session.Requests, requestID)
-			am.mu.Unlock()
-			if req.Connection != nil {
-				am.sendSudoApprovalResponse(req.Connection, SudoApprovalRequest{RequestID: requestID}, approved, reason)
-				_ = req.Connection.Close()
-			}
-			return
+			return req
 		}
 	}
 
-	am.mu.Unlock()
-	log.Warn().Msgf("Timeout request not found: %s", requestID)
+	return nil
+}
+
+// takePendingRequestsLocked detaches a session's pending requests. They are then
+// beyond finalizeRequest's reach, so the taker owns answering and closing them.
+// Callers must hold am.mu.
+func takePendingRequestsLocked(session *SessionInfo) []*SudoRequest {
+	pending := slices.Collect(maps.Values(session.Requests))
+	clear(session.Requests)
+	return pending
+}
+
+// denyPendingRequests answers each detached request, closes its connection, and
+// releases the goroutine waiting on it—which would otherwise hold an answered
+// request until its own 30s timeout. Must run without am.mu held: signalCompletion
+// takes it.
+func (am *AuthManager) denyPendingRequests(pending []*SudoRequest, reason string) {
+	for _, req := range pending {
+		if req.Connection != nil {
+			am.sendSudoApprovalResponse(req.Connection, req.Request, false, reason)
+			_ = req.Connection.Close()
+		}
+		am.signalCompletion(req.Request.RequestID)
+	}
 }

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -560,8 +560,7 @@ func (am *AuthManager) sendIsAlpconResponse(conn net.Conn, username, groupname s
 	_ = conn.SetWriteDeadline(time.Now().Add(authSocketWriteTimeout))
 	_, err = conn.Write(responseJSON)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to send is_alpacon_response")
-		return
+		log.WithLevel(authSocketWriteLevel(err)).Err(err).Msg("Failed to send is_alpacon_response")
 	}
 }
 
@@ -597,17 +596,21 @@ func (am *AuthManager) sendSudoApprovalResponse(conn net.Conn, req SudoApprovalR
 	}
 }
 
-// logSudoResponseWriteError downgrades a client that is already gone to a
-// warning: by the time a denial reaches a torn-down session, sudo has usually
-// exited, and the write fails as a broken pipe, a reset, a closed socket, or
-// authSocketWriteTimeout expiring on a peer that stopped reading.
-func logSudoResponseWriteError(err error, requestID string) {
-	level := zerolog.ErrorLevel
+// authSocketWriteLevel downgrades a client that is already gone to a warning:
+// by the time a response reaches a torn-down session, the PAM client has
+// usually exited, and the write fails as a broken pipe, a reset, a closed
+// socket, or authSocketWriteTimeout expiring on a peer that stopped reading.
+func authSocketWriteLevel(err error) zerolog.Level {
 	if errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) ||
 		errors.Is(err, net.ErrClosed) || errors.Is(err, os.ErrDeadlineExceeded) {
-		level = zerolog.WarnLevel
+		return zerolog.WarnLevel
 	}
-	log.WithLevel(level).Err(err).Str("request_id", requestID).Msg("Failed to send sudo_approval_response")
+
+	return zerolog.ErrorLevel
+}
+
+func logSudoResponseWriteError(err error, requestID string) {
+	log.WithLevel(authSocketWriteLevel(err)).Err(err).Str("request_id", requestID).Msg("Failed to send sudo_approval_response")
 }
 
 // HandleSudoApprovalResponse owns the response and close for the request it

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -521,8 +521,9 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 	// Wait for response, timeout, or context cancellation
 	select {
 	case <-completionChan:
-		// Response received and processed by HandleSudoApprovalResponse
-		log.Debug().Msgf("sudo_approval response received for request %s", sudoApprovalReq.RequestID)
+		// Signaled by whoever took the request: HandleSudoApprovalResponse on a
+		// server response, denyPendingRequests on a locally decided deny.
+		log.Debug().Str("request_id", sudoApprovalReq.RequestID).Msg("sudo_approval request answered")
 	case <-time.After(30 * time.Second):
 		// The take under am.mu is what settles the race; this check only keeps the
 		// timeout from warning about a request the response path already took.
@@ -626,7 +627,7 @@ func (am *AuthManager) HandleSudoApprovalResponse(response SudoApprovalResponse)
 		am.mu.RUnlock()
 
 		// Routine after a timeout: the waiter already answered and deregistered.
-		log.Warn().Str("request_id", response.RequestID).Msg("No pending sudo_approval request for response")
+		log.Debug().Str("request_id", response.RequestID).Msg("No pending sudo_approval request for response")
 
 		return fmt.Errorf("no pending sudo_approval request found for request_id: %s", response.RequestID)
 	}

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -623,12 +623,6 @@ func (am *AuthManager) HandleSudoApprovalResponse(response SudoApprovalResponse)
 	am.mu.Unlock()
 
 	if sudoRequest == nil {
-		am.mu.RLock()
-		for _, session := range am.pidToSessionMap {
-			log.Debug().Msgf("Session %s requests: %+v", session.SessionID, session.Requests)
-		}
-		am.mu.RUnlock()
-
 		// Routine after a timeout: the waiter already answered and deregistered.
 		log.Debug().Str("request_id", response.RequestID).Msg("No pending sudo_approval request for response")
 

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -888,7 +888,11 @@ func (am *AuthManager) finalizeRequest(requestID, reason string) {
 	am.mu.Unlock()
 
 	if req == nil {
-		log.Warn().Msgf("No pending sudo request to finalize: %s", requestID)
+		// Routine: the server response or a session teardown took the request first.
+		log.Debug().
+			Str("request_id", requestID).
+			Str("reason", reason).
+			Msg("No pending sudo request to finalize")
 		return
 	}
 

--- a/pkg/runner/auth_manager_cleanup_test.go
+++ b/pkg/runner/auth_manager_cleanup_test.go
@@ -1,0 +1,378 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// registerPipeRequest registers a pending request the way handleSudoApprovalRequest
+// does, minus the completion channel—tests that need one add it with
+// registerCompletionChannel.
+func registerPipeRequest(am *AuthManager, req SudoApprovalRequest) net.Conn {
+	client, server := net.Pipe()
+	am.pidToSessionMap[req.PID] = &SessionInfo{
+		Kind:      TrackerKindWebsh,
+		SessionID: req.SessionID,
+		PID:       req.PID,
+		Requests: map[string]*SudoRequest{
+			req.RequestID: {Connection: server, Request: req},
+		},
+	}
+	return client
+}
+
+// expectSingleResponse decodes the one response the connection is allowed to
+// carry and asserts the write was followed by a close.
+func expectSingleResponse(t *testing.T, client net.Conn) SudoApprovalResponse {
+	t.Helper()
+
+	// Without this a regression hangs until the suite-wide panic instead of failing here.
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	dec := json.NewDecoder(client)
+	var resp SudoApprovalResponse
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	// EOF proves both: no second response, and the connection was closed.
+	if err := dec.Decode(&resp); !errors.Is(err, io.EOF) {
+		t.Errorf("expected EOF after single response, got %v", err)
+	}
+	return resp
+}
+
+// TestFinalizeRequest_SendsSingleFullResponseAndCloses pins the one-response rule:
+// the PAM client parses all it reads until EOF as one JSON document (alpamon-pam
+// alpacon_approval.c), so a second response would break it.
+func TestFinalizeRequest_SendsSingleFullResponseAndCloses(t *testing.T) {
+	am := newTestAuthManager()
+	req := SudoApprovalRequest{
+		RequestID: "req-1",
+		Username:  "alice",
+		Groupname: "wheel",
+		PID:       4242,
+		PPID:      4200,
+		Command:   "sudo systemctl restart nginx",
+		SessionID: "sess-1",
+	}
+	client := registerPipeRequest(am, req)
+
+	// net.Pipe is unbuffered, so the write has to run against this goroutine's reads.
+	go am.finalizeRequest(req.RequestID, "Communication error")
+
+	want := SudoApprovalResponse{
+		RequestID: "req-1",
+		Type:      "sudo_approval_response",
+		Username:  "alice",
+		Groupname: "wheel",
+		PID:       4242,
+		PPID:      4200,
+		Command:   "sudo systemctl restart nginx",
+		SessionID: "sess-1",
+		Reason:    "Communication error",
+	}
+	if resp := expectSingleResponse(t, client); resp != want {
+		t.Errorf("response: got %+v, want %+v", resp, want)
+	}
+
+	// finalizeRequest deregisters before it writes, so the close seen above
+	// means the deletion already happened.
+	if _, exists := am.pidToSessionMap[4242].Requests["req-1"]; exists {
+		t.Error("request was not deregistered")
+	}
+}
+
+// TestFinalizeRequest_UnknownRequestIsNoop covers a request HandleSudoApprovalResponse
+// already took: finalizing it must leave every other pending request alone.
+func TestFinalizeRequest_UnknownRequestIsNoop(t *testing.T) {
+	am := newTestAuthManager()
+	pending := SudoApprovalRequest{RequestID: "req-pending", PID: 2, SessionID: "sess-2"}
+	registerPipeRequest(am, pending)
+
+	am.finalizeRequest("req-gone", "Response timeout")
+
+	if _, exists := am.pidToSessionMap[2].Requests["req-pending"]; !exists {
+		t.Error("an unrelated pending request was dropped")
+	}
+}
+
+// TestFinalizeRequest_RacesHandleResponse is the race the single-ownership rule
+// exists for: a server response arriving at the same moment the request gives up.
+// Both paths delete under am.mu, so only the winner finds the request and writes.
+func TestFinalizeRequest_RacesHandleResponse(t *testing.T) {
+	am := newTestAuthManager()
+	req := SudoApprovalRequest{RequestID: "req-race", Username: "alice", PID: 3333, SessionID: "sess-race"}
+	client := registerPipeRequest(am, req)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		am.finalizeRequest(req.RequestID, "Response timeout")
+	}()
+	go func() {
+		defer wg.Done()
+		_ = am.HandleSudoApprovalResponse(SudoApprovalResponse{
+			RequestID: req.RequestID,
+			Type:      "sudo_approval_response",
+			Approved:  true,
+			Username:  "alice",
+			PID:       3333,
+			SessionID: "sess-race",
+		})
+	}()
+
+	resp := expectSingleResponse(t, client)
+	if resp.RequestID != req.RequestID {
+		t.Errorf("request_id: got %q, want %q", resp.RequestID, req.RequestID)
+	}
+	// Exactly one of the two wrote, so the response is wholly one path's or
+	// wholly the other's—never a mix.
+	approval := resp.Approved && resp.Reason == ""
+	timeout := !resp.Approved && resp.Reason == "Response timeout"
+	if !approval && !timeout {
+		t.Errorf("response belongs to neither path: %+v", resp)
+	}
+
+	wg.Wait()
+}
+
+// TestRemovePIDSessionMapping_DeniesPendingRequestsAndSignalsWaiter checks both
+// halves of the remover's job for requests it puts out of finalizeRequest's reach:
+// answering and closing them, or the PAM client waits out its own timeout and falls
+// back to its fail-open setting, and signalling handleSudoApprovalRequest, which is
+// still parked on the completion channel holding an already-answered request.
+func TestRemovePIDSessionMapping_DeniesPendingRequestsAndSignalsWaiter(t *testing.T) {
+	am := newTestAuthManager()
+	req := SudoApprovalRequest{
+		RequestID: "req-websh",
+		Username:  "alice",
+		PID:       7777,
+		Command:   "sudo reboot",
+		SessionID: "sess-websh",
+	}
+	client := registerPipeRequest(am, req)
+	completion := registerCompletionChannel(am, req.RequestID)
+
+	go am.RemovePIDSessionMapping(7777)
+
+	want := SudoApprovalResponse{
+		RequestID: "req-websh",
+		Type:      "sudo_approval_response",
+		Username:  "alice",
+		PID:       7777,
+		Command:   "sudo reboot",
+		SessionID: "sess-websh",
+		Reason:    "Session ended",
+	}
+	if resp := expectSingleResponse(t, client); resp != want {
+		t.Errorf("response: got %+v, want %+v", resp, want)
+	}
+
+	select {
+	case <-completion:
+	case <-time.After(2 * time.Second):
+		t.Error("waiter was never signaled")
+	}
+}
+
+// TestHandleSudoApprovalResponse_SignalsWaiterOnWriteFailure covers a client that
+// gave up before the server answered: the write fails, but the request is already
+// deregistered, so nothing else will ever release the waiter.
+func TestHandleSudoApprovalResponse_SignalsWaiterOnWriteFailure(t *testing.T) {
+	am := newTestAuthManager()
+	req := SudoApprovalRequest{RequestID: "req-dead", Username: "alice", PID: 9999, SessionID: "sess-dead"}
+	client := registerPipeRequest(am, req)
+	completion := registerCompletionChannel(am, req.RequestID)
+	_ = client.Close()
+
+	err := am.HandleSudoApprovalResponse(SudoApprovalResponse{
+		RequestID: req.RequestID,
+		Type:      "sudo_approval_response",
+		Approved:  true,
+		Username:  "alice",
+		PID:       9999,
+		SessionID: "sess-dead",
+	})
+	if err == nil {
+		t.Error("a write to a closed client should be reported")
+	}
+
+	select {
+	case <-completion:
+	default:
+		t.Error("waiter was never signaled")
+	}
+}
+
+// TestAddPIDSessionMapping_SameEntryKeepsRequests checks re-registering the entry
+// already installed for a pid displaces nothing. The connection is closed up front:
+// a regression that denied them would fail its write instead of blocking on net.Pipe.
+func TestAddPIDSessionMapping_SameEntryKeepsRequests(t *testing.T) {
+	am := newTestAuthManager()
+	req := SudoApprovalRequest{RequestID: "req-same", Username: "alice", PID: 1212, SessionID: "sess-same"}
+	client := registerPipeRequest(am, req)
+	_ = client.Close()
+	session := am.pidToSessionMap[1212]
+
+	am.AddPIDSessionMapping(1212, session)
+
+	if _, exists := session.Requests[req.RequestID]; !exists {
+		t.Error("re-registering the same entry dropped its pending request")
+	}
+}
+
+// TestAddPIDSessionMapping_DeniesReplacedRequests covers a pid reused by a new
+// session: overwriting puts the old entry's requests out of reach just as removing
+// it does, so the replacement has to answer them too.
+func TestAddPIDSessionMapping_DeniesReplacedRequests(t *testing.T) {
+	am := newTestAuthManager()
+	req := SudoApprovalRequest{RequestID: "req-stale", Username: "alice", PID: 5555, SessionID: "sess-old"}
+	client := registerPipeRequest(am, req)
+
+	go am.AddPIDSessionMapping(5555, &SessionInfo{
+		SessionID: "sess-new",
+		PID:       5555,
+		Requests:  map[string]*SudoRequest{},
+	})
+
+	want := SudoApprovalResponse{
+		RequestID: "req-stale",
+		Type:      "sudo_approval_response",
+		Username:  "alice",
+		PID:       5555,
+		SessionID: "sess-old",
+		Reason:    "Session replaced",
+	}
+	if resp := expectSingleResponse(t, client); resp != want {
+		t.Errorf("response: got %+v, want %+v", resp, want)
+	}
+}
+
+func TestAddPIDCommandMapping_DeniesReplacedRequests(t *testing.T) {
+	am := newTestAuthManager()
+	req := SudoApprovalRequest{RequestID: "req-stale-cmd", Username: "bob", PID: 6666}
+	client := registerPipeRequest(am, req)
+
+	go am.AddPIDCommandMapping(6666, "cmd-new", "bob")
+
+	want := SudoApprovalResponse{
+		RequestID: "req-stale-cmd",
+		Type:      "sudo_approval_response",
+		Username:  "bob",
+		PID:       6666,
+		Reason:    "Session replaced",
+	}
+	if resp := expectSingleResponse(t, client); resp != want {
+		t.Errorf("response: got %+v, want %+v", resp, want)
+	}
+}
+
+// TestHandleSudoApprovalRequest_RetryFailureAnswersOnce is issue #396 itself: the
+// retry-failure path used to write its own response and close, then leave the
+// still-registered request for a second response and close. The cancelled context
+// fails the retry immediately instead of spending its 25s budget.
+func TestHandleSudoApprovalRequest_RetryFailureAnswersOnce(t *testing.T) {
+	am := newTestAuthManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	am.ctx = ctx
+	am.pidToSessionMap[4200] = &SessionInfo{
+		Kind:      TrackerKindWebsh,
+		SessionID: "sess-retry",
+		PID:       4200,
+		Requests:  make(map[string]*SudoRequest),
+	}
+	data, err := json.Marshal(SudoApprovalRequest{
+		RequestID: "req-retry",
+		Type:      "sudo_approval",
+		Username:  "alice",
+		PID:       424242,
+		PPID:      4200,
+		Command:   "sudo reboot",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, server := net.Pipe()
+
+	go am.handleSudoApprovalRequest(data, server)
+
+	want := SudoApprovalResponse{
+		RequestID:    "req-retry",
+		Type:         "sudo_approval_response",
+		Username:     "alice",
+		PID:          424242,
+		PPID:         4200,
+		Command:      "sudo reboot",
+		IsAlpconUser: true,
+		SessionID:    "sess-retry",
+		Reason:       "Communication error",
+	}
+	if resp := expectSingleResponse(t, client); resp != want {
+		t.Errorf("response: got %+v, want %+v", resp, want)
+	}
+	if _, exists := am.pidToSessionMap[4200].Requests["req-retry"]; exists {
+		t.Error("request was not deregistered")
+	}
+}
+
+// TestHandleSudoApprovalRequest_LocalSudoRegistersNothing checks a sudo outside any
+// tracked session is answered on the spot and registers nothing—no request, and no
+// completion channel for a waiter that never exists.
+func TestHandleSudoApprovalRequest_LocalSudoRegistersNothing(t *testing.T) {
+	am := newTestAuthManager()
+	data, err := json.Marshal(SudoApprovalRequest{
+		RequestID: "req-local",
+		Type:      "sudo_approval",
+		Username:  "alice",
+		PID:       999999,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, server := net.Pipe()
+
+	go am.handleSudoApprovalRequest(data, server)
+
+	resp := expectSingleResponse(t, client)
+	if !resp.Approved || resp.IsAlpconUser {
+		t.Errorf("local sudo response: got %+v, want approved non-Alpacon", resp)
+	}
+	if len(am.completionChannels) != 0 {
+		t.Errorf("completion channels left behind: %v", am.completionChannels)
+	}
+	if len(am.pidToSessionMap) != 0 {
+		t.Errorf("tracker entries left behind: %v", am.pidToSessionMap)
+	}
+}
+
+func TestRemovePIDCommandMapping_DeniesPendingRequests(t *testing.T) {
+	am := newTestAuthManager()
+	req := SudoApprovalRequest{RequestID: "req-cmd", Username: "bob", PID: 8888}
+	client := registerPipeRequest(am, req)
+	session := am.pidToSessionMap[8888]
+	session.Kind = TrackerKindCommand
+	session.SessionID = ""
+	session.CommandID = "cmd-1"
+
+	go am.RemovePIDCommandMapping(8888, "cmd-1")
+
+	want := SudoApprovalResponse{
+		RequestID: "req-cmd",
+		Type:      "sudo_approval_response",
+		Username:  "bob",
+		PID:       8888,
+		Reason:    "Session ended",
+	}
+	if resp := expectSingleResponse(t, client); resp != want {
+		t.Errorf("response: got %+v, want %+v", resp, want)
+	}
+}

--- a/pkg/runner/auth_manager_completion_test.go
+++ b/pkg/runner/auth_manager_completion_test.go
@@ -5,12 +5,21 @@ import (
 	"time"
 )
 
-// The channel must come from newCompletionChannel, not from the test: a channel
-// the test allocates itself would keep passing after the production capacity is
-// dropped, pinning nothing.
+// registerCompletionChannel mirrors what handleSudoApprovalRequest does inside
+// its registration critical section.
+func registerCompletionChannel(am *AuthManager, requestID string) chan struct{} {
+	am.mu.Lock()
+	defer am.mu.Unlock()
+
+	return am.newCompletionChannelLocked(requestID)
+}
+
+// TestNewCompletionChannel_SurvivesSignalBeforeReceive takes its channel from
+// newCompletionChannelLocked: one the test allocates itself would keep passing
+// after the production capacity is dropped.
 func TestNewCompletionChannel_SurvivesSignalBeforeReceive(t *testing.T) {
 	am := newTestAuthManager()
-	ch := am.newCompletionChannel("req-1")
+	ch := registerCompletionChannel(am, "req-1")
 
 	// The websocket read loop can process the response while the waiter is still
 	// inside sendSudoRequestWithRetry, before it reaches its select.
@@ -23,11 +32,12 @@ func TestNewCompletionChannel_SurvivesSignalBeforeReceive(t *testing.T) {
 	}
 }
 
-// signalCompletion runs on the websocket read loop, so it must never wait for a
-// receiver, not even when the buffer already holds a signal.
+// TestSignalCompletion_DoesNotBlockWhenAlreadySignaled pins that signalCompletion,
+// which runs on the websocket read loop, never waits for a receiver—not even when
+// the buffer already holds a signal.
 func TestSignalCompletion_DoesNotBlockWhenAlreadySignaled(t *testing.T) {
 	am := newTestAuthManager()
-	am.newCompletionChannel("req-1")
+	registerCompletionChannel(am, "req-1")
 	am.signalCompletion("req-1")
 
 	returned := make(chan struct{})
@@ -43,11 +53,11 @@ func TestSignalCompletion_DoesNotBlockWhenAlreadySignaled(t *testing.T) {
 	}
 }
 
-// The timeout path removes the channel, so a response arriving afterwards reaches
-// signalCompletion with nothing registered.
+// TestSignalCompletion_UnknownRequestIsNoop covers a response arriving after the
+// timeout path removed the channel.
 func TestSignalCompletion_UnknownRequestIsNoop(t *testing.T) {
 	am := newTestAuthManager()
-	am.newCompletionChannel("req-1")
+	registerCompletionChannel(am, "req-1")
 	am.removeCompletionChannel("req-1")
 
 	am.signalCompletion("req-1")

--- a/pkg/runner/auth_session_event.go
+++ b/pkg/runner/auth_session_event.go
@@ -361,6 +361,7 @@ func (am *AuthManager) sendSessionEventResponse(conn net.Conn, received bool) {
 		return
 	}
 
+	_ = conn.SetWriteDeadline(time.Now().Add(authSocketWriteTimeout))
 	if _, err := conn.Write(responseJSON); err != nil {
 		log.Warn().Err(err).Msg("Failed to send session_event_response")
 	}

--- a/pkg/runner/control_client.go
+++ b/pkg/runner/control_client.go
@@ -206,10 +206,9 @@ func (cc *ControlClient) HandleMessage(message []byte) {
 	case "sudo_approval_response":
 		log.Debug().Msgf("Received sudo_approval_response: %+v", response)
 		if authManager != nil {
-			err := authManager.HandleSudoApprovalResponse(response)
-			if err != nil {
-				log.Error().Err(err).Msg("Failed to handle sudo approval response")
-			}
+			// Each failure path logs at its own level inside the handler; a client
+			// that already left is a warning, not an error.
+			_ = authManager.HandleSudoApprovalResponse(response)
 		} else {
 			log.Error().Msg("AuthManager not available")
 		}


### PR DESCRIPTION
Closes #396

## The bug

The retry-failure path in `handleSudoApprovalRequest` wrote a response and closed the socket, then `cleanupTimeoutRequest` looked the still-registered request up and wrote a second response and closed again.

The alpamon-pam client reads auth.sock until EOF and parses the whole buffer as one JSON document. Two concatenated responses fail parsing, so the deny reason never reaches PAM.

## The fix

**One ownership rule.** A pending request is answered and closed by whoever takes it out of `session.Requests`, and by nobody else.

- `cleanupTimeoutRequest` is renamed `finalizeRequest`—two of its three callers are not timeouts.
- The retry-failure path's direct write and duplicate `Close()` are gone.

**Whoever removes a session entry follows the same rule.** Taking a session entry out of the map puts its pending requests beyond `finalizeRequest`'s reach, so every function that does so answers and closes them:

- `RemovePIDSessionMapping`, `RemovePIDCommandMapping`: deny with `"Session ended"`
- `AddPIDSessionMapping`, `AddPIDCommandMapping`: deny a reused pid's leftovers with `"Session replaced"`

Without that, a PTY teardown during the up-to-25s retry left the socket open with nothing written, and the PAM client waited out its own timeout before falling back to its fail-open setting.

**Responses carry the full request.** Each pending request keeps the `SudoApprovalRequest` it was registered with, so every response carries the requester's fields instead of only the request id.

## Hardening

- Every write to the auth socket now carries `authSocketWriteTimeout` (5s). The deny paths run inline on PTY teardown and on Command registration, and `HandleSudoApprovalResponse` writes from the websocket read loop, so a peer that stopped reading must not stall any of them. The sibling response paths `sendIsAlpconResponse` and `sendSessionEventResponse` got the same deadline.
- A write that fails because the client is already gone—broken pipe, reset, closed socket, or the deadline—is a warning rather than an error, and `control_client.go` no longer repeats that error at error level. `authSocketWriteLevel` makes that decision for both `sendSudoApprovalResponse` and `sendIsAlpconResponse`; `check_user` is answered on every PAM sudo hook, so it produces the same noise from a client that already left.
- `HandleSudoApprovalResponse` closes the connection when its write fails: the request is already deregistered at that point, so nothing else could reclaim the descriptor.
- `AddPIDSessionMapping` fills in its defaults under `am.mu`—re-registering the entry already installed for a pid writes fields a concurrent lookup is reading. `putSession` becomes `putSessionLocked`, and both callers answer the displaced entry's requests after unlocking.

## Tests

New `pkg/runner/auth_manager_cleanup_test.go`, extended `auth_manager_completion_test.go`.

The central one is `TestHandleSudoApprovalRequest_RetryFailureAnswersOnce`: it runs issue #396's own path through `handleSudoApprovalRequest` and asserts exactly one response followed by EOF. A pre-cancelled `am.ctx` fails the retry immediately instead of spending its 25s budget.

Reintroducing the old double-write ordering (`sendSudoApprovalResponse` → `cleanupTimeoutRequest` → `Close()`) fails it, as it should:

```
--- FAIL: TestHandleSudoApprovalRequest_RetryFailureAnswersOnce (0.00s)
    auth_manager_cleanup_test.go:319: expected EOF after single response, got <nil>
```

The rest: `TestFinalizeRequest_*` (single response, no-op on an unregistered request, race against `HandleSudoApprovalResponse`), `TestRemovePID{Session,Command}Mapping_*`, `TestAddPID{Session,Command}Mapping_*`, `TestHandleSudoApprovalResponse_SignalsWaiterOnWriteFailure`, `TestHandleSudoApprovalRequest_LocalSudoRegistersNothing`.

```
gofmt -l pkg/runner/   # no output
go vet ./pkg/runner    # ok
go test ./pkg/runner -p 1 -count=1
ok  github.com/alpacax/alpamon/v2/pkg/runner  45.470s
```

All targeted tests also pass under `-race`.

- `HandleSudoApprovalResponse` no longer dumps every session's pending requests before the unmatched-response debug line; the line below it already said no request matched the id.

## Review notes

- The deny reason strings (`"Session ended"`, `"Session replaced"`, `"Communication error"`) never reach alpacon-server. `sendSudoApprovalResponse` writes only to auth.sock, and the sole outbound POST, `sendSudoRequestWithRetry`, sends a `SudoApprovalRequest`, which carries no reason field. Their only audience is alpamon-pam, so the compatibility question belongs in that repo. (Corrected from the original note, which asked about the server.)
- 5s for `authSocketWriteTimeout` sits between the 25s retry budget and the PAM client's own 30s, and every caller closes the connection right after the write, so no path accumulates two deadlines.
- `AddPIDSessionMapping` clears `session.CommandID` on every call. The only production caller (`pty.go:135`) passes a fresh pointer each time, but re-registering the same pointer is now pinned as supported behavior by a test.

