### PR TITLE
fix(firewall): validate rules on the update operation

### DIFF
--- a/pkg/executor/handlers/firewall/firewall.go
+++ b/pkg/executor/handlers/firewall/firewall.go
@@ -153,6 +153,11 @@ func (h *FirewallHandler) Validate(cmd string, args *common.CommandArgs) error {
 			if args.RuleID == "" {
 				return fmt.Errorf("firewall update: rule ID is required")
 			}
+			// handleUpdateOperation applies args.Rules[0] alone, so anything past it
+			// would be dropped without a trace.
+			if len(args.Rules) > 1 {
+				return fmt.Errorf("firewall update: at most one rule is allowed, got %d", len(args.Rules))
+			}
 			// Update without rules only deletes, so rules stay optional here (unlike add).
 			return h.validator.ValidateBatchRules(args.Rules)
 		default:

--- a/pkg/executor/handlers/firewall/firewall.go
+++ b/pkg/executor/handlers/firewall/firewall.go
@@ -153,7 +153,8 @@ func (h *FirewallHandler) Validate(cmd string, args *common.CommandArgs) error {
 			if args.RuleID == "" {
 				return fmt.Errorf("firewall update: rule ID is required")
 			}
-			return nil
+			// Update without rules only deletes, so rules stay optional here (unlike add).
+			return h.validator.ValidateBatchRules(args.Rules)
 		default:
 			return fmt.Errorf("firewall: unknown operation '%s'", operation)
 		}

--- a/pkg/executor/handlers/firewall/firewall_test.go
+++ b/pkg/executor/handlers/firewall/firewall_test.go
@@ -205,6 +205,19 @@ func TestFirewallHandler_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "firewall update multiple rules",
+			cmd:  "firewall",
+			args: &common.CommandArgs{
+				Operation: "update",
+				RuleID:    "1",
+				Rules: []common.FirewallRule{
+					{Protocol: "tcp", PortStart: 80, Target: "ACCEPT"},
+					{Protocol: "tcp", PortStart: 443, Target: "ACCEPT"},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "firewall update without rules",
 			cmd:  "firewall",
 			args: &common.CommandArgs{

--- a/pkg/executor/handlers/firewall/firewall_test.go
+++ b/pkg/executor/handlers/firewall/firewall_test.go
@@ -181,6 +181,39 @@ func TestFirewallHandler_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "firewall update valid rule",
+			cmd:  "firewall",
+			args: &common.CommandArgs{
+				Operation: "update",
+				RuleID:    "1",
+				Rules: []common.FirewallRule{
+					{Protocol: "tcp", PortStart: 80, Target: "ACCEPT"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "firewall update invalid rule",
+			cmd:  "firewall",
+			args: &common.CommandArgs{
+				Operation: "update",
+				RuleID:    "1",
+				Rules: []common.FirewallRule{
+					{Protocol: "bogus-proto", Source: "not-a-cidr", Target: "ACCEPT"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "firewall update without rules",
+			cmd:  "firewall",
+			args: &common.CommandArgs{
+				Operation: "update",
+				RuleID:    "1",
+			},
+			wantErr: false,
+		},
+		{
 			name:    "firewall-rollback valid",
 			cmd:     "firewall-rollback",
 			args:    &common.CommandArgs{},


### PR DESCRIPTION
## Background

`FirewallHandler.Validate` applies a different bar per operation. `add` and `batch` run `h.validator.ValidateBatchRules(args.Rules)`; `update` checked `args.RuleID` and returned `nil` without looking at `args.Rules` at all.

`update` is implemented as delete-then-add, and `handleUpdateOperation` hands `args.Rules[0]` straight to `backend.AddRule` (`pkg/executor/handlers/firewall/firewall.go:405-413`). So a rule that `add` rejects with

```
rule[0]: invalid protocol 'bogus-proto'
```

reached the backend unchecked when the same payload arrived as `update`.

This is not an injection path. Rule fields go to `nft` and `iptables` as an argv array with no shell, so there is nothing to escape. Two problems remain. A late backend error replaces a clean validation error, and a rule that a lenient backend accepts lands in the firewall without ever being checked.

## Changes

`pkg/executor/handlers/firewall/firewall.go`: the `FirewallOpUpdate` case returns `h.validator.ValidateBatchRules(args.Rules)` after the `RuleID` guard, the same call `add` and `batch` already make. No new validator function.

`ValidateBatchRules` is called unconditionally rather than behind a `len(args.Rules) > 0` guard. It returns `nil` for an empty slice (`validator.go:220-227`), so the guard would only restate that.

`update` also rejects more than one rule. `handleUpdateOperation` applies `args.Rules[0]` alone, so a second rule was dropped without a trace, and validating the whole slice could fail on a rule execution would never touch. Capping at one rule matches execution and turns the silent drop into an error. In alpacon-server, `send_rule_to_agent` sends exactly one rule for `update` and multi-rule payloads go out as `operation: 'batch'`, so no current caller is affected.

Rules stay optional for `update`, unlike `add`. `handleUpdateOperation` treats a ruleless update as delete-only and exits 0, so requiring at least one rule here would break calls that work today. A comment at the case records that, since the asymmetry with `add` invites a well-meaning fix.

Out of scope:

- `delete` also checks only `RuleID`. It never reads the rule body, so it is left alone.
- Backend error message formats in `nftables.go` and `iptables.go` are untouched.
- `args.ChainName` still reaches `handleAddOperation` and `handleUpdateOperation` without passing `ValidateChainName`, unlike the `flush` case. Pre-existing and identical on `add`; a separate issue rather than a widening of this one.

## Testing

Four cases in the `TestFirewallHandler_Validate` table (`firewall_test.go:183-228`), which calls `handler.Validate` directly:

- `firewall update valid rule`: `{Protocol: "tcp", PortStart: 80, Target: "ACCEPT"}` passes.
- `firewall update invalid rule`: `{Protocol: "bogus-proto", Source: "not-a-cidr"}` is rejected. Confirmed as a regression test by restoring the old `firewall.go` and rerunning:

  ```
  --- FAIL: TestFirewallHandler_Validate/firewall_update_invalid_rule (0.00s)
  ```

- `firewall update without rules`: no `Rules` still passes, pinning the delete-only update.
- `firewall update multiple rules`: two rules are rejected. Confirmed as a regression test by stashing `firewall.go` and rerunning:

  ```
  --- FAIL: TestFirewallHandler_Validate/firewall_update_multiple_rules (0.00s)
  ```

`TestFirewallHandler_Execute` calls `Execute` directly and never enters `Validate`, so its existing ruleless `update` case is unaffected.

Local run on darwin/arm64: `gofmt -l`, `go vet ./...` and `staticcheck ./pkg/executor/handlers/firewall` clean, `go test ./... -p 1 -count=1` all `ok` (`pkg/executor/handlers/firewall 0.270s`).

Not verified: no run against a live `nft` or `iptables` host. The change is confined to argument validation, which happens before any backend call.

Closes #412
