### PR TITLE
fix(utils): fail once on an unclassifiable platform instead of looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ sudo systemctl restart alpamon
 sudo journalctl -u alpamon -f
 ```
 
+The unit also sets `RestartPreventExitStatus=78`. Alpamon exits with 78 (`EX_CONFIG`) when startup hits a condition a restart cannot clear, such as a Linux distribution it cannot classify. systemd then leaves the service in `failed` instead of restarting it, so `systemctl status alpamon` still shows the reason. Fix the underlying condition and start the service again.
+
 The unit sets `KillMode=process`, so restarting or stopping alpamon signals only the agent itself, not the whole control-group. Sessions it launched—Websh terminals and detached jobs such as `tmux`, `screen`, or `nohup`'d commands—keep running across a restart, the same way `sshd` leaves active login sessions alone. Reattach to them from a new session after the agent reconnects.
 
 ### macOS (launchd)

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ sudo systemctl restart alpamon
 sudo journalctl -u alpamon -f
 ```
 
-The unit also sets `RestartPreventExitStatus=78`. Alpamon exits with 78 (`EX_CONFIG`) when startup hits a condition a restart cannot clear, such as a Linux distribution it cannot classify. systemd then leaves the service in `failed` instead of restarting it, so `systemctl status alpamon` still shows the reason. Fix the underlying condition and start the service again.
-
 The unit sets `KillMode=process`, so restarting or stopping alpamon signals only the agent itself, not the whole control-group. Sessions it launched—Websh terminals and detached jobs such as `tmux`, `screen`, or `nohup`'d commands—keep running across a restart, the same way `sshd` leaves active login sessions alone. Reattach to them from a new session after the agent reconnects.
+
+The unit also sets `RestartPreventExitStatus=78`. Alpamon exits with 78 (`EX_CONFIG`) when startup hits a condition a restart cannot clear, such as a Linux distribution it cannot classify. systemd then leaves the service in `failed` instead of restarting it, so `systemctl status alpamon` still shows the reason. Fix the underlying condition and start the service again.
 
 ### macOS (launchd)
 

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -107,10 +106,7 @@ func runAgent(ready chan<- struct{}) {
 	// platform
 	if err := utils.InitPlatform(); err != nil {
 		log.Error().Err(err).Msg("Failed to initialize platform.")
-		if errors.Is(err, utils.ErrUnsupportedPlatform) {
-			os.Exit(utils.ConfigErrorExitCode)
-		}
-		os.Exit(1)
+		os.Exit(utils.StartupExitCode(err))
 	}
 
 	// Pid

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -104,7 +105,13 @@ func runAgent(ready chan<- struct{}) {
 	updater.CleanupStaleOld()
 
 	// platform
-	utils.InitPlatform()
+	if err := utils.InitPlatform(); err != nil {
+		log.Error().Err(err).Msg("Failed to initialize platform.")
+		if errors.Is(err, utils.ErrUnsupportedPlatform) {
+			os.Exit(utils.ConfigErrorExitCode)
+		}
+		os.Exit(1)
+	}
 
 	// Pid
 	pidFilePath, err := pidfile.WritePID(pidfile.FilePath(name))

--- a/configs/alpamon.service
+++ b/configs/alpamon.service
@@ -12,6 +12,8 @@ KillMode=process
 SELinuxContext=-unconfined_u:unconfined_r:unconfined_t:s0
 AppArmorProfile=-unconfined
 Restart=on-failure
+# EX_CONFIG from utils.ConfigErrorExitCode: a startup failure no restart can clear.
+RestartPreventExitStatus=78
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=alpamon

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -7,6 +7,12 @@
 //
 // A plugin defines a Plugin value and either calls Plugin.Run directly or
 // embeds it under a Cobra root command via NewRootCmd.
+//
+// Run exits with utils.ConfigErrorExitCode (78) when startup hits a condition
+// no restart can clear, such as a host the platform classifier cannot map. A
+// plugin's service unit should carry RestartPreventExitStatus=78 alongside its
+// Restart= setting, the way configs/alpamon.service does; without it systemd
+// relaunches straight back into the same failure.
 package plugin
 
 import (

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -11,6 +11,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -174,7 +175,13 @@ func (p *Plugin) run() int {
 	if p.InitLogger != nil {
 		p.InitLogger()
 	}
-	utils.InitPlatform()
+	if err := utils.InitPlatform(); err != nil {
+		log.Error().Err(err).Msg("Failed to initialize platform.")
+		if errors.Is(err, utils.ErrUnsupportedPlatform) {
+			return utils.ConfigErrorExitCode
+		}
+		return 1
+	}
 
 	pidFilePath, err := pidfile.WritePID(pidfile.FilePath(p.Name))
 	if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -17,7 +17,6 @@ package plugin
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -183,10 +182,7 @@ func (p *Plugin) run() int {
 	}
 	if err := utils.InitPlatform(); err != nil {
 		log.Error().Err(err).Msg("Failed to initialize platform.")
-		if errors.Is(err, utils.ErrUnsupportedPlatform) {
-			return utils.ConfigErrorExitCode
-		}
-		return 1
+		return utils.StartupExitCode(err)
 	}
 
 	pidFilePath, err := pidfile.WritePID(pidfile.FilePath(p.Name))

--- a/pkg/utils/exitcode.go
+++ b/pkg/utils/exitcode.go
@@ -1,0 +1,7 @@
+package utils
+
+// ConfigErrorExitCode is the exit status for a startup failure no restart can
+// clear (sysexits.h EX_CONFIG). configs/alpamon.service repeats the literal in
+// RestartPreventExitStatus, so the unit settles in failed with the reason still
+// readable instead of relaunching into the same failure.
+const ConfigErrorExitCode = 78

--- a/pkg/utils/exitcode.go
+++ b/pkg/utils/exitcode.go
@@ -1,7 +1,18 @@
 package utils
 
+import "errors"
+
 // ConfigErrorExitCode is the exit status for a startup failure no restart can
 // clear (sysexits.h EX_CONFIG). configs/alpamon.service repeats the literal in
 // RestartPreventExitStatus, so the unit settles in failed with the reason still
 // readable instead of relaunching into the same failure.
 const ConfigErrorExitCode = 78
+
+// StartupExitCode maps a startup failure to its exit status: a condition no
+// restart can clear gets ConfigErrorExitCode, anything else stays restartable.
+func StartupExitCode(err error) int {
+	if errors.Is(err, ErrUnsupportedPlatform) {
+		return ConfigErrorExitCode
+	}
+	return 1
+}

--- a/pkg/utils/exitcode_test.go
+++ b/pkg/utils/exitcode_test.go
@@ -1,11 +1,31 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 )
+
+// The callers turn this into os.Exit / a return code, neither reachable from a test, so the mapping itself is what gets pinned.
+func TestStartupExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"wrapped sentinel", fmt.Errorf("%w: os=linux distribution=%q", ErrUnsupportedPlatform, "gentoo"), ConfigErrorExitCode},
+		{"host lookup failure", fmt.Errorf("failed to retrieve platform information: %w", errors.New("no os-release")), 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StartupExitCode(tt.err); got != tt.want {
+				t.Errorf("StartupExitCode(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
 
 // systemd parses RestartPreventExitStatus as a literal and cannot read the Go constant, so drift between the two silently restores the restart loop this code exists to stop.
 func TestConfigErrorExitCodeMatchesUnitFile(t *testing.T) {

--- a/pkg/utils/exitcode_test.go
+++ b/pkg/utils/exitcode_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// systemd parses RestartPreventExitStatus as a literal and cannot read the Go constant, so drift between the two silently restores the restart loop this code exists to stop.
+func TestConfigErrorExitCodeMatchesUnitFile(t *testing.T) {
+	unit, err := os.ReadFile("../../configs/alpamon.service")
+	if err != nil {
+		t.Fatalf("failed to read the unit file: %v", err)
+	}
+	want := fmt.Sprintf("RestartPreventExitStatus=%d", ConfigErrorExitCode)
+	if !strings.Contains(string(unit), want) {
+		t.Errorf("configs/alpamon.service must contain %q", want)
+	}
+}

--- a/pkg/utils/exitcode_test.go
+++ b/pkg/utils/exitcode_test.go
@@ -14,7 +14,17 @@ func TestConfigErrorExitCodeMatchesUnitFile(t *testing.T) {
 		t.Fatalf("failed to read the unit file: %v", err)
 	}
 	want := fmt.Sprintf("RestartPreventExitStatus=%d", ConfigErrorExitCode)
-	if !strings.Contains(string(unit), want) {
-		t.Errorf("configs/alpamon.service must contain %q", want)
+	// A commented-out or misplaced directive is inert to systemd, so a substring match would pass on a unit that still restart-loops.
+	var section string
+	for line := range strings.SplitSeq(string(unit), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = line
+			continue
+		}
+		if section == "[Service]" && line == want {
+			return
+		}
 	}
+	t.Errorf("configs/alpamon.service must set %q under [Service]", want)
 }

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -17,6 +17,10 @@ var (
 	PlatformID     string
 )
 
+// ErrUnsupportedPlatform marks the classification failure callers translate
+// into ConfigErrorExitCode.
+var ErrUnsupportedPlatform = errors.New("unsupported platform")
+
 // Mirrors alpacon-server servers/constants.py PLATFORM_ALIASES 1:1 — never add ids the server lacks: write-once Server.platform makes a divergence permanent.
 var platformAliases = map[string]string{
 	"debian":    "debian",
@@ -119,18 +123,26 @@ func ResolveServerPlatform(goos, explicit string, detect func() (string, error))
 	return explicit, "", nil
 }
 
+// The raw distribution id for this host; empty off Linux, where GOOS alone classifies. The callers' error texts differ, so wrapping stays with them.
+func rawHostPlatform() (string, error) {
+	if runtime.GOOS != "linux" {
+		return "", nil
+	}
+	info, err := host.Info()
+	if err != nil {
+		return "", err
+	}
+	return info.Platform, nil
+}
+
 // The value register and migrate send; errors instead of defaulting because the server persists it write-once, fixable only by re-registering.
 func DetectRegistrationPlatform() (string, error) {
-	var raw string
-	if runtime.GOOS == "linux" {
-		info, err := host.Info()
-		if err != nil {
-			return "", fmt.Errorf(
-				"failed to detect the host platform: %w.\n"+
-					"Pass --platform debian|rhel to skip detection if you know the host is compatible",
-				err)
-		}
-		raw = info.Platform
+	raw, err := rawHostPlatform()
+	if err != nil {
+		return "", fmt.Errorf(
+			"failed to detect the host platform: %w.\n"+
+				"Pass --platform debian|rhel to skip detection if you know the host is compatible",
+			err)
 	}
 	return ResolveRegistrationPlatform(runtime.GOOS, raw)
 }
@@ -149,19 +161,11 @@ func ResolveRegistrationPlatform(goos, raw string) (string, error) {
 	return like, nil
 }
 
-// ErrUnsupportedPlatform marks the classification failure callers translate
-// into ConfigErrorExitCode.
-var ErrUnsupportedPlatform = errors.New("unsupported platform")
-
 // Classifies the host once at startup; the error is terminal for the caller because every handler switches on these values and guessing would misreport to the server.
 func InitPlatform() error {
-	var raw string
-	if runtime.GOOS == "linux" {
-		info, err := host.Info()
-		if err != nil {
-			return fmt.Errorf("failed to retrieve platform information: %w", err)
-		}
-		raw = info.Platform
+	raw, err := rawHostPlatform()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve platform information: %w", err)
 	}
 	return applyPlatform(runtime.GOOS, raw)
 }

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -1,13 +1,12 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
-	"os"
 	"runtime"
 	"slices"
 	"strings"
 
-	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v4/host"
 )
 
@@ -150,30 +149,39 @@ func ResolveRegistrationPlatform(goos, raw string) (string, error) {
 	return like, nil
 }
 
-// Classifies the host once at startup; unclassifiable is fatal because every handler switches on these values and guessing would misreport to the server.
-func InitPlatform() {
+// ErrUnsupportedPlatform marks the classification failure callers translate
+// into ConfigErrorExitCode.
+var ErrUnsupportedPlatform = errors.New("unsupported platform")
+
+// Classifies the host once at startup; the error is terminal for the caller because every handler switches on these values and guessing would misreport to the server.
+func InitPlatform() error {
 	var raw string
 	if runtime.GOOS == "linux" {
 		info, err := host.Info()
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to retrieve platform information.")
-			os.Exit(1)
+			return fmt.Errorf("failed to retrieve platform information: %w", err)
 		}
 		raw = info.Platform
 	}
+	return applyPlatform(runtime.GOOS, raw)
+}
 
-	like, pkgManager, ok := ResolvePlatform(runtime.GOOS, raw)
+// InitPlatform's host-free half, split the way DetectRegistrationPlatform splits from ResolveRegistrationPlatform, so the sentinel and the globals it writes are testable without a host.
+func applyPlatform(goos, raw string) error {
+	like, pkgManager, ok := ResolvePlatform(goos, raw)
 	if !ok {
-		log.Fatal().Msgf(
-			"Unsupported platform: os=%s distribution=%q. "+
+		return fmt.Errorf(
+			"%w: os=%s distribution=%q. "+
 				"alpamon supports debian- and rhel-family Linux distributions "+
-				"(including openSUSE/SLES), macOS, and Windows.",
-			runtime.GOOS, raw)
+				"(including openSUSE/SLES), macOS, and Windows",
+			ErrUnsupportedPlatform, goos, raw)
 	}
 
 	PlatformLike = like
 	PackageManager = pkgManager
 	PlatformID = raw
+
+	return nil
 }
 
 // SetPlatformLike sets PlatformLike for tests.

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -6,9 +6,16 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-
-	"github.com/shirou/gopsutil/v4/host"
 )
+
+// applyPlatform writes package globals, so restore them and keep test ordering from leaking.
+func savePlatformGlobals(t *testing.T) {
+	t.Helper()
+	like, pkgManager, id := PlatformLike, PackageManager, PlatformID
+	t.Cleanup(func() {
+		PlatformLike, PackageManager, PlatformID = like, pkgManager, id
+	})
+}
 
 // Vectors mirror alpacon-server servers/test_utils.py:68-96: the 1:1 table correspondence is the contract, and write-once Server.platform makes a divergence permanent.
 func TestResolvePlatform(t *testing.T) {
@@ -149,26 +156,17 @@ func TestValidateServerPlatform(t *testing.T) {
 	}
 }
 
-// Feeds ResolvePlatform what InitPlatform reads, so every CI row guards its own distro — the #348 case the pure vectors miss; CI-gated to keep local runs green off-matrix.
-func TestResolvePlatform_CIHost(t *testing.T) {
+// Runs the real startup path instead of re-reading the host itself, so every CI row guards its own distro — the #348 case the pure vectors miss; CI-gated to keep local runs green off-matrix.
+func TestInitPlatform_CIHost(t *testing.T) {
 	if os.Getenv("CI") == "" {
 		t.Skip("CI-matrix guard: host distros are only pinned supported on CI runners")
 	}
+	savePlatformGlobals(t)
 
-	var raw string
-	if runtime.GOOS == "linux" {
-		info, err := host.Info()
-		if err != nil {
-			t.Fatalf("host.Info() failed: %v", err)
-		}
-		raw = info.Platform
+	if err := InitPlatform(); err != nil {
+		t.Fatalf("CI host not classified: %v", err)
 	}
-
-	like, pkgManager, ok := ResolvePlatform(runtime.GOOS, raw)
-	if !ok {
-		t.Fatalf("CI host not classified: os=%s distribution=%q", runtime.GOOS, raw)
-	}
-	t.Logf("os=%s distribution=%q -> like=%s pkgManager=%s", runtime.GOOS, raw, like, pkgManager)
+	t.Logf("os=%s -> like=%s pkgManager=%s id=%q", runtime.GOOS, PlatformLike, PackageManager, PlatformID)
 }
 
 // Both directions: a false negative skips a needed dup, a false positive runs a destructive one.
@@ -245,6 +243,51 @@ func TestResolveServerPlatform(t *testing.T) {
 			}
 			if tt.wantWarning != "" && !strings.Contains(warning, tt.wantWarning) {
 				t.Errorf("warning must name the detected platform %q, got %q", tt.wantWarning, warning)
+			}
+		})
+	}
+}
+
+// Callers pick ConfigErrorExitCode off this sentinel, so an unwrapped error would silently downgrade the failure back to a restartable exit 1.
+func TestApplyPlatform_UnsupportedWrapsSentinel(t *testing.T) {
+	savePlatformGlobals(t)
+	SetPlatformLike("untouched")
+	SetPackageManager("untouched")
+	SetPlatformID("untouched")
+
+	err := applyPlatform("linux", "gentoo")
+	if !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Fatalf("error must wrap ErrUnsupportedPlatform, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "gentoo") {
+		t.Errorf("error must name the distribution, got %q", err)
+	}
+	if PlatformLike != "untouched" || PackageManager != "untouched" || PlatformID != "untouched" {
+		t.Errorf("a failed classification must leave the globals alone, got like=%q pkgManager=%q id=%q",
+			PlatformLike, PackageManager, PlatformID)
+	}
+}
+
+// The three globals disagree on SUSE, so each has to land from its own source rather than be derived from another.
+func TestApplyPlatform_SetsGlobals(t *testing.T) {
+	savePlatformGlobals(t)
+
+	for _, tt := range []struct {
+		goos, raw, like, pkgManager, id string
+	}{
+		{"linux", "ubuntu", "debian", PkgApt, "ubuntu"},
+		{"linux", "rocky", "rhel", PkgYum, "rocky"},
+		{"linux", "opensuse-tumbleweed", "rhel", PkgZypper, "opensuse-tumbleweed"},
+		{"darwin", "", "darwin", PkgBrew, ""},
+		{"windows", "", "windows", PkgNone, ""},
+	} {
+		t.Run(tt.goos+"/"+tt.raw, func(t *testing.T) {
+			if err := applyPlatform(tt.goos, tt.raw); err != nil {
+				t.Fatalf("applyPlatform(%q, %q) = %v", tt.goos, tt.raw, err)
+			}
+			if PlatformLike != tt.like || PackageManager != tt.pkgManager || PlatformID != tt.id {
+				t.Errorf("got like=%q pkgManager=%q id=%q, want %q %q %q",
+					PlatformLike, PackageManager, PlatformID, tt.like, tt.pkgManager, tt.id)
 			}
 		})
 	}


### PR DESCRIPTION
## Background

`utils.InitPlatform()` ended in `log.Fatal` when the classifier could not map the host, which logs and exits 1. The systemd unit sets `Restart=on-failure`, so exit 1 reads as transient and the unit relaunches straight into the same failure. It ends at the default start limit (`DefaultStartLimitBurst=5` over `DefaultStartLimitIntervalSec=10s`) reporting:

```
start request repeated too quickly
```

That is what `systemctl status alpamon` shows. The line that actually names the cause — `Unsupported platform: os=linux distribution="gentoo"` — sits buried in five repetitions of journal output. `InitPlatform` also runs before `pidfile.WritePID`, so there is no PID file left behind to point at either.

An unclassifiable distribution is not a transient condition. Restarting cannot clear it.

## Changes

The classification failure now travels back as a sentinel instead of killing the process:

- `pkg/utils/platform.go`: `InitPlatform` returns an error wrapping `ErrUnsupportedPlatform` rather than calling `log.Fatal`. The host lookup splits from the classification half (`applyPlatform`), the same way `DetectRegistrationPlatform` already splits from `ResolveRegistrationPlatform`, so the sentinel and the globals it writes are reachable without a host. The host half is shared too: `rawHostPlatform` replaces the `if runtime.GOOS == "linux" { host.Info() }` block that `InitPlatform` and `DetectRegistrationPlatform` each carried, returning the raw id and leaving the wrapping to callers whose error texts differ.
- `pkg/utils/exitcode.go`: new `ConfigErrorExitCode = 78` (`sysexits.h` `EX_CONFIG`), and `StartupExitCode(err)` which maps a startup failure to its exit status — the sentinel to 78, anything else to a restartable 1.
- `cmd/alpamon/command/root.go:107` and `pkg/plugin/plugin.go:183`: both callers route their failure through `StartupExitCode`. `pkg/plugin` returns rather than exits, so its deferred cleanup chain and its own exit path still run — both were skipped by `log.Fatal`.
- `pkg/plugin` package doc: plugin repos import this SDK but ship their own unit files, so the doc states the other half of the contract — a plugin unit needs `RestartPreventExitStatus=78` or it keeps restart-looping on the code the SDK now returns.
- `configs/alpamon.service`: `RestartPreventExitStatus=78` alongside the existing `Restart=on-failure`.
- `README.md`: what an operator sees after an EX_CONFIG exit, in the Service management section.

systemd no longer restarts the unit by itself: it exits 78 once and stays `failed` with `systemctl status` naming the reason. `RestartPreventExitStatus` only blocks the automatic restart, and this repo also ships `configs/alpamon-restart.timer`, which `scripts/postinstall.sh` enables. That timer sends an explicit `systemctl restart` five minutes after activation and once per boot, and an external restart is not blocked — so the unit takes that one extra attempt, exits 78 again, and settles back into `failed`. `OnActiveSec` without `OnUnitActiveSec` fires once per activation, so this is a single retry, not a loop. This is the same "do not restart a deliberate exit" shape #129 established for `quit`.

The exit code is duplicated in `configs/alpamon.service` because systemd parses `RestartPreventExitStatus` as a literal and cannot read a Go constant. A test pins the two together (see Testing).

Deliberately left out of scope:

- `host.Info()` failures still exit 1. A missing `os-release` is not a verdict on which distributions are supported, and unlike classification it may clear on a retry.
- The PID file failure at `root.go:113` still exits 1. A stale pidfile is the kind of thing a restart does clear.
- Which distributions classify is untouched. That stays with #348 and #393.

The same "no restart can clear this" failure class still exits 1 elsewhere — `pkg/config/config.go:97,102,108,120` and `root.go:178` are all `log.Fatal`. Those are follow-up work, not part of this change.

## Testing

New in `pkg/utils`:

- `TestApplyPlatform_UnsupportedWrapsSentinel`: the classification failure wraps `ErrUnsupportedPlatform` and names the distribution, and leaves `PlatformLike` / `PackageManager` / `PlatformID` untouched. Without the wrap, `StartupExitCode` silently falls back to a restartable exit 1.
- `TestApplyPlatform_SetsGlobals`: all three globals land from their own source across debian, rhel, SUSE, darwin and windows.
- `TestStartupExitCode`: a wrapped sentinel maps to 78 and a host lookup failure to 1. The callers themselves end in `os.Exit` or a return code, neither reachable from a test, so the mapping is what gets pinned.
- `TestConfigErrorExitCodeMatchesUnitFile`: `configs/alpamon.service` sets `RestartPreventExitStatus=78` as an active directive under `[Service]`. Matched line by line rather than as a substring, since a commented-out or misplaced directive is inert to systemd and would otherwise keep the test green while the restart loop returns. Confirmed by mutating the unit file each way and watching the test fail.

`TestResolvePlatform_CIHost` re-read the host itself and called `ResolvePlatform` directly, so the CI matrix never entered `InitPlatform`. It is now `TestInitPlatform_CIHost` and calls what the agent actually runs at startup.

`applyPlatform`, `SetPlatformLike`, `SetPackageManager` and `SetPlatformID` go from 0% to full statement coverage.

Local run on darwin/arm64: `gofmt -l .`, `go build ./...` and `go vet ./...` clean, `go test ./... -p 1 -count=1` all `ok` (`pkg/utils 0.414s`, `pkg/plugin 0.284s`).

Not verified: this has not been run under a real systemd unit to observe the `failed` state end to end. The assertion above is that the unit file and the constant agree, and that `StartupExitCode` maps the sentinel to 78 — not that systemd behaves as documented.

Closes #397
