### PR TITLE
test(utils): unify assertion style in fs and archive tests

### DIFF
--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -5,88 +5,59 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateZip_SingleFile(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "hello.txt")
-	if err := os.WriteFile(src, []byte("hello world"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(src, []byte("hello world"), 0644))
 
 	dest := filepath.Join(dir, "out.zip")
-	if err := CreateZip(dest, []string{src}, false); err != nil {
-		t.Fatalf("CreateZip() error: %v", err)
-	}
+	require.NoError(t, CreateZip(dest, []string{src}, false))
 
 	r, err := zip.OpenReader(dest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = r.Close() }()
 
-	if len(r.File) != 1 {
-		t.Fatalf("expected 1 file in zip, got %d", len(r.File))
-	}
-	if r.File[0].Name != "hello.txt" {
-		t.Errorf("expected entry name hello.txt, got %s", r.File[0].Name)
-	}
+	require.Len(t, r.File, 1)
+	assert.Equal(t, "hello.txt", r.File[0].Name)
 }
 
 func TestCreateZip_RecursiveDirectory(t *testing.T) {
 	dir := t.TempDir()
 	subdir := filepath.Join(dir, "mydir", "sub")
-	if err := os.MkdirAll(subdir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "mydir", "a.txt"), []byte("a"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(subdir, "b.txt"), []byte("b"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(subdir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mydir", "a.txt"), []byte("a"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "b.txt"), []byte("b"), 0644))
 
 	dest := filepath.Join(dir, "out.zip")
-	if err := CreateZip(dest, []string{filepath.Join(dir, "mydir")}, true); err != nil {
-		t.Fatalf("CreateZip() error: %v", err)
-	}
+	require.NoError(t, CreateZip(dest, []string{filepath.Join(dir, "mydir")}, true))
 
 	r, err := zip.OpenReader(dest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = r.Close() }()
 
-	if len(r.File) != 2 {
-		t.Fatalf("expected 2 files in zip, got %d", len(r.File))
-	}
+	assert.Len(t, r.File, 2)
 }
 
 func TestCreateZip_BulkMultiplePaths(t *testing.T) {
 	dir := t.TempDir()
 	f1 := filepath.Join(dir, "one.txt")
 	f2 := filepath.Join(dir, "two.txt")
-	if err := os.WriteFile(f1, []byte("1"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(f2, []byte("2"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(f1, []byte("1"), 0644))
+	require.NoError(t, os.WriteFile(f2, []byte("2"), 0644))
 
 	dest := filepath.Join(dir, "out.zip")
-	if err := CreateZip(dest, []string{f1, f2}, true); err != nil {
-		t.Fatalf("CreateZip() error: %v", err)
-	}
+	require.NoError(t, CreateZip(dest, []string{f1, f2}, true))
 
 	r, err := zip.OpenReader(dest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = r.Close() }()
 
-	if len(r.File) != 2 {
-		t.Fatalf("expected 2 files in zip, got %d", len(r.File))
-	}
+	assert.Len(t, r.File, 2)
 }
 
 func TestUnzip(t *testing.T) {
@@ -95,9 +66,7 @@ func TestUnzip(t *testing.T) {
 	// Create a zip with a file and subdirectory
 	zipPath := filepath.Join(dir, "test.zip")
 	f, err := os.Create(zipPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	w := zip.NewWriter(f)
 	zw, _ := w.Create("root.txt")
 	_, _ = zw.Write([]byte("root"))
@@ -107,29 +76,17 @@ func TestUnzip(t *testing.T) {
 	_ = f.Close()
 
 	extractDir := filepath.Join(dir, "out")
-	if err := os.MkdirAll(extractDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(extractDir, 0755))
 
-	if err := Unzip(zipPath, extractDir); err != nil {
-		t.Fatalf("Unzip() error: %v", err)
-	}
+	require.NoError(t, Unzip(zipPath, extractDir))
 
 	content, err := os.ReadFile(filepath.Join(extractDir, "root.txt"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != "root" {
-		t.Errorf("root.txt content = %q, want %q", content, "root")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "root", string(content))
 
 	content, err = os.ReadFile(filepath.Join(extractDir, "sub", "nested.txt"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != "nested" {
-		t.Errorf("nested.txt content = %q, want %q", content, "nested")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "nested", string(content))
 }
 
 func TestUnzip_ZipSlipRejected(t *testing.T) {
@@ -138,9 +95,7 @@ func TestUnzip_ZipSlipRejected(t *testing.T) {
 	// Create a malicious zip with path traversal
 	zipPath := filepath.Join(dir, "evil.zip")
 	f, err := os.Create(zipPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	w := zip.NewWriter(f)
 	zw, _ := w.Create("../../etc/passwd")
 	_, _ = zw.Write([]byte("malicious"))
@@ -148,14 +103,9 @@ func TestUnzip_ZipSlipRejected(t *testing.T) {
 	_ = f.Close()
 
 	extractDir := filepath.Join(dir, "out")
-	if err := os.MkdirAll(extractDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(extractDir, 0755))
 
-	err = Unzip(zipPath, extractDir)
-	if err == nil {
-		t.Fatal("expected zip-slip rejection error")
-	}
+	assert.Error(t, Unzip(zipPath, extractDir))
 }
 
 func TestCreateZipAndUnzip_RoundTrip(t *testing.T) {
@@ -163,45 +113,25 @@ func TestCreateZipAndUnzip_RoundTrip(t *testing.T) {
 
 	// Create source files
 	srcDir := filepath.Join(dir, "src")
-	if err := os.MkdirAll(filepath.Join(srcDir, "sub"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("aaa"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(srcDir, "sub", "b.txt"), []byte("bbb"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "sub"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("aaa"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "sub", "b.txt"), []byte("bbb"), 0644))
 
 	// Zip
 	zipPath := filepath.Join(dir, "archive.zip")
-	if err := CreateZip(zipPath, []string{srcDir}, true); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, CreateZip(zipPath, []string{srcDir}, true))
 
 	// Unzip
 	outDir := filepath.Join(dir, "out")
-	if err := os.MkdirAll(outDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := Unzip(zipPath, outDir); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(outDir, 0755))
+	require.NoError(t, Unzip(zipPath, outDir))
 
 	// Verify round-trip
 	content, err := os.ReadFile(filepath.Join(outDir, "src", "a.txt"))
-	if err != nil {
-		t.Fatalf("a.txt not found after round-trip: %v", err)
-	}
-	if string(content) != "aaa" {
-		t.Errorf("a.txt = %q, want %q", content, "aaa")
-	}
+	require.NoError(t, err, "a.txt not found after round-trip")
+	assert.Equal(t, "aaa", string(content))
 
 	content, err = os.ReadFile(filepath.Join(outDir, "src", "sub", "b.txt"))
-	if err != nil {
-		t.Fatalf("sub/b.txt not found after round-trip: %v", err)
-	}
-	if string(content) != "bbb" {
-		t.Errorf("sub/b.txt = %q, want %q", content, "bbb")
-	}
+	require.NoError(t, err, "sub/b.txt not found after round-trip")
+	assert.Equal(t, "bbb", string(content))
 }

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// writeZip builds a zip at path with one entry per name/content pair. A nil
+// map produces an empty zip.
+func writeZip(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	w := zip.NewWriter(f)
+	for name, content := range entries {
+		zw, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = zw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+}
+
 func TestCreateZip_SingleFile(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "hello.txt")
@@ -63,17 +80,11 @@ func TestCreateZip_BulkMultiplePaths(t *testing.T) {
 func TestUnzip(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create a zip with a file and subdirectory
 	zipPath := filepath.Join(dir, "test.zip")
-	f, err := os.Create(zipPath)
-	require.NoError(t, err)
-	w := zip.NewWriter(f)
-	zw, _ := w.Create("root.txt")
-	_, _ = zw.Write([]byte("root"))
-	zw, _ = w.Create("sub/nested.txt")
-	_, _ = zw.Write([]byte("nested"))
-	_ = w.Close()
-	_ = f.Close()
+	writeZip(t, zipPath, map[string]string{
+		"root.txt":       "root",
+		"sub/nested.txt": "nested",
+	})
 
 	extractDir := filepath.Join(dir, "out")
 	require.NoError(t, os.MkdirAll(extractDir, 0755))
@@ -92,15 +103,8 @@ func TestUnzip(t *testing.T) {
 func TestUnzip_ZipSlipRejected(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create a malicious zip with path traversal
 	zipPath := filepath.Join(dir, "evil.zip")
-	f, err := os.Create(zipPath)
-	require.NoError(t, err)
-	w := zip.NewWriter(f)
-	zw, _ := w.Create("../../etc/passwd")
-	_, _ = zw.Write([]byte("malicious"))
-	_ = w.Close()
-	_ = f.Close()
+	writeZip(t, zipPath, map[string]string{"../../etc/passwd": "malicious"})
 
 	extractDir := filepath.Join(dir, "out")
 	require.NoError(t, os.MkdirAll(extractDir, 0755))

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -105,7 +105,7 @@ func TestUnzip_ZipSlipRejected(t *testing.T) {
 	extractDir := filepath.Join(dir, "out")
 	require.NoError(t, os.MkdirAll(extractDir, 0755))
 
-	assert.Error(t, Unzip(zipPath, extractDir))
+	assert.ErrorContains(t, Unzip(zipPath, extractDir), "illegal file path in zip")
 }
 
 func TestCreateZipAndUnzip_RoundTrip(t *testing.T) {

--- a/pkg/utils/fs_test.go
+++ b/pkg/utils/fs_test.go
@@ -144,7 +144,7 @@ func TestCopyDir(t *testing.T) {
 
 		// Old content should not exist
 		_, err = os.Stat(filepath.Join(dstDir, "old.txt"))
-		assert.True(t, os.IsNotExist(err), "old.txt should not exist after overwrite")
+		assert.ErrorIs(t, err, os.ErrNotExist, "old.txt should not exist after overwrite")
 	})
 
 	t.Run("non-existent source returns error", func(t *testing.T) {

--- a/pkg/utils/fs_test.go
+++ b/pkg/utils/fs_test.go
@@ -198,33 +198,43 @@ func TestOpenIfZip(t *testing.T) {
 		_ = rc.Close()
 	})
 
-	t.Run("non-zip file returns nil", func(t *testing.T) {
-		p := filepath.Join(tmpDir, "plain.txt")
-		require.NoError(t, os.WriteFile(p, []byte("hello"), 0644))
-		rc := OpenIfZip(p, ".txt")
-		if rc != nil {
-			_ = rc.Close()
-		}
-		assert.Nil(t, rc)
-	})
+	tests := []struct {
+		name  string
+		file  string
+		ext   string
+		isZip bool
+	}{
+		{
+			name: "non-zip file returns nil",
+			file: "plain.txt",
+			ext:  ".txt",
+		},
+		{
+			name:  "denylisted extension returns nil",
+			file:  "lib.jar",
+			ext:   ".jar",
+			isZip: true,
+		},
+		{
+			name:  "uppercase denylisted extension returns nil",
+			file:  "lib.JAR",
+			ext:   ".JAR",
+			isZip: true,
+		},
+	}
 
-	t.Run("denylisted extension returns nil", func(t *testing.T) {
-		p := filepath.Join(tmpDir, "lib.jar")
-		makeZipFile(t, p)
-		rc := OpenIfZip(p, ".jar")
-		if rc != nil {
-			_ = rc.Close()
-		}
-		assert.Nil(t, rc)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(tmpDir, tc.file)
+			if tc.isZip {
+				makeZipFile(t, p)
+			} else {
+				require.NoError(t, os.WriteFile(p, []byte("hello"), 0644))
+			}
 
-	t.Run("uppercase denylisted extension returns nil", func(t *testing.T) {
-		p := filepath.Join(tmpDir, "lib.JAR")
-		makeZipFile(t, p)
-		rc := OpenIfZip(p, ".JAR")
-		if rc != nil {
-			_ = rc.Close()
-		}
-		assert.Nil(t, rc)
-	})
+			if rc := OpenIfZip(p, tc.ext); !assert.Nil(t, rc) {
+				_ = rc.Close()
+			}
+		})
+	}
 }

--- a/pkg/utils/fs_test.go
+++ b/pkg/utils/fs_test.go
@@ -79,8 +79,10 @@ func TestCopyFile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, string(content), string(got))
 
-		srcInfo, _ := os.Stat(srcPath)
-		dstInfo, _ := os.Stat(dstPath)
+		srcInfo, err := os.Stat(srcPath)
+		require.NoError(t, err)
+		dstInfo, err := os.Stat(dstPath)
+		require.NoError(t, err)
 		assert.Equal(t, srcInfo.Mode(), dstInfo.Mode())
 	})
 

--- a/pkg/utils/fs_test.go
+++ b/pkg/utils/fs_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"archive/zip"
 	"os"
 	"path/filepath"
 	"testing"
@@ -178,21 +177,12 @@ func TestChownRecursive(t *testing.T) {
 	})
 }
 
-func makeZipFile(t *testing.T, path string) {
-	t.Helper()
-	f, err := os.Create(path)
-	require.NoError(t, err)
-	w := zip.NewWriter(f)
-	_ = w.Close()
-	_ = f.Close()
-}
-
 func TestOpenIfZip(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	t.Run("valid zip returns handle", func(t *testing.T) {
 		p := filepath.Join(tmpDir, "valid.zip")
-		makeZipFile(t, p)
+		writeZip(t, p, nil)
 		rc := OpenIfZip(p, ".zip")
 		require.NotNil(t, rc)
 		_ = rc.Close()
@@ -227,7 +217,7 @@ func TestOpenIfZip(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := filepath.Join(tmpDir, tc.file)
 			if tc.isZip {
-				makeZipFile(t, p)
+				writeZip(t, p, nil)
 			} else {
 				require.NoError(t, os.WriteFile(p, []byte("hello"), 0644))
 			}

--- a/pkg/utils/fs_test.go
+++ b/pkg/utils/fs_test.go
@@ -5,13 +5,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFileExists(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_file_exists_*")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
+	require.NoError(t, err)
 	tmpPath := tmpFile.Name()
 	_ = tmpFile.Close()
 	defer func() { _ = os.Remove(tmpPath) }()
@@ -50,216 +51,135 @@ func TestFileExists(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := FileExists(tc.path)
-			if got != tc.want {
-				t.Fatalf("FileExists(%q) = %v, want %v", tc.path, got, tc.want)
-			}
+			assert.Equal(t, tc.want, FileExists(tc.path), "path %q", tc.path)
 		})
 	}
 }
 
 func TestCopyFile(t *testing.T) {
 	srcFile, err := os.CreateTemp("", "test_copy_src_*")
-	if err != nil {
-		t.Fatalf("failed to create source file: %v", err)
-	}
+	require.NoError(t, err)
 	srcPath := srcFile.Name()
 	defer func() { _ = os.Remove(srcPath) }()
 
 	content := []byte("hello world")
-	if _, err := srcFile.Write(content); err != nil {
-		t.Fatalf("failed to write source: %v", err)
-	}
+	_, err = srcFile.Write(content)
+	require.NoError(t, err)
 	_ = srcFile.Close()
 
-	if err := os.Chmod(srcPath, 0644); err != nil {
-		t.Fatalf("failed to chmod source: %v", err)
-	}
+	require.NoError(t, os.Chmod(srcPath, 0644))
 
 	t.Run("basic copy", func(t *testing.T) {
 		dstPath := srcPath + "_copy"
 		defer func() { _ = os.Remove(dstPath) }()
 
-		err := CopyFile(srcPath, dstPath, true)
-		if err != nil {
-			t.Fatalf("CopyFile() error: %v", err)
-		}
+		require.NoError(t, CopyFile(srcPath, dstPath, true))
 
 		got, err := os.ReadFile(dstPath)
-		if err != nil {
-			t.Fatalf("failed to read dst: %v", err)
-		}
-		if string(got) != string(content) {
-			t.Fatalf("CopyFile() content = %q, want %q", got, content)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, string(content), string(got))
 
 		srcInfo, _ := os.Stat(srcPath)
 		dstInfo, _ := os.Stat(dstPath)
-		if srcInfo.Mode() != dstInfo.Mode() {
-			t.Fatalf("CopyFile() mode = %v, want %v", dstInfo.Mode(), srcInfo.Mode())
-		}
+		assert.Equal(t, srcInfo.Mode(), dstInfo.Mode())
 	})
 
 	t.Run("non-existent source", func(t *testing.T) {
-		err := CopyFile("/nonexistent/file", "/tmp/dst", true)
-		if err == nil {
-			t.Fatal("CopyFile() expected error for non-existent source")
-		}
+		assert.Error(t, CopyFile("/nonexistent/file", "/tmp/dst", true))
 	})
 
 	t.Run("non-existent destination directory", func(t *testing.T) {
-		err := CopyFile(srcPath, "/nonexistent/dir/file", true)
-		if err == nil {
-			t.Fatal("CopyFile() expected error for non-existent destination directory")
-		}
+		assert.Error(t, CopyFile(srcPath, "/nonexistent/dir/file", true))
 	})
 }
 
 func TestCopyDir(t *testing.T) {
 	srcDir, err := os.MkdirTemp("", "test_copydir_src_*")
-	if err != nil {
-		t.Fatalf("failed to create source dir: %v", err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(srcDir) }()
 
-	if err := os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("one"), 0644); err != nil {
-		t.Fatalf("failed to create file1: %v", err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("one"), 0644))
 	subDir := filepath.Join(srcDir, "subdir")
-	if err := os.Mkdir(subDir, 0755); err != nil {
-		t.Fatalf("failed to create subdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(subDir, "file2.txt"), []byte("two"), 0644); err != nil {
-		t.Fatalf("failed to create file2: %v", err)
-	}
+	require.NoError(t, os.Mkdir(subDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "file2.txt"), []byte("two"), 0644))
 
 	t.Run("basic directory copy", func(t *testing.T) {
 		dstDir, err := os.MkdirTemp("", "test_copydir_dst_*")
-		if err != nil {
-			t.Fatalf("failed to create dst dir: %v", err)
-		}
+		require.NoError(t, err)
 		_ = os.RemoveAll(dstDir)
 		defer func() { _ = os.RemoveAll(dstDir) }()
 
-		err = CopyDir(srcDir, dstDir, false)
-		if err != nil {
-			t.Fatalf("CopyDir() error: %v", err)
-		}
+		require.NoError(t, CopyDir(srcDir, dstDir, false))
 
 		got1, err := os.ReadFile(filepath.Join(dstDir, "file1.txt"))
-		if err != nil {
-			t.Fatalf("file1.txt not copied: %v", err)
-		}
-		if string(got1) != "one" {
-			t.Fatalf("file1.txt content = %q, want %q", got1, "one")
-		}
+		require.NoError(t, err, "file1.txt not copied")
+		assert.Equal(t, "one", string(got1))
 
 		got2, err := os.ReadFile(filepath.Join(dstDir, "subdir", "file2.txt"))
-		if err != nil {
-			t.Fatalf("subdir/file2.txt not copied: %v", err)
-		}
-		if string(got2) != "two" {
-			t.Fatalf("subdir/file2.txt content = %q, want %q", got2, "two")
-		}
+		require.NoError(t, err, "subdir/file2.txt not copied")
+		assert.Equal(t, "two", string(got2))
 	})
 
 	t.Run("reject infinite recursion", func(t *testing.T) {
 		dst := filepath.Join(srcDir, "inside")
-		err := CopyDir(srcDir, dst, false)
-		if err == nil {
-			t.Fatal("CopyDir() expected error for dst inside src")
-		}
+		assert.Error(t, CopyDir(srcDir, dst, false))
 	})
 
 	t.Run("overwrite existing directory", func(t *testing.T) {
 		dstDir, err := os.MkdirTemp("", "test_copydir_overwrite_*")
-		if err != nil {
-			t.Fatalf("failed to create dst dir: %v", err)
-		}
+		require.NoError(t, err)
 		defer func() { _ = os.RemoveAll(dstDir) }()
 
 		// Create existing content that should be replaced
-		if err := os.WriteFile(filepath.Join(dstDir, "old.txt"), []byte("old"), 0644); err != nil {
-			t.Fatalf("failed to create old file: %v", err)
-		}
+		require.NoError(t, os.WriteFile(filepath.Join(dstDir, "old.txt"), []byte("old"), 0644))
 
-		err = CopyDir(srcDir, dstDir, true)
-		if err != nil {
-			t.Fatalf("CopyDir() with overwrite error: %v", err)
-		}
+		require.NoError(t, CopyDir(srcDir, dstDir, true))
 
 		// New content should exist
 		got, err := os.ReadFile(filepath.Join(dstDir, "file1.txt"))
-		if err != nil {
-			t.Fatalf("file1.txt not copied: %v", err)
-		}
-		if string(got) != "one" {
-			t.Fatalf("file1.txt content = %q, want %q", got, "one")
-		}
+		require.NoError(t, err, "file1.txt not copied")
+		assert.Equal(t, "one", string(got))
 
 		// Old content should not exist
-		if _, err := os.Stat(filepath.Join(dstDir, "old.txt")); !os.IsNotExist(err) {
-			t.Fatal("old.txt should not exist after overwrite")
-		}
+		_, err = os.Stat(filepath.Join(dstDir, "old.txt"))
+		assert.True(t, os.IsNotExist(err), "old.txt should not exist after overwrite")
 	})
 
 	t.Run("non-existent source returns error", func(t *testing.T) {
-		err := CopyDir("/nonexistent/source", "/tmp/dst", false)
-		if err == nil {
-			t.Fatal("CopyDir() expected error for non-existent source")
-		}
+		assert.Error(t, CopyDir("/nonexistent/source", "/tmp/dst", false))
 	})
 }
 
 func TestGetCopyPath(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "test_getcopypath_*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	srcPath := filepath.Join(tmpDir, "file.txt")
-	if err := os.WriteFile(srcPath, []byte("test"), 0644); err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(srcPath, []byte("test"), 0644))
 
 	t.Run("generates numbered copy", func(t *testing.T) {
-		got := GetCopyPath(srcPath, srcPath)
-		expected := filepath.Join(tmpDir, "file (1).txt")
-		if got != expected {
-			t.Fatalf("GetCopyPath() = %q, want %q", got, expected)
-		}
+		assert.Equal(t, filepath.Join(tmpDir, "file (1).txt"), GetCopyPath(srcPath, srcPath))
 	})
 
 	t.Run("skips existing numbered copies", func(t *testing.T) {
 		copy1 := filepath.Join(tmpDir, "file (1).txt")
-		if err := os.WriteFile(copy1, []byte("copy"), 0644); err != nil {
-			t.Fatalf("failed to create copy: %v", err)
-		}
+		require.NoError(t, os.WriteFile(copy1, []byte("copy"), 0644))
 
-		got := GetCopyPath(srcPath, srcPath)
-		expected := filepath.Join(tmpDir, "file (2).txt")
-		if got != expected {
-			t.Fatalf("GetCopyPath() = %q, want %q", got, expected)
-		}
+		assert.Equal(t, filepath.Join(tmpDir, "file (2).txt"), GetCopyPath(srcPath, srcPath))
 	})
 }
 
 func TestChownRecursive(t *testing.T) {
 	t.Run("non-existent path returns error", func(t *testing.T) {
-		err := ChownRecursive("/nonexistent/path", 1000, 1000)
-		if err == nil {
-			t.Fatal("ChownRecursive() expected error for non-existent path")
-		}
+		assert.Error(t, ChownRecursive("/nonexistent/path", 1000, 1000))
 	})
 }
 
 func makeZipFile(t *testing.T, path string) {
 	t.Helper()
 	f, err := os.Create(path)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	w := zip.NewWriter(f)
 	_ = w.Close()
 	_ = f.Close()
@@ -272,38 +192,37 @@ func TestOpenIfZip(t *testing.T) {
 		p := filepath.Join(tmpDir, "valid.zip")
 		makeZipFile(t, p)
 		rc := OpenIfZip(p, ".zip")
-		if rc == nil {
-			t.Fatal("expected non-nil ReadCloser for valid zip")
-		}
+		require.NotNil(t, rc)
 		_ = rc.Close()
 	})
 
 	t.Run("non-zip file returns nil", func(t *testing.T) {
 		p := filepath.Join(tmpDir, "plain.txt")
-		if err := os.WriteFile(p, []byte("hello"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if rc := OpenIfZip(p, ".txt"); rc != nil {
+		require.NoError(t, os.WriteFile(p, []byte("hello"), 0644))
+		rc := OpenIfZip(p, ".txt")
+		if rc != nil {
 			_ = rc.Close()
-			t.Fatal("expected nil for non-zip content")
 		}
+		assert.Nil(t, rc)
 	})
 
 	t.Run("denylisted extension returns nil", func(t *testing.T) {
 		p := filepath.Join(tmpDir, "lib.jar")
 		makeZipFile(t, p)
-		if rc := OpenIfZip(p, ".jar"); rc != nil {
+		rc := OpenIfZip(p, ".jar")
+		if rc != nil {
 			_ = rc.Close()
-			t.Fatal("expected nil for denylisted .jar extension")
 		}
+		assert.Nil(t, rc)
 	})
 
 	t.Run("uppercase denylisted extension returns nil", func(t *testing.T) {
 		p := filepath.Join(tmpDir, "lib.JAR")
 		makeZipFile(t, p)
-		if rc := OpenIfZip(p, ".JAR"); rc != nil {
+		rc := OpenIfZip(p, ".JAR")
+		if rc != nil {
 			_ = rc.Close()
-			t.Fatal("expected nil for denylisted .JAR extension")
 		}
+		assert.Nil(t, rc)
 	})
 }


### PR DESCRIPTION
First PR for #370. Scope is `pkg/utils` only—`fs_test.go` and `archive_test.go`.

`pkg/utils` is a leaf package with no test helpers of its own, and it carried both patterns the issue is about: checks that must stop the test and checks that can keep reporting. That makes it the right place to settle how `require` and `assert` get chosen before the other nine packages follow.

## What changed

Every hand-written check becomes testify. `require` where the test cannot continue past a failure—setup, and anything the next line dereferences or indexes. `assert` where it can keep reporting. No test was added, removed, or renamed; `go test -v` reports the same 217 PASS lines on this branch as on `main`.

```
pkg/utils/archive_test.go | 184 +++++++++++-----------------------
pkg/utils/fs_test.go      | 249 ++++++++++++++++------------------------------
2 files changed, 144 insertions(+), 289 deletions(-)
```

## Two conversions that are not mechanical

These are the spots where the obvious testify call is not equivalent to the code it replaces, so they are written differently on purpose.

**`assert.Equal` on `[]byte` separates nil from empty.** `ObjectsAreEqual` short-circuits when either side is a nil slice, so `assert.Equal(t, content, got)` fails on a nil/empty mismatch that the old `string(got) != string(content)` treated as equal. The content checks compare strings to keep the original meaning.

**`assert.NoFileExists` is looser than the not-exist check it would replace.** It returns true on *any* `Lstat` error and true when the path is a directory. The overwrite check keeps `os.Stat` and asserts the error itself—`assert.ErrorIs(t, err, os.ErrNotExist)`—rather than accepting a permission error as proof of deletion.

## Three checks moved from `t.Fatalf` to `assert`

The content comparisons in `TestCopyFile/basic copy` and both `TestCopyDir` subtests stop the test today and no longer will. Nothing downstream of them dereferences the compared values, so a failure reports and continues instead of hiding the checks below it.

The original file has 41 checks and zero `t.Errorf`, and the same author's `archive_test.go`—added five weeks later—uses `t.Errorf` for this exact content-comparison pattern. The review on #221 does not discuss the choice. So the uniform `t.Fatalf` reads as the default rather than a decision, and these three read better as `assert`.

## Applied from review

Five follow-up commits sit on top of the initial rewrite:

- `4771fc5a` — `TestCopyFile/basic copy` discarded both `os.Stat` errors and then dereferenced the result, so a failing `Stat` panicked instead of failing the test. Both calls now bind the error and `require.NoError` it.
- `0d0ed021` — `assert.True(t, os.IsNotExist(err))` prints only `false` on failure and throws the actual error away. `assert.ErrorIs(t, err, os.ErrNotExist)` keeps the meaning and reports what the error was.
- `e1ae79e4` — the three `OpenIfZip` nil subtests differed only in filename, extension, and whether the file was a real zip, so they fold into a table. The `rc != nil` guard and `assert.Nil` also made the same decision twice; the assertion's return value now drives the cleanup.
- `2761227d` — the zip-slip test asserted only that *an* error occurred, which a merely malformed zip also satisfies. `assert.ErrorContains(t, ..., "illegal file path in zip")` pins it to the guard in `Unzip`.
- `0018bcee` — the zip-construction block was duplicated across `TestUnzip` and `TestUnzip_ZipSlipRejected` and dropped every error inside it: a failing `w.Create` left `zw` nil and panicked on the next line, and a failing `w.Close` silently produced a truncated zip that only surfaced later as a confusing `Unzip` failure. One checked `writeZip` helper replaces both, and absorbs `makeZipFile`—its empty zip is now `writeZip(t, p, nil)`.

## Verification

- `go test ./pkg/utils/ -count=20 -race -shuffle=on` passes
- `go vet ./pkg/utils/...` and `gofmt -l` clean
- No `time.Sleep`, `time.After`, `Ticker`, or `Eventually` in either file

## Left for follow-ups on #370

Not folded in, so this diff stays close to assertion rewrites and "behavior unchanged" is something a reviewer can check by reading:

- `fs_test.go` uses `os.CreateTemp("")`/`os.MkdirTemp("")` six times where `t.TempDir()` would clean up on panic; `archive_test.go` already uses `t.TempDir()`
- `TestGetCopyPath` subtests are order-dependent: the first asserts `file (1).txt` and only holds while the second has not created it yet
- The other 11 test files in `pkg/utils` still hold raw `t.Fatal`/`t.Error` calls; #370's candidate list scopes this PR to these two

Refs #370
