### PR TITLE
ci: move the Rocky Linux containers to rockylinux/rockylinux

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -69,7 +69,7 @@ jobs:
             runner: ubuntu-latest
           # RHEL/CentOS yum-based (amd64)
           - distro: rocky-8
-            container: rockylinux:8
+            container: rockylinux/rockylinux:8
             pkg_manager: yum
             runner: ubuntu-latest
           - distro: rhel-8
@@ -78,7 +78,7 @@ jobs:
             runner: ubuntu-latest
           # RHEL/CentOS dnf-based (amd64)
           - distro: rocky-9
-            container: rockylinux:9
+            container: rockylinux/rockylinux:9
             pkg_manager: dnf
             runner: ubuntu-latest
           - distro: almalinux-9
@@ -115,7 +115,7 @@ jobs:
             pkg_manager: apt-get
             runner: ubuntu-24.04-arm
           - distro: rocky-9-arm64
-            container: rockylinux:9
+            container: rockylinux/rockylinux:9
             pkg_manager: dnf
             runner: ubuntu-24.04-arm
           - distro: amazonlinux-2023-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
             arch: amd64
             install_cmd: apt-get install -y -o Acquire::Retries=3
           - pkg_type: rpm
-            container: rockylinux:9
+            container: rockylinux/rockylinux:9
             arch: amd64
             install_cmd: dnf install -y
     container: ${{ matrix.container }}


### PR DESCRIPTION
## Background

The distro compatibility jobs and the release rpm install check pull `rockylinux:8` and `rockylinux:9` from Docker Hub's `library/rockylinux`. That repository's most recent tag update is 2024-05-30, and its highest versions are 8.9 and 9.3. `rockylinux/rockylinux` publishes 8.10 and 9.8, with its `9` tag updated 2026-06-12.

Nothing is broken by the old images today. `$releasever` still resolves to the current minor, so packages install at current versions and the jobs pass. The concern is that the base layer itself is roughly 26 months behind, so the environment the compatibility checks run against is older than what alpamon is actually installed on.

## Changes

Four `container:` values swap from `rockylinux:N` to `rockylinux/rockylinux:N`:

| File | Line | Job |
|---|---|---|
| `.github/workflows/build-and-test.yml` | 72 | `rocky-8` |
| `.github/workflows/build-and-test.yml` | 81 | `rocky-9` |
| `.github/workflows/build-and-test.yml` | 118 | `rocky-9-arm64` |
| `.github/workflows/release.yml` | 191 | rpm install check |

No other change. The base moves from 8.9 to 8.10 and from 9.3 to 9.8.

## Testing

Both tags were confirmed to exist and to publish the architectures the matrix needs, via the Docker Hub API:

```
rockylinux/rockylinux:8 -> last_updated 2024-06-05, [arm64, amd64]
rockylinux/rockylinux:9 -> last_updated 2026-06-12, [amd64, arm64, ppc64le, s390x]
```

The `rocky-8`, `rocky-9` and `rocky-9-arm64` jobs on this PR are what verify the new base builds and tests cleanly.

Not verified: the rpm install check in `release.yml` runs only on a release, so its new base stays unverified until the next tag is cut. No official Rocky Linux statement about the maintenance status of either repository was checked — the comparison rests on Docker Hub tag timestamps and on `rpm -q rocky-release` inside the containers.

Closes #376
