### PR TITLE
build(go): raise the go directive to 1.25.13

### DIFF
--- a/.github/actions/setup-go-generate/action.yml
+++ b/.github/actions/setup-go-generate/action.yml
@@ -3,17 +3,17 @@ description: >-
   Install the Go toolchain and generate the gitignored ent package. The tree
   imports ent subpackages that aren't checked in, so codegen must run before
   any command that loads packages (build, test, tidy, govulncheck, lint).
-inputs:
-  go-version:
-    description: Go version to install
-    required: true
 runs:
   using: composite
   steps:
+    # go.mod is the only source of truth for the toolchain. setup-go pins
+    # GOTOOLCHAIN=local, so a version resolved from anywhere else (a workflow
+    # env, a `1.25.x` wildcard hitting a stale runner cache) fails every
+    # package-loading command the moment it lags behind the go directive.
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ inputs.go-version }}
+        go-version-file: go.mod
 
     - name: Generate go code
       run: go generate ./pkg/db/ent

--- a/.github/actions/setup-go-generate/action.yml
+++ b/.github/actions/setup-go-generate/action.yml
@@ -3,6 +3,8 @@ description: >-
   Install the Go toolchain and generate the gitignored ent package. The tree
   imports ent subpackages that aren't checked in, so codegen must run before
   any command that loads packages (build, test, tidy, govulncheck, lint).
+  Assumes the repository is checked out at the workspace root: both the go.mod
+  the toolchain is read from and the generate path resolve from there.
 runs:
   using: composite
   steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,9 +13,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.25.12'
-
 jobs:
   verify-tidy:
     name: Verify go.mod and go.sum are tidy
@@ -26,8 +23,6 @@ jobs:
 
       - name: Set up Go and generate ent code
         uses: ./.github/actions/setup-go-generate
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - name: Verify go.mod and go.sum are tidy
         run: |
@@ -151,8 +146,6 @@ jobs:
 
       - name: Set up Go and generate ent code
         uses: ./.github/actions/setup-go-generate
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - name: Build
         run: go build -v .
@@ -170,8 +163,6 @@ jobs:
 
       - name: Set up Go and generate ent code
         uses: ./.github/actions/setup-go-generate
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - name: Build
         run: go build -v .
@@ -258,8 +249,6 @@ jobs:
 
       - name: Set up Go and generate ent code
         uses: ./.github/actions/setup-go-generate
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - name: Build
         run: go build -v .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.25.12'
-
 jobs:
   linter:
     name: golangci-lint
@@ -29,8 +26,6 @@ jobs:
 
       - name: Set up Go and generate ent code
         uses: ./.github/actions/setup-go-generate
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - name: GolangCI-Lint
         uses: golangci/golangci-lint-action@v9
@@ -48,8 +43,6 @@ jobs:
 
       - name: Set up Go and generate ent code
         uses: ./.github/actions/setup-go-generate
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/setup-go-generate
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       # Report findings without gating merges: a newly published CVE in a
       # transitive dep or stdlib would otherwise turn unrelated PRs red.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: write
 
-env:
-  GO_VERSION: '1.25.12'
-
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-and-test.yml
@@ -58,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       # GoReleaser needs write access to two repositories with a single
       # token: this repo (to attach release assets) and homebrew-alpacon

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,6 @@ release:
 before:
   hooks:
     - go generate ./pkg/db/ent
-    - go mod tidy
 
 builds:
   - id: alpamon-linux

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ go build -o alpamon ./cmd/alpamon         # native
 GOOS=windows GOARCH=amd64 go build ./cmd/alpamon   # Windows cross-compile
 ```
 
-Go 1.25.12+ is required. `GOPATH/bin` should be on `PATH`. The generated Ent code is gitignored, so run `go generate ./pkg/db/ent` (see below) before the first build.
+The Go toolchain the `go` directive in `go.mod` names is required. `GOPATH/bin` should be on `PATH`. The generated Ent code is gitignored, so run `go generate ./pkg/db/ent` (see below) before the first build.
 
 ### Generate Ent schema code
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alpacax/alpamon/v2
 
-go 1.25.12
+go 1.25.13
 
 require (
 	entgo.io/ent v0.14.5


### PR DESCRIPTION
## Summary

`govulncheck` found four standard-library vulnerabilities reachable from our
code on go1.25.12. All four are fixed in go1.25.13, so raising the `go`
directive is the entire remedy.

**No Go functionality changed.** Not a line of application code was touched:
the fixes live in the toolchain that compiles us, and the only Go source
change in this branch is the `go` directive in `go.mod`.

## Vulnerabilities cleared

| ID | Package | Issue |
| --- | --- | --- |
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` | quadratic complexity in `resolvePath` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` | unbounded post-handshake messages |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` | no maximum recursion depth |
| [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) | `net/http` (idna) | ASCII-only Punycode labels not rejected |

Reachable call sites included `pkg/runner/ftp.go`, `pkg/runner/client.go`,
`pkg/migrate/migrate.go`, `pkg/scheduler/session.go`, and
`pkg/executor/handlers/file/file_io_unix.go`.

## Release notes

[Go 1.25.13](https://go.dev/doc/devel/release#go1.25.13), released
2026-08-13, carries security fixes to the `go` command, `crypto/tls`,
`encoding/asn1`, `encoding/xml`, `html/template`, `net/http`, and `net/url`,
plus bug fixes to the compiler, the runtime, `crypto/tls`, and `os`. Full
change list: [Go1.25.13 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.13+label%3ACherryPickApproved).

## CI change: one source of truth for the toolchain

Every `setup-go` call resolved its version from a `GO_VERSION` workflow env,
so the toolchain had two sources of truth and a bump had to land in four
files at once. `setup-go` pins `GOTOOLCHAIN=local`, which makes that drift
fatal instead of self-healing: the moment the resolved version lags behind
the `go` directive, every command that loads packages dies before it runs.

`alpacon-cli` hit exactly this on its own 1.25.13 bump. Its `govulncheck` job
resolved `1.25.x` to a cached 1.25.12 while `go.mod` already required
1.25.13, and the scan failed before it started:

```
govulncheck: loading packages: err: exit status 1: stderr: go: go.mod requires go >= 1.25.13 (running go 1.25.12; GOTOOLCHAIN=local)
```

Alpamon was one drifted bump away from the same failure, so this branch
removes the second source of truth rather than waiting for it to fire: every
`setup-go` now reads `go-version-file: go.mod`, and the `GO_VERSION` env is
gone from all three workflows. Alpamon installs `govulncheck` with `go
install` rather than through `golang/govulncheck-action`, so it does not need
the extra unwrapping that `alpacon-cli` required.

Dockerfiles stay on `FROM golang:1.25`—that tag already tracks the newest
patch.

## Review follow-ups

Four commits added after review, all on the same theme of leaving exactly one
place where a version or an assumption is written down.

| Commit | Change |
| --- | --- |
| `71cffffa` | `govulncheck` is installed at `@v1.7.0` instead of `@latest`, closing the last `GOTOOLCHAIN=local` drift path in CI |
| `2469eae2` | `README.md:185` no longer names a patch version; it points at the `go` directive in `go.mod` |
| `a01225b8` | `setup-go-generate` records in its `description` that it assumes a workspace-root checkout |
| `f04d2578` | `.goreleaser.yaml` no longer runs `go mod tidy` at release time |

The pin costs no coverage: `govulncheck` fetches its vulnerability data from
`vuln.go.dev` on every run, so only the scanner engine is held back, never the
CVE feed. v1.7.0 declares `go 1.25.0`, below the 1.25.13 in `go.mod`. The
version has to be bumped by hand, since Dependabot does not track versions
inside a `run` step.

Dropping the release-time `go mod tidy` is safe because `release.yml` calls
`build-and-test.yml` on the tag and `goreleaser` runs with
`needs: [build-and-test]`, so `verify-tidy` has already failed on any `go.mod`
or `go.sum` diff for the exact commit being released. The `go generate` hook
stays: the ent output is gitignored, so the release clone has none of it.

## Verification

Run locally on go1.25.13:

| Check | Result |
| --- | --- |
| `go build ./...` | passes |
| `go vet ./...` | passes |
| `go test ./... -p 1` | every package `ok`, no `FAIL` or `panic` |
| `go mod tidy` | no `go.sum` change |
| `gofmt -l` (excluding generated ent code) | clean |
| `alpamon --help` | runs |
| `govulncheck ./...` | `No vulnerabilities found` |

