### PR TITLE
test(signing): unify assertion style and consolidate test fixtures

### DIFF
--- a/pkg/signing/fixtures_test.go
+++ b/pkg/signing/fixtures_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+const testServerID = "server-456"
+
+func testKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
 	t.Helper()
 	pub, priv, err := ed25519.GenerateKey(nil)
 	require.NoError(t, err)
@@ -37,27 +39,29 @@ func writeKeyResponse(t *testing.T, w http.ResponseWriter, resp publicKeyRespons
 	assert.NoError(t, json.NewEncoder(w).Encode(resp))
 }
 
-// keyServer serves resp for every request, counting fetches when count is non-nil.
-func keyServer(t *testing.T, count *atomic.Int32, resp publicKeyResponse) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if count != nil {
-			count.Add(1)
-		}
+// keyServer serves resp for every request, counting fetches.
+func keyServer(t *testing.T, resp publicKeyResponse) (*httptest.Server, *atomic.Int32) {
+	var count atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count.Add(1)
 		writeKeyResponse(t, w, resp)
 	}))
+	t.Cleanup(srv.Close)
+	return srv, &count
 }
 
-func newTestServer(t *testing.T, pub ed25519.PublicKey, kid string) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// pathCheckingKeyServer is like keyServer but 404s outside the public-key path.
+func pathCheckingKeyServer(t *testing.T, pub ed25519.PublicKey, kid string) *httptest.Server {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/commands/public-key/" {
 			http.NotFound(w, r)
 			return
 		}
 		writeKeyResponse(t, w, testKeyResponse(pub, kid))
 	}))
+	t.Cleanup(srv.Close)
+	return srv
 }
-
-const testServerID = "server-456"
 
 func testCommand(sig string) *protocol.Command {
 	return &protocol.Command{

--- a/pkg/signing/fixtures_test.go
+++ b/pkg/signing/fixtures_test.go
@@ -22,7 +22,6 @@ func newTestKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
 }
 
 // testKeyResponse is what the AI server returns for an active Ed25519 key.
-// Tests that need an invalid response override a field on the result.
 func testKeyResponse(pub ed25519.PublicKey, kid string) publicKeyResponse {
 	return publicKeyResponse{
 		Algorithm: "Ed25519",

--- a/pkg/signing/fixtures_test.go
+++ b/pkg/signing/fixtures_test.go
@@ -1,0 +1,81 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/alpacax/alpamon/v2/internal/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	return pub, priv
+}
+
+// testKeyResponse is what the AI server returns for an active Ed25519 key.
+// Tests that need an invalid response override a field on the result.
+func testKeyResponse(pub ed25519.PublicKey, kid string) publicKeyResponse {
+	return publicKeyResponse{
+		Algorithm: "Ed25519",
+		PublicKey: base64.StdEncoding.EncodeToString(pub),
+		KeyID:     kid,
+		ValidFrom: "2026-01-01T00:00:00Z",
+	}
+}
+
+func writeKeyResponse(t *testing.T, w http.ResponseWriter, resp publicKeyResponse) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	assert.NoError(t, json.NewEncoder(w).Encode(resp))
+}
+
+// keyServer serves resp for every request, counting fetches when count is non-nil.
+func keyServer(t *testing.T, count *atomic.Int32, resp publicKeyResponse) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if count != nil {
+			count.Add(1)
+		}
+		writeKeyResponse(t, w, resp)
+	}))
+}
+
+func newTestServer(t *testing.T, pub ed25519.PublicKey) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/commands/public-key/" {
+			http.NotFound(w, r)
+			return
+		}
+		writeKeyResponse(t, w, testKeyResponse(pub, "key-test-123"))
+	}))
+}
+
+const testServerID = "server-456"
+
+func testCommand(sig string) *protocol.Command {
+	return &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "whoami",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		Signature:  sig,
+	}
+}
+
+// signedCommand returns a command carrying a signature valid for serverID.
+func signedCommand(t *testing.T, priv ed25519.PrivateKey, serverID string) *protocol.Command {
+	t.Helper()
+	cmd := testCommand("")
+	cmd.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(priv, BuildCanonicalPayload(cmd, serverID)))
+	return cmd
+}

--- a/pkg/signing/fixtures_test.go
+++ b/pkg/signing/fixtures_test.go
@@ -47,13 +47,13 @@ func keyServer(t *testing.T, count *atomic.Int32, resp publicKeyResponse) *httpt
 	}))
 }
 
-func newTestServer(t *testing.T, pub ed25519.PublicKey) *httptest.Server {
+func newTestServer(t *testing.T, pub ed25519.PublicKey, kid string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/commands/public-key/" {
 			http.NotFound(w, r)
 			return
 		}
-		writeKeyResponse(t, w, testKeyResponse(pub, "key-test-123"))
+		writeKeyResponse(t, w, testKeyResponse(pub, kid))
 	}))
 }
 

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -50,7 +50,7 @@ func TestIsLocalEnv(t *testing.T) {
 
 func TestKeyManager_Refresh(t *testing.T) {
 	pub, _ := newTestKey(t)
-	server := newTestServer(t, pub)
+	server := newTestServer(t, pub, "key-test-123")
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -2,8 +2,6 @@ package signing
 
 import (
 	"crypto/ed25519"
-	"encoding/base64"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -14,50 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func newTestKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
-	t.Helper()
-	pub, priv, err := ed25519.GenerateKey(nil)
-	require.NoError(t, err)
-	return pub, priv
-}
-
-// testKeyResponse is what the AI server returns for an active Ed25519 key.
-// Tests that need an invalid response override a field on the result.
-func testKeyResponse(pub ed25519.PublicKey, kid string) publicKeyResponse {
-	return publicKeyResponse{
-		Algorithm: "Ed25519",
-		PublicKey: base64.StdEncoding.EncodeToString(pub),
-		KeyID:     kid,
-		ValidFrom: "2026-01-01T00:00:00Z",
-	}
-}
-
-func writeKeyResponse(t *testing.T, w http.ResponseWriter, resp publicKeyResponse) {
-	t.Helper()
-	w.Header().Set("Content-Type", "application/json")
-	assert.NoError(t, json.NewEncoder(w).Encode(resp))
-}
-
-// keyServer serves resp for every request, counting fetches when count is non-nil.
-func keyServer(t *testing.T, count *atomic.Int32, resp publicKeyResponse) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if count != nil {
-			count.Add(1)
-		}
-		writeKeyResponse(t, w, resp)
-	}))
-}
-
-func newTestServer(t *testing.T, pub ed25519.PublicKey) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/commands/public-key/" {
-			http.NotFound(w, r)
-			return
-		}
-		writeKeyResponse(t, w, testKeyResponse(pub, "key-test-123"))
-	}))
-}
 
 func TestResolveAuthEnv(t *testing.T) {
 	tests := []struct {

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -9,6 +9,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestServer(pub ed25519.PublicKey) *httptest.Server {
@@ -35,22 +38,13 @@ func TestKeyManager_Refresh(t *testing.T) {
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
-	if err := km.Refresh(); err != nil {
-		t.Fatalf("Refresh failed: %v", err)
-	}
+	require.NoError(t, km.Refresh())
 
 	key, err := km.GetPublicKey()
-	if err != nil {
-		t.Fatalf("GetPublicKey failed: %v", err)
-	}
+	require.NoError(t, err)
 
-	if !pub.Equal(key) {
-		t.Error("fetched key does not match expected public key")
-	}
-
-	if km.keyID != "key-test-123" {
-		t.Errorf("expected key ID 'key-test-123', got '%s'", km.keyID)
-	}
+	assert.Equal(t, pub, key)
+	assert.Equal(t, "key-test-123", km.keyID)
 }
 
 func TestKeyManager_CacheHit(t *testing.T) {
@@ -73,17 +67,13 @@ func TestKeyManager_CacheHit(t *testing.T) {
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	// First call fetches
-	if _, err := km.GetPublicKey(); err != nil {
-		t.Fatalf("first GetPublicKey failed: %v", err)
-	}
+	_, err := km.GetPublicKey()
+	require.NoError(t, err)
 	// Second call should use cache
-	if _, err := km.GetPublicKey(); err != nil {
-		t.Fatalf("second GetPublicKey failed: %v", err)
-	}
+	_, err = km.GetPublicKey()
+	require.NoError(t, err)
 
-	if fetchCount.Load() != 1 {
-		t.Errorf("expected 1 fetch, got %d", fetchCount.Load())
-	}
+	assert.Equal(t, int32(1), fetchCount.Load())
 }
 
 func TestKeyManager_CacheExpiry(t *testing.T) {
@@ -105,30 +95,24 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
-	if _, err := km.GetPublicKey(); err != nil {
-		t.Fatalf("first GetPublicKey failed: %v", err)
-	}
+	_, err := km.GetPublicKey()
+	require.NoError(t, err)
 	// Simulate cache expiry by moving lastFetch into the past
 	km.mu.Lock()
 	km.lastFetch = time.Now().Add(-2 * time.Hour)
 	km.mu.Unlock()
 
-	if _, err := km.GetPublicKey(); err != nil {
-		t.Fatalf("second GetPublicKey failed: %v", err)
-	}
+	_, err = km.GetPublicKey()
+	require.NoError(t, err)
 
-	if fetchCount.Load() != 2 {
-		t.Errorf("expected 2 fetches after cache expiry, got %d", fetchCount.Load())
-	}
+	assert.Equal(t, int32(2), fetchCount.Load())
 }
 
 func TestKeyManager_ServerUnavailable(t *testing.T) {
 	km := NewKeyManager("http://localhost:1", 3600, "", &http.Client{Timeout: 1 * time.Second})
 
 	_, err := km.GetPublicKey()
-	if err == nil {
-		t.Error("expected error when server is unavailable")
-	}
+	assert.Error(t, err)
 }
 
 func TestKeyManager_InvalidAlgorithm(t *testing.T) {
@@ -146,9 +130,7 @@ func TestKeyManager_InvalidAlgorithm(t *testing.T) {
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	_, err := km.GetPublicKey()
-	if err == nil {
-		t.Error("expected error for unsupported algorithm")
-	}
+	assert.Error(t, err)
 }
 
 func TestKeyManager_InvalidKeySize(t *testing.T) {
@@ -166,9 +148,7 @@ func TestKeyManager_InvalidKeySize(t *testing.T) {
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	_, err := km.GetPublicKey()
-	if err == nil {
-		t.Error("expected error for invalid key size")
-	}
+	assert.Error(t, err)
 }
 
 func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
@@ -192,21 +172,13 @@ func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 
 	// First call fetches
 	key1, err := km.GetPublicKeyForKID("key-test-123")
-	if err != nil {
-		t.Fatalf("first GetPublicKeyForKID failed: %v", err)
-	}
+	require.NoError(t, err)
 	// Second call with same kid should use cache
 	key2, err := km.GetPublicKeyForKID("key-test-123")
-	if err != nil {
-		t.Fatalf("second GetPublicKeyForKID failed: %v", err)
-	}
+	require.NoError(t, err)
 
-	if !key1.Equal(key2) {
-		t.Error("keys should match")
-	}
-	if fetchCount.Load() != 1 {
-		t.Errorf("expected 1 fetch for matching kid, got %d", fetchCount.Load())
-	}
+	assert.Equal(t, key1, key2)
+	assert.Equal(t, int32(1), fetchCount.Load())
 }
 
 func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
@@ -231,17 +203,13 @@ func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 
 	// Request matching kid: success
 	_, err := km.GetPublicKeyForKID("key-v2")
-	if err != nil {
-		t.Fatalf("expected success when kid matches active key: %v", err)
-	}
+	require.NoError(t, err, "expected success when kid matches active key")
 
 	// Request non-matching kid: refresh returns key-v2 again, kid still
 	// doesn't match → error. This prevents a compromised relay from
 	// directing alpamon to accept an arbitrary key.
 	_, err = km.GetPublicKeyForKID("key-v999")
-	if err == nil {
-		t.Error("expected error when kid doesn't match the active key for this environment")
-	}
+	assert.Error(t, err, "expected error when kid doesn't match the active key for this environment")
 }
 
 func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
@@ -277,25 +245,15 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 
 	// Fetch key-v1 (active before rotation)
 	key1, err := km.GetPublicKeyForKID("key-v1")
-	if err != nil {
-		t.Fatalf("first fetch failed: %v", err)
-	}
-	if !key1.Equal(pub1) {
-		t.Error("first key should be pub1")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, pub1, key1)
 
 	// Request key-v2: kid mismatch triggers env-scoped refresh,
 	// which now returns key-v2 (rotated active key).
 	key2, err := km.GetPublicKeyForKID("key-v2")
-	if err != nil {
-		t.Fatalf("second fetch failed: %v", err)
-	}
-	if !key2.Equal(pub2) {
-		t.Error("second key should be pub2")
-	}
-	if fetchCount.Load() != 2 {
-		t.Errorf("expected 2 fetches for key rotation, got %d", fetchCount.Load())
-	}
+	require.NoError(t, err)
+	assert.Equal(t, pub2, key2)
+	assert.Equal(t, int32(2), fetchCount.Load())
 }
 
 func TestKeyManager_ExpiresAt(t *testing.T) {
@@ -318,28 +276,21 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client()) // Long TTL, but expires_at overrides
 
-	if _, err := km.GetPublicKey(); err != nil {
-		t.Fatalf("first GetPublicKey failed: %v", err)
-	}
+	_, err := km.GetPublicKey()
+	require.NoError(t, err)
 	// Should use cache (not expired yet)
-	if _, err := km.GetPublicKey(); err != nil {
-		t.Fatalf("second GetPublicKey failed: %v", err)
-	}
-	if fetchCount.Load() != 1 {
-		t.Errorf("expected 1 fetch before expiry, got %d", fetchCount.Load())
-	}
+	_, err = km.GetPublicKey()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), fetchCount.Load())
 
 	// Simulate expires_at having passed by moving it into the past
 	km.mu.Lock()
 	km.expiresAt = time.Now().Add(-1 * time.Second)
 	km.mu.Unlock()
 
-	if _, err := km.GetPublicKey(); err != nil {
-		t.Fatalf("third GetPublicKey failed: %v", err)
-	}
-	if fetchCount.Load() != 2 {
-		t.Errorf("expected 2 fetches after expires_at, got %d", fetchCount.Load())
-	}
+	_, err = km.GetPublicKey()
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), fetchCount.Load())
 }
 
 func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
@@ -366,9 +317,7 @@ func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
 
 	// First fetch succeeds
 	_, err := km.GetPublicKey()
-	if err != nil {
-		t.Fatalf("first fetch should succeed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Simulate cache expiry
 	km.mu.Lock()
@@ -377,9 +326,7 @@ func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
 
 	// Expired key + refresh failure should return error, not stale key
 	_, err = km.GetPublicKey()
-	if err == nil {
-		t.Error("expected error when key is expired and refresh fails")
-	}
+	assert.Error(t, err, "expected error when key is expired and refresh fails")
 }
 
 func TestResolveAuthEnv(t *testing.T) {
@@ -396,10 +343,7 @@ func TestResolveAuthEnv(t *testing.T) {
 		{"invalid-url", ""},
 	}
 	for _, tt := range tests {
-		got := ResolveAuthEnv(tt.serverURL)
-		if got != tt.want {
-			t.Errorf("ResolveAuthEnv(%q) = %q, want %q", tt.serverURL, got, tt.want)
-		}
+		assert.Equal(t, tt.want, ResolveAuthEnv(tt.serverURL), "ResolveAuthEnv(%q)", tt.serverURL)
 	}
 }
 
@@ -416,10 +360,7 @@ func TestIsLocalEnv(t *testing.T) {
 		{"invalid-url", false},
 	}
 	for _, tt := range tests {
-		got := IsLocalEnv(tt.serverURL)
-		if got != tt.want {
-			t.Errorf("IsLocalEnv(%q) = %v, want %v", tt.serverURL, got, tt.want)
-		}
+		assert.Equal(t, tt.want, IsLocalEnv(tt.serverURL), "IsLocalEnv(%q)", tt.serverURL)
 	}
 }
 
@@ -445,21 +386,14 @@ func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
 	// With authEnv="dev", requests should include ?auth_env=dev
 	km := NewKeyManager(server.URL, 3600, "dev", server.Client())
 	_, err := km.GetPublicKey()
-	if err != nil {
-		t.Fatalf("GetPublicKey failed: %v", err)
-	}
-	if !authEnvPresent || receivedAuthEnv != "dev" {
-		t.Errorf("expected auth_env=dev in request, got present=%v value=%q", authEnvPresent, receivedAuthEnv)
-	}
+	require.NoError(t, err)
+	assert.True(t, authEnvPresent, "expected auth_env in request")
+	assert.Equal(t, "dev", receivedAuthEnv)
 
 	// With empty authEnv, requests should not include auth_env param at all
 	authEnvPresent = true // reset
 	km2 := NewKeyManager(server.URL, 3600, "", server.Client())
 	_, err = km2.GetPublicKey()
-	if err != nil {
-		t.Fatalf("GetPublicKey failed: %v", err)
-	}
-	if authEnvPresent {
-		t.Errorf("expected auth_env param to be absent, but it was present with value %q", receivedAuthEnv)
-	}
+	require.NoError(t, err)
+	assert.False(t, authEnvPresent, "expected auth_env param to be absent, but it was present with value %q", receivedAuthEnv)
 }

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -58,6 +58,41 @@ func newTestServer(t *testing.T, pub ed25519.PublicKey) *httptest.Server {
 	}))
 }
 
+func TestResolveAuthEnv(t *testing.T) {
+	tests := []struct {
+		serverURL string
+		want      string
+	}{
+		{"https://dev.alpacon.io", "dev"},
+		{"https://dev.alpacon.io/", "dev"},
+		{"https://us.alpacon.io", ""},
+		{"https://kr.alpacon.io", ""},
+		{"https://dev.example.com", ""},
+		{"http://localhost:8000", ""},
+		{"invalid-url", ""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, ResolveAuthEnv(tt.serverURL), "ResolveAuthEnv(%q)", tt.serverURL)
+	}
+}
+
+func TestIsLocalEnv(t *testing.T) {
+	tests := []struct {
+		serverURL string
+		want      bool
+	}{
+		{"http://localhost:8000", true},
+		{"http://127.0.0.1:8000", true},
+		{"http://[::1]:8000", true},
+		{"https://dev.alpacon.io", false},
+		{"https://us.alpacon.io", false},
+		{"invalid-url", false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, IsLocalEnv(tt.serverURL), "IsLocalEnv(%q)", tt.serverURL)
+	}
+}
+
 func TestKeyManager_Refresh(t *testing.T) {
 	pub, _ := newTestKey(t)
 	server := newTestServer(t, pub)
@@ -113,6 +148,63 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(2), fetchCount.Load())
+}
+
+func TestKeyManager_ExpiresAt(t *testing.T) {
+	pub, _ := newTestKey(t)
+
+	var fetchCount atomic.Int32
+	resp := testKeyResponse(pub, "key-test")
+	resp.ExpiresAt = "2099-01-01T00:00:00Z"
+	server := keyServer(t, &fetchCount, resp)
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, "", server.Client()) // Long TTL, but expires_at overrides
+
+	_, err := km.GetPublicKey()
+	require.NoError(t, err)
+	// Should use cache (not expired yet)
+	_, err = km.GetPublicKey()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), fetchCount.Load())
+
+	// Simulate expires_at having passed by moving it into the past
+	km.mu.Lock()
+	km.expiresAt = time.Now().Add(-1 * time.Second)
+	km.mu.Unlock()
+
+	_, err = km.GetPublicKey()
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), fetchCount.Load())
+}
+
+func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
+	pub, _ := newTestKey(t)
+
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if callCount.Add(1) > 1 {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		writeKeyResponse(t, w, testKeyResponse(pub, "key-test"))
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
+
+	// First fetch succeeds
+	_, err := km.GetPublicKey()
+	require.NoError(t, err)
+
+	// Simulate cache expiry
+	km.mu.Lock()
+	km.lastFetch = time.Now().Add(-2 * time.Hour)
+	km.mu.Unlock()
+
+	// Expired key + refresh failure should return error, not stale key
+	_, err = km.GetPublicKey()
+	assert.ErrorContains(t, err, "public key expired and refresh failed")
 }
 
 func TestKeyManager_ServerUnavailable(t *testing.T) {
@@ -215,98 +307,6 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pub2, key2)
 	assert.Equal(t, int32(2), fetchCount.Load())
-}
-
-func TestKeyManager_ExpiresAt(t *testing.T) {
-	pub, _ := newTestKey(t)
-
-	var fetchCount atomic.Int32
-	resp := testKeyResponse(pub, "key-test")
-	resp.ExpiresAt = "2099-01-01T00:00:00Z"
-	server := keyServer(t, &fetchCount, resp)
-	defer server.Close()
-
-	km := NewKeyManager(server.URL, 3600, "", server.Client()) // Long TTL, but expires_at overrides
-
-	_, err := km.GetPublicKey()
-	require.NoError(t, err)
-	// Should use cache (not expired yet)
-	_, err = km.GetPublicKey()
-	require.NoError(t, err)
-	assert.Equal(t, int32(1), fetchCount.Load())
-
-	// Simulate expires_at having passed by moving it into the past
-	km.mu.Lock()
-	km.expiresAt = time.Now().Add(-1 * time.Second)
-	km.mu.Unlock()
-
-	_, err = km.GetPublicKey()
-	require.NoError(t, err)
-	assert.Equal(t, int32(2), fetchCount.Load())
-}
-
-func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
-	pub, _ := newTestKey(t)
-
-	var callCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if callCount.Add(1) > 1 {
-			http.Error(w, "server error", http.StatusInternalServerError)
-			return
-		}
-		writeKeyResponse(t, w, testKeyResponse(pub, "key-test"))
-	}))
-	defer server.Close()
-
-	km := NewKeyManager(server.URL, 3600, "", server.Client())
-
-	// First fetch succeeds
-	_, err := km.GetPublicKey()
-	require.NoError(t, err)
-
-	// Simulate cache expiry
-	km.mu.Lock()
-	km.lastFetch = time.Now().Add(-2 * time.Hour)
-	km.mu.Unlock()
-
-	// Expired key + refresh failure should return error, not stale key
-	_, err = km.GetPublicKey()
-	assert.ErrorContains(t, err, "public key expired and refresh failed")
-}
-
-func TestResolveAuthEnv(t *testing.T) {
-	tests := []struct {
-		serverURL string
-		want      string
-	}{
-		{"https://dev.alpacon.io", "dev"},
-		{"https://dev.alpacon.io/", "dev"},
-		{"https://us.alpacon.io", ""},
-		{"https://kr.alpacon.io", ""},
-		{"https://dev.example.com", ""},
-		{"http://localhost:8000", ""},
-		{"invalid-url", ""},
-	}
-	for _, tt := range tests {
-		assert.Equal(t, tt.want, ResolveAuthEnv(tt.serverURL), "ResolveAuthEnv(%q)", tt.serverURL)
-	}
-}
-
-func TestIsLocalEnv(t *testing.T) {
-	tests := []struct {
-		serverURL string
-		want      bool
-	}{
-		{"http://localhost:8000", true},
-		{"http://127.0.0.1:8000", true},
-		{"http://[::1]:8000", true},
-		{"https://dev.alpacon.io", false},
-		{"https://us.alpacon.io", false},
-		{"invalid-url", false},
-	}
-	for _, tt := range tests {
-		assert.Equal(t, tt.want, IsLocalEnv(tt.serverURL), "IsLocalEnv(%q)", tt.serverURL)
-	}
 }
 
 func TestKeyManager_AuthEnvQueryParam(t *testing.T) {

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -73,10 +73,8 @@ func TestKeyManager_CacheHit(t *testing.T) {
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
-	// First call fetches
 	_, err := km.GetPublicKey()
 	require.NoError(t, err)
-	// Second call should use cache
 	_, err = km.GetPublicKey()
 	require.NoError(t, err)
 
@@ -94,7 +92,7 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 
 	_, err := km.GetPublicKey()
 	require.NoError(t, err)
-	// Simulate cache expiry by moving lastFetch into the past
+	// Simulate cache expiry
 	km.mu.Lock()
 	km.lastFetch = time.Now().Add(-2 * time.Hour)
 	km.mu.Unlock()
@@ -118,12 +116,11 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 
 	_, err := km.GetPublicKey()
 	require.NoError(t, err)
-	// Should use cache (not expired yet)
 	_, err = km.GetPublicKey()
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), fetchCount.Load())
 
-	// Simulate expires_at having passed by moving it into the past
+	// Simulate expires_at having passed
 	km.mu.Lock()
 	km.expiresAt = time.Now().Add(-1 * time.Second)
 	km.mu.Unlock()
@@ -148,7 +145,6 @@ func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
-	// First fetch succeeds
 	_, err := km.GetPublicKey()
 	require.NoError(t, err)
 
@@ -157,7 +153,7 @@ func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
 	km.lastFetch = time.Now().Add(-2 * time.Hour)
 	km.mu.Unlock()
 
-	// Expired key + refresh failure should return error, not stale key
+	// Must not fall back to the stale key
 	_, err = km.GetPublicKey()
 	assert.ErrorContains(t, err, "public key expired and refresh failed")
 }
@@ -200,10 +196,8 @@ func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
-	// First call fetches
 	key1, err := km.GetPublicKeyForKID("key-test-123")
 	require.NoError(t, err)
-	// Second call with same kid should use cache
 	key2, err := km.GetPublicKeyForKID("key-test-123")
 	require.NoError(t, err)
 
@@ -214,21 +208,16 @@ func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 	pub, _ := newTestKey(t)
 
-	// Server always returns the active key for this env (key-v2).
-	// Alpamon should reject commands signed with a kid that doesn't match
-	// the active key, even after refreshing.
+	// Alpamon must reject a kid that does not match the active key, even
+	// though the refresh returns that same active key.
 	server := keyServer(t, nil, testKeyResponse(pub, "key-v2"))
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
-	// Request matching kid: success
 	_, err := km.GetPublicKeyForKID("key-v2")
 	require.NoError(t, err, "expected success when kid matches active key")
 
-	// Request non-matching kid: refresh returns key-v2 again, kid still
-	// doesn't match → error. This prevents a compromised relay from
-	// directing alpamon to accept an arbitrary key.
 	_, err = km.GetPublicKeyForKID("key-v999")
 	assert.ErrorContains(t, err, `key "key-v999" is not the active key for this environment`)
 }
@@ -238,8 +227,6 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 	pub2, _ := newTestKey(t)
 
 	var fetchCount atomic.Int32
-	// Server simulates key rotation: first fetch returns key-v1,
-	// subsequent fetches return key-v2 (the new active key).
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := testKeyResponse(pub2, "key-v2")
 		if fetchCount.Add(1) == 1 {
@@ -251,13 +238,10 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
-	// Fetch key-v1 (active before rotation)
 	key1, err := km.GetPublicKeyForKID("key-v1")
 	require.NoError(t, err)
 	assert.Equal(t, pub1, key1)
 
-	// Request key-v2: kid mismatch triggers env-scoped refresh,
-	// which now returns key-v2 (rotated active key).
 	key2, err := km.GetPublicKeyForKID("key-v2")
 	require.NoError(t, err)
 	assert.Equal(t, pub2, key2)
@@ -277,7 +261,6 @@ func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// With authEnv="dev", requests should include ?auth_env=dev
 	km := NewKeyManager(server.URL, 3600, "dev", server.Client())
 	_, err := km.GetPublicKey()
 	require.NoError(t, err)
@@ -286,7 +269,6 @@ func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
 	assert.Contains(t, *q, "auth_env")
 	assert.Equal(t, "dev", q.Get("auth_env"))
 
-	// With empty authEnv, requests should not include auth_env param at all
 	km2 := NewKeyManager(server.URL, 3600, "", server.Client())
 	_, err = km2.GetPublicKey()
 	require.NoError(t, err)

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -112,7 +112,7 @@ func TestKeyManager_ServerUnavailable(t *testing.T) {
 	km := NewKeyManager("http://localhost:1", 3600, "", &http.Client{Timeout: 1 * time.Second})
 
 	_, err := km.GetPublicKey()
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to fetch public key")
 }
 
 func TestKeyManager_InvalidAlgorithm(t *testing.T) {
@@ -130,7 +130,7 @@ func TestKeyManager_InvalidAlgorithm(t *testing.T) {
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	_, err := km.GetPublicKey()
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unsupported algorithm: RSA")
 }
 
 func TestKeyManager_InvalidKeySize(t *testing.T) {
@@ -148,7 +148,7 @@ func TestKeyManager_InvalidKeySize(t *testing.T) {
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	_, err := km.GetPublicKey()
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid public key size")
 }
 
 func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
@@ -209,7 +209,7 @@ func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 	// doesn't match → error. This prevents a compromised relay from
 	// directing alpamon to accept an arbitrary key.
 	_, err = km.GetPublicKeyForKID("key-v999")
-	assert.Error(t, err, "expected error when kid doesn't match the active key for this environment")
+	assert.ErrorContains(t, err, `key "key-v999" is not the active key for this environment`)
 }
 
 func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
@@ -326,7 +326,7 @@ func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
 
 	// Expired key + refresh failure should return error, not stale key
 	_, err = km.GetPublicKey()
-	assert.Error(t, err, "expected error when key is expired and refresh fails")
+	assert.ErrorContains(t, err, "public key expired and refresh failed")
 }
 
 func TestResolveAuthEnv(t *testing.T) {

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -27,7 +27,9 @@ func TestResolveAuthEnv(t *testing.T) {
 		{"invalid-url", ""},
 	}
 	for _, tt := range tests {
-		assert.Equal(t, tt.want, ResolveAuthEnv(tt.serverURL), "ResolveAuthEnv(%q)", tt.serverURL)
+		t.Run(tt.serverURL, func(t *testing.T) {
+			assert.Equal(t, tt.want, ResolveAuthEnv(tt.serverURL))
+		})
 	}
 }
 
@@ -44,7 +46,9 @@ func TestIsLocalEnv(t *testing.T) {
 		{"invalid-url", false},
 	}
 	for _, tt := range tests {
-		assert.Equal(t, tt.want, IsLocalEnv(tt.serverURL), "IsLocalEnv(%q)", tt.serverURL)
+		t.Run(tt.serverURL, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsLocalEnv(tt.serverURL))
+		})
 	}
 }
 

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -312,11 +313,12 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
 	pub, _ := newTestKey(t)
 
-	var receivedAuthEnv string
-	var authEnvPresent bool
+	// The handler runs on the server's goroutine and the assertions read from
+	// the test's, so the query crosses goroutines and needs to be published.
+	var lastQuery atomic.Pointer[url.Values]
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, authEnvPresent = r.URL.Query()["auth_env"]
-		receivedAuthEnv = r.URL.Query().Get("auth_env")
+		q := r.URL.Query()
+		lastQuery.Store(&q)
 		writeKeyResponse(t, w, testKeyResponse(pub, "key-dev-1"))
 	}))
 	defer server.Close()
@@ -325,13 +327,16 @@ func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
 	km := NewKeyManager(server.URL, 3600, "dev", server.Client())
 	_, err := km.GetPublicKey()
 	require.NoError(t, err)
-	assert.True(t, authEnvPresent, "expected auth_env in request")
-	assert.Equal(t, "dev", receivedAuthEnv)
+	q := lastQuery.Load()
+	require.NotNil(t, q)
+	assert.Contains(t, *q, "auth_env")
+	assert.Equal(t, "dev", q.Get("auth_env"))
 
 	// With empty authEnv, requests should not include auth_env param at all
-	authEnvPresent = true // reset
 	km2 := NewKeyManager(server.URL, 3600, "", server.Client())
 	_, err = km2.GetPublicKey()
 	require.NoError(t, err)
-	assert.False(t, authEnvPresent, "expected auth_env param to be absent, but it was present with value %q", receivedAuthEnv)
+	q = lastQuery.Load()
+	require.NotNil(t, q)
+	assert.NotContains(t, *q, "auth_env")
 }

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -49,9 +49,8 @@ func TestIsLocalEnv(t *testing.T) {
 }
 
 func TestKeyManager_Refresh(t *testing.T) {
-	pub, _ := newTestKey(t)
-	server := newTestServer(t, pub, "key-test-123")
-	defer server.Close()
+	pub, _ := testKey(t)
+	server := pathCheckingKeyServer(t, pub, "key-test-123")
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
@@ -65,11 +64,9 @@ func TestKeyManager_Refresh(t *testing.T) {
 }
 
 func TestKeyManager_CacheHit(t *testing.T) {
-	pub, _ := newTestKey(t)
+	pub, _ := testKey(t)
 
-	var fetchCount atomic.Int32
-	server := keyServer(t, &fetchCount, testKeyResponse(pub, "key-test"))
-	defer server.Close()
+	server, fetchCount := keyServer(t, testKeyResponse(pub, "key-test"))
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
@@ -82,11 +79,9 @@ func TestKeyManager_CacheHit(t *testing.T) {
 }
 
 func TestKeyManager_CacheExpiry(t *testing.T) {
-	pub, _ := newTestKey(t)
+	pub, _ := testKey(t)
 
-	var fetchCount atomic.Int32
-	server := keyServer(t, &fetchCount, testKeyResponse(pub, "key-test"))
-	defer server.Close()
+	server, fetchCount := keyServer(t, testKeyResponse(pub, "key-test"))
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
@@ -104,13 +99,11 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 }
 
 func TestKeyManager_ExpiresAt(t *testing.T) {
-	pub, _ := newTestKey(t)
+	pub, _ := testKey(t)
 
-	var fetchCount atomic.Int32
 	resp := testKeyResponse(pub, "key-test")
 	resp.ExpiresAt = "2099-01-01T00:00:00Z"
-	server := keyServer(t, &fetchCount, resp)
-	defer server.Close()
+	server, fetchCount := keyServer(t, resp)
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client()) // Long TTL, but expires_at overrides
 
@@ -131,7 +124,7 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 }
 
 func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
-	pub, _ := newTestKey(t)
+	pub, _ := testKey(t)
 
 	var callCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -168,8 +161,7 @@ func TestKeyManager_ServerUnavailable(t *testing.T) {
 func TestKeyManager_InvalidAlgorithm(t *testing.T) {
 	resp := testKeyResponse(make([]byte, ed25519.PublicKeySize), "key-test")
 	resp.Algorithm = "RSA"
-	server := keyServer(t, nil, resp)
-	defer server.Close()
+	server, _ := keyServer(t, resp)
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
@@ -178,8 +170,7 @@ func TestKeyManager_InvalidAlgorithm(t *testing.T) {
 }
 
 func TestKeyManager_InvalidKeySize(t *testing.T) {
-	server := keyServer(t, nil, testKeyResponse([]byte("tooshort"), "key-test"))
-	defer server.Close()
+	server, _ := keyServer(t, testKeyResponse([]byte("tooshort"), "key-test"))
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
@@ -188,11 +179,9 @@ func TestKeyManager_InvalidKeySize(t *testing.T) {
 }
 
 func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
-	pub, _ := newTestKey(t)
+	pub, _ := testKey(t)
 
-	var fetchCount atomic.Int32
-	server := keyServer(t, &fetchCount, testKeyResponse(pub, "key-test-123"))
-	defer server.Close()
+	server, fetchCount := keyServer(t, testKeyResponse(pub, "key-test-123"))
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
@@ -201,17 +190,17 @@ func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 	key2, err := km.GetPublicKeyForKID("key-test-123")
 	require.NoError(t, err)
 
+	assert.Equal(t, pub, key1)
 	assert.Equal(t, key1, key2)
 	assert.Equal(t, int32(1), fetchCount.Load())
 }
 
 func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
-	pub, _ := newTestKey(t)
+	pub, _ := testKey(t)
 
 	// Alpamon must reject a kid that does not match the active key, even
 	// though the refresh returns that same active key.
-	server := keyServer(t, nil, testKeyResponse(pub, "key-v2"))
-	defer server.Close()
+	server, _ := keyServer(t, testKeyResponse(pub, "key-v2"))
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
@@ -223,8 +212,8 @@ func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 }
 
 func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
-	pub1, _ := newTestKey(t)
-	pub2, _ := newTestKey(t)
+	pub1, _ := testKey(t)
+	pub2, _ := testKey(t)
 
 	var fetchCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -249,7 +238,7 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 }
 
 func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
-	pub, _ := newTestKey(t)
+	pub, _ := testKey(t)
 
 	// The handler runs on the server's goroutine and the assertions read from
 	// the test's, so the query crosses goroutines and needs to be published.
@@ -266,7 +255,6 @@ func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
 	require.NoError(t, err)
 	q := lastQuery.Load()
 	require.NotNil(t, q)
-	assert.Contains(t, *q, "auth_env")
 	assert.Equal(t, "dev", q.Get("auth_env"))
 
 	km2 := NewKeyManager(server.URL, 3600, "", server.Client())

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -14,26 +14,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestServer(pub ed25519.PublicKey) *httptest.Server {
+func newTestKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	return pub, priv
+}
+
+// testKeyResponse is what the AI server returns for an active Ed25519 key.
+// Tests that need an invalid response override a field on the result.
+func testKeyResponse(pub ed25519.PublicKey, kid string) publicKeyResponse {
+	return publicKeyResponse{
+		Algorithm: "Ed25519",
+		PublicKey: base64.StdEncoding.EncodeToString(pub),
+		KeyID:     kid,
+		ValidFrom: "2026-01-01T00:00:00Z",
+	}
+}
+
+func writeKeyResponse(t *testing.T, w http.ResponseWriter, resp publicKeyResponse) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	assert.NoError(t, json.NewEncoder(w).Encode(resp))
+}
+
+// keyServer serves resp for every request, counting fetches when count is non-nil.
+func keyServer(t *testing.T, count *atomic.Int32, resp publicKeyResponse) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if count != nil {
+			count.Add(1)
+		}
+		writeKeyResponse(t, w, resp)
+	}))
+}
+
+func newTestServer(t *testing.T, pub ed25519.PublicKey) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/commands/public-key/" {
 			http.NotFound(w, r)
 			return
 		}
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString(pub),
-			KeyID:     "key-test-123",
-			ValidFrom: "2026-01-01T00:00:00Z",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
+		writeKeyResponse(t, w, testKeyResponse(pub, "key-test-123"))
 	}))
 }
 
 func TestKeyManager_Refresh(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
-	server := newTestServer(pub)
+	pub, _ := newTestKey(t)
+	server := newTestServer(t, pub)
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
@@ -48,20 +75,10 @@ func TestKeyManager_Refresh(t *testing.T) {
 }
 
 func TestKeyManager_CacheHit(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	var fetchCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount.Add(1)
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString(pub),
-			KeyID:     "key-test",
-			ValidFrom: "2026-01-01T00:00:00Z",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	server := keyServer(t, &fetchCount, testKeyResponse(pub, "key-test"))
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
@@ -77,20 +94,10 @@ func TestKeyManager_CacheHit(t *testing.T) {
 }
 
 func TestKeyManager_CacheExpiry(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	var fetchCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount.Add(1)
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString(pub),
-			KeyID:     "key-test",
-			ValidFrom: "2026-01-01T00:00:00Z",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	server := keyServer(t, &fetchCount, testKeyResponse(pub, "key-test"))
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
@@ -116,15 +123,9 @@ func TestKeyManager_ServerUnavailable(t *testing.T) {
 }
 
 func TestKeyManager_InvalidAlgorithm(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := publicKeyResponse{
-			Algorithm: "RSA",
-			PublicKey: base64.StdEncoding.EncodeToString(make([]byte, 32)),
-			KeyID:     "key-test",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	resp := testKeyResponse(make([]byte, ed25519.PublicKeySize), "key-test")
+	resp.Algorithm = "RSA"
+	server := keyServer(t, nil, resp)
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
@@ -134,15 +135,7 @@ func TestKeyManager_InvalidAlgorithm(t *testing.T) {
 }
 
 func TestKeyManager_InvalidKeySize(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString([]byte("tooshort")),
-			KeyID:     "key-test",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	server := keyServer(t, nil, testKeyResponse([]byte("tooshort"), "key-test"))
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
@@ -152,20 +145,10 @@ func TestKeyManager_InvalidKeySize(t *testing.T) {
 }
 
 func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	var fetchCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount.Add(1)
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString(pub),
-			KeyID:     "key-test-123",
-			ValidFrom: "2026-01-01T00:00:00Z",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	server := keyServer(t, &fetchCount, testKeyResponse(pub, "key-test-123"))
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
@@ -182,21 +165,12 @@ func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 }
 
 func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	// Server always returns the active key for this env (key-v2).
 	// Alpamon should reject commands signed with a kid that doesn't match
 	// the active key, even after refreshing.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString(pub),
-			KeyID:     "key-v2",
-			ValidFrom: "2026-01-01T00:00:00Z",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	server := keyServer(t, nil, testKeyResponse(pub, "key-v2"))
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client())
@@ -213,31 +187,18 @@ func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 }
 
 func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
-	pub1, _, _ := ed25519.GenerateKey(nil)
-	pub2, _, _ := ed25519.GenerateKey(nil)
+	pub1, _ := newTestKey(t)
+	pub2, _ := newTestKey(t)
 
 	var fetchCount atomic.Int32
 	// Server simulates key rotation: first fetch returns key-v1,
 	// subsequent fetches return key-v2 (the new active key).
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := fetchCount.Add(1)
-		var pub ed25519.PublicKey
-		var kid string
-		if n == 1 {
-			pub = pub1
-			kid = "key-v1"
-		} else {
-			pub = pub2
-			kid = "key-v2"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := testKeyResponse(pub2, "key-v2")
+		if fetchCount.Add(1) == 1 {
+			resp = testKeyResponse(pub1, "key-v1")
 		}
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString(pub),
-			KeyID:     kid,
-			ValidFrom: "2026-01-01T00:00:00Z",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
+		writeKeyResponse(t, w, resp)
 	}))
 	defer server.Close()
 
@@ -257,21 +218,12 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 }
 
 func TestKeyManager_ExpiresAt(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	var fetchCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount.Add(1)
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString(pub),
-			KeyID:     "key-test",
-			ValidFrom: "2026-01-01T00:00:00Z",
-			ExpiresAt: "2099-01-01T00:00:00Z",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	resp := testKeyResponse(pub, "key-test")
+	resp.ExpiresAt = "2099-01-01T00:00:00Z"
+	server := keyServer(t, &fetchCount, resp)
 	defer server.Close()
 
 	km := NewKeyManager(server.URL, 3600, "", server.Client()) // Long TTL, but expires_at overrides
@@ -294,22 +246,15 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 }
 
 func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	var callCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if callCount.Add(1) > 1 {
 			http.Error(w, "server error", http.StatusInternalServerError)
 			return
 		}
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString(pub),
-			KeyID:     "key-test",
-			ValidFrom: "2026-01-01T00:00:00Z",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
+		writeKeyResponse(t, w, testKeyResponse(pub, "key-test"))
 	}))
 	defer server.Close()
 
@@ -365,21 +310,14 @@ func TestIsLocalEnv(t *testing.T) {
 }
 
 func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	var receivedAuthEnv string
 	var authEnvPresent bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, authEnvPresent = r.URL.Query()["auth_env"]
 		receivedAuthEnv = r.URL.Query().Get("auth_env")
-		resp := publicKeyResponse{
-			Algorithm: "Ed25519",
-			PublicKey: base64.StdEncoding.EncodeToString(pub),
-			KeyID:     "key-dev-1",
-			ValidFrom: "2026-01-01T00:00:00Z",
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
+		writeKeyResponse(t, w, testKeyResponse(pub, "key-dev-1"))
 	}))
 	defer server.Close()
 

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -84,7 +84,7 @@ func TestVerifyCommand_TamperedPayload(t *testing.T) {
 	// Tamper with the command
 	cmd.Line = "rm -rf /"
 
-	assert.Error(t, VerifyCommand(cmd, serverID, pub))
+	assert.ErrorIs(t, VerifyCommand(cmd, serverID, pub), ErrSignatureMismatch)
 }
 
 func TestVerifyCommand_WrongServerID(t *testing.T) {
@@ -103,7 +103,7 @@ func TestVerifyCommand_WrongServerID(t *testing.T) {
 	sig := ed25519.Sign(priv, payload)
 	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
 
-	assert.Error(t, VerifyCommand(cmd, "different-server", pub))
+	assert.ErrorIs(t, VerifyCommand(cmd, "different-server", pub), ErrSignatureMismatch)
 }
 
 func TestVerifyCommand_EmptySignature(t *testing.T) {
@@ -117,7 +117,7 @@ func TestVerifyCommand_EmptySignature(t *testing.T) {
 		Group: "root",
 	}
 
-	assert.Error(t, VerifyCommand(cmd, "server-456", pub))
+	assert.ErrorContains(t, VerifyCommand(cmd, "server-456", pub), "empty signature")
 }
 
 func TestVerifyCommand_InvalidBase64(t *testing.T) {
@@ -132,7 +132,7 @@ func TestVerifyCommand_InvalidBase64(t *testing.T) {
 		Signature: "not-valid-base64!!!",
 	}
 
-	assert.Error(t, VerifyCommand(cmd, "server-456", pub))
+	assert.ErrorContains(t, VerifyCommand(cmd, "server-456", pub), "invalid signature encoding")
 }
 
 func TestVerifyCommand_WrongSignatureSize(t *testing.T) {
@@ -147,7 +147,7 @@ func TestVerifyCommand_WrongSignatureSize(t *testing.T) {
 		Signature: base64.StdEncoding.EncodeToString([]byte("tooshort")),
 	}
 
-	assert.Error(t, VerifyCommand(cmd, "server-456", pub))
+	assert.ErrorContains(t, VerifyCommand(cmd, "server-456", pub), "invalid signature size")
 }
 
 func TestVerifyCommand_NilPublicKey(t *testing.T) {
@@ -160,13 +160,13 @@ func TestVerifyCommand_NilPublicKey(t *testing.T) {
 		Signature: base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)),
 	}
 
-	assert.Error(t, VerifyCommand(cmd, "server-456", nil))
+	assert.ErrorContains(t, VerifyCommand(cmd, "server-456", nil), "invalid public key size")
 }
 
 func TestVerifyCommand_NilCommand(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
-	assert.Error(t, VerifyCommand(nil, "server-456", pub))
+	assert.ErrorContains(t, VerifyCommand(nil, "server-456", pub), "nil command")
 }
 
 func TestBuildCanonicalPayload_NilCommand(t *testing.T) {

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -10,163 +10,126 @@ import (
 )
 
 func TestBuildCanonicalPayload(t *testing.T) {
-	cmd := &protocol.Command{
-		ID:         "test-uuid",
-		Shell:      "system",
-		Line:       "echo hello",
-		User:       "root",
-		Group:      "alpacon",
-		AnalyzedAt: "2026-01-01T00:00:00+00:00",
+	tests := []struct {
+		name     string
+		cmd      *protocol.Command
+		serverID string
+		// Must match Python's json.dumps(sort_keys=True, separators=(',', ':'))
+		want string
+	}{
+		{
+			name: "all fields set",
+			cmd: &protocol.Command{
+				ID:         "test-uuid",
+				Shell:      "system",
+				Line:       "echo hello",
+				User:       "root",
+				Group:      "alpacon",
+				AnalyzedAt: "2026-01-01T00:00:00+00:00",
+			},
+			serverID: "server-uuid",
+			want:     `{"command_id":"test-uuid","groupname":"alpacon","line":"echo hello","server_id":"server-uuid","shell":"system","timestamp":"2026-01-01T00:00:00+00:00","username":"root"}`,
+		},
+		{
+			name: "empty analyzed_at",
+			cmd: &protocol.Command{
+				ID:    "cmd-1",
+				Shell: "system",
+				Line:  "ls",
+				User:  "deploy",
+				Group: "deploy",
+			},
+			serverID: "srv-1",
+			want:     `{"command_id":"cmd-1","groupname":"deploy","line":"ls","server_id":"srv-1","shell":"system","timestamp":"","username":"deploy"}`,
+		},
+		{
+			// <, > and & must not be escaped either, matching json.dumps
+			name: "html characters",
+			cmd: &protocol.Command{
+				ID:         "cmd-1",
+				Shell:      "system",
+				Line:       "echo '<h1>test</h1>' & cat /etc/passwd",
+				User:       "root",
+				Group:      "root",
+				AnalyzedAt: "2026-01-01T00:00:00+00:00",
+			},
+			serverID: "srv-1",
+			want:     `{"command_id":"cmd-1","groupname":"root","line":"echo '<h1>test</h1>' & cat /etc/passwd","server_id":"srv-1","shell":"system","timestamp":"2026-01-01T00:00:00+00:00","username":"root"}`,
+		},
 	}
-
-	payload := BuildCanonicalPayload(cmd, "server-uuid")
-
-	// Must match Python's json.dumps(sort_keys=True, separators=(',', ':'))
-	expected := `{"command_id":"test-uuid","groupname":"alpacon","line":"echo hello","server_id":"server-uuid","shell":"system","timestamp":"2026-01-01T00:00:00+00:00","username":"root"}`
-
-	assert.Equal(t, expected, string(payload))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, string(BuildCanonicalPayload(tt.cmd, tt.serverID)))
+		})
+	}
 }
 
-func TestBuildCanonicalPayload_EmptyAnalyzedAt(t *testing.T) {
-	cmd := &protocol.Command{
-		ID:    "cmd-1",
-		Shell: "system",
-		Line:  "ls",
-		User:  "deploy",
-		Group: "deploy",
+const testServerID = "server-456"
+
+func testCommand(sig string) *protocol.Command {
+	return &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "whoami",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		Signature:  sig,
 	}
+}
 
-	payload := BuildCanonicalPayload(cmd, "srv-1")
-	expected := `{"command_id":"cmd-1","groupname":"deploy","line":"ls","server_id":"srv-1","shell":"system","timestamp":"","username":"deploy"}`
-
-	assert.Equal(t, expected, string(payload))
+// signedCommand returns a command carrying a signature valid for serverID.
+func signedCommand(t *testing.T, priv ed25519.PrivateKey, serverID string) *protocol.Command {
+	t.Helper()
+	cmd := testCommand("")
+	cmd.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(priv, BuildCanonicalPayload(cmd, serverID)))
+	return cmd
 }
 
 func TestVerifyCommand_Valid(t *testing.T) {
 	pub, priv := newTestKey(t)
 
-	cmd := &protocol.Command{
-		ID:         "cmd-123",
-		Shell:      "system",
-		Line:       "whoami",
-		User:       "root",
-		Group:      "root",
-		AnalyzedAt: "2026-03-01T12:00:00+00:00",
-	}
-	serverID := "server-456"
-
-	payload := BuildCanonicalPayload(cmd, serverID)
-	sig := ed25519.Sign(priv, payload)
-	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
-
-	assert.NoError(t, VerifyCommand(cmd, serverID, pub))
+	assert.NoError(t, VerifyCommand(signedCommand(t, priv, testServerID), testServerID, pub))
 }
 
 func TestVerifyCommand_TamperedPayload(t *testing.T) {
 	pub, priv := newTestKey(t)
 
-	cmd := &protocol.Command{
-		ID:         "cmd-123",
-		Shell:      "system",
-		Line:       "whoami",
-		User:       "root",
-		Group:      "root",
-		AnalyzedAt: "2026-03-01T12:00:00+00:00",
-	}
-	serverID := "server-456"
-
-	payload := BuildCanonicalPayload(cmd, serverID)
-	sig := ed25519.Sign(priv, payload)
-	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
-
-	// Tamper with the command
+	cmd := signedCommand(t, priv, testServerID)
 	cmd.Line = "rm -rf /"
 
-	assert.ErrorIs(t, VerifyCommand(cmd, serverID, pub), ErrSignatureMismatch)
+	assert.ErrorIs(t, VerifyCommand(cmd, testServerID, pub), ErrSignatureMismatch)
 }
 
 func TestVerifyCommand_WrongServerID(t *testing.T) {
 	pub, priv := newTestKey(t)
 
-	cmd := &protocol.Command{
-		ID:         "cmd-123",
-		Shell:      "system",
-		Line:       "whoami",
-		User:       "root",
-		Group:      "root",
-		AnalyzedAt: "2026-03-01T12:00:00+00:00",
-	}
-
-	payload := BuildCanonicalPayload(cmd, "server-456")
-	sig := ed25519.Sign(priv, payload)
-	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
+	cmd := signedCommand(t, priv, testServerID)
 
 	assert.ErrorIs(t, VerifyCommand(cmd, "different-server", pub), ErrSignatureMismatch)
 }
 
-func TestVerifyCommand_EmptySignature(t *testing.T) {
+func TestVerifyCommand_Errors(t *testing.T) {
 	pub, _ := newTestKey(t)
 
-	cmd := &protocol.Command{
-		ID:    "cmd-123",
-		Shell: "system",
-		Line:  "whoami",
-		User:  "root",
-		Group: "root",
+	tests := []struct {
+		name string
+		cmd  *protocol.Command
+		key  ed25519.PublicKey
+		want string
+	}{
+		{"empty signature", testCommand(""), pub, "empty signature"},
+		{"invalid base64", testCommand("not-valid-base64!!!"), pub, "invalid signature encoding"},
+		{"wrong signature size", testCommand(base64.StdEncoding.EncodeToString([]byte("tooshort"))), pub, "invalid signature size"},
+		{"nil public key", testCommand(base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))), nil, "invalid public key size"},
+		{"nil command", nil, pub, "nil command"},
 	}
-
-	assert.ErrorContains(t, VerifyCommand(cmd, "server-456", pub), "empty signature")
-}
-
-func TestVerifyCommand_InvalidBase64(t *testing.T) {
-	pub, _ := newTestKey(t)
-
-	cmd := &protocol.Command{
-		ID:        "cmd-123",
-		Shell:     "system",
-		Line:      "whoami",
-		User:      "root",
-		Group:     "root",
-		Signature: "not-valid-base64!!!",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ErrorContains(t, VerifyCommand(tt.cmd, testServerID, tt.key), tt.want)
+		})
 	}
-
-	assert.ErrorContains(t, VerifyCommand(cmd, "server-456", pub), "invalid signature encoding")
 }
-
-func TestVerifyCommand_WrongSignatureSize(t *testing.T) {
-	pub, _ := newTestKey(t)
-
-	cmd := &protocol.Command{
-		ID:        "cmd-123",
-		Shell:     "system",
-		Line:      "whoami",
-		User:      "root",
-		Group:     "root",
-		Signature: base64.StdEncoding.EncodeToString([]byte("tooshort")),
-	}
-
-	assert.ErrorContains(t, VerifyCommand(cmd, "server-456", pub), "invalid signature size")
-}
-
-func TestVerifyCommand_NilPublicKey(t *testing.T) {
-	cmd := &protocol.Command{
-		ID:        "cmd-123",
-		Shell:     "system",
-		Line:      "whoami",
-		User:      "root",
-		Group:     "root",
-		Signature: base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)),
-	}
-
-	assert.ErrorContains(t, VerifyCommand(cmd, "server-456", nil), "invalid public key size")
-}
-
-func TestVerifyCommand_NilCommand(t *testing.T) {
-	pub, _ := newTestKey(t)
-
-	assert.ErrorContains(t, VerifyCommand(nil, "server-456", pub), "nil command")
-}
-
 func TestBuildCanonicalPayload_NilCommand(t *testing.T) {
 	assert.Nil(t, BuildCanonicalPayload(nil, "srv-1"))
 }
@@ -214,21 +177,4 @@ func TestBuildCanonicalPayload_LiteralBackslashU2028(t *testing.T) {
 	// JSON should contain the escaped form \\u2028/\\u2029
 	assert.Contains(t, payload, `\\u2028`)
 	assert.Contains(t, payload, `\\u2029`)
-}
-
-func TestBuildCanonicalPayload_HTMLChars(t *testing.T) {
-	// Verify that <, >, & are NOT escaped (matching Python's json.dumps behavior)
-	cmd := &protocol.Command{
-		ID:         "cmd-1",
-		Shell:      "system",
-		Line:       "echo '<h1>test</h1>' & cat /etc/passwd",
-		User:       "root",
-		Group:      "root",
-		AnalyzedAt: "2026-01-01T00:00:00+00:00",
-	}
-
-	payload := BuildCanonicalPayload(cmd, "srv-1")
-	expected := `{"command_id":"cmd-1","groupname":"root","line":"echo '<h1>test</h1>' & cat /etc/passwd","server_id":"srv-1","shell":"system","timestamp":"2026-01-01T00:00:00+00:00","username":"root"}`
-
-	assert.Equal(t, expected, string(payload))
 }

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -9,28 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testServerID = "server-456"
-
-func testCommand(sig string) *protocol.Command {
-	return &protocol.Command{
-		ID:         "cmd-123",
-		Shell:      "system",
-		Line:       "whoami",
-		User:       "root",
-		Group:      "root",
-		AnalyzedAt: "2026-03-01T12:00:00+00:00",
-		Signature:  sig,
-	}
-}
-
-// signedCommand returns a command carrying a signature valid for serverID.
-func signedCommand(t *testing.T, priv ed25519.PrivateKey, serverID string) *protocol.Command {
-	t.Helper()
-	cmd := testCommand("")
-	cmd.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(priv, BuildCanonicalPayload(cmd, serverID)))
-	return cmd
-}
-
 func TestBuildCanonicalPayload(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/alpacax/alpamon/v2/internal/protocol"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBuildCanonicalPayload(t *testing.T) {
@@ -44,8 +43,7 @@ func TestBuildCanonicalPayload_EmptyAnalyzedAt(t *testing.T) {
 }
 
 func TestVerifyCommand_Valid(t *testing.T) {
-	pub, priv, err := ed25519.GenerateKey(nil)
-	require.NoError(t, err)
+	pub, priv := newTestKey(t)
 
 	cmd := &protocol.Command{
 		ID:         "cmd-123",
@@ -65,7 +63,7 @@ func TestVerifyCommand_Valid(t *testing.T) {
 }
 
 func TestVerifyCommand_TamperedPayload(t *testing.T) {
-	pub, priv, _ := ed25519.GenerateKey(nil)
+	pub, priv := newTestKey(t)
 
 	cmd := &protocol.Command{
 		ID:         "cmd-123",
@@ -88,7 +86,7 @@ func TestVerifyCommand_TamperedPayload(t *testing.T) {
 }
 
 func TestVerifyCommand_WrongServerID(t *testing.T) {
-	pub, priv, _ := ed25519.GenerateKey(nil)
+	pub, priv := newTestKey(t)
 
 	cmd := &protocol.Command{
 		ID:         "cmd-123",
@@ -107,7 +105,7 @@ func TestVerifyCommand_WrongServerID(t *testing.T) {
 }
 
 func TestVerifyCommand_EmptySignature(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	cmd := &protocol.Command{
 		ID:    "cmd-123",
@@ -121,7 +119,7 @@ func TestVerifyCommand_EmptySignature(t *testing.T) {
 }
 
 func TestVerifyCommand_InvalidBase64(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	cmd := &protocol.Command{
 		ID:        "cmd-123",
@@ -136,7 +134,7 @@ func TestVerifyCommand_InvalidBase64(t *testing.T) {
 }
 
 func TestVerifyCommand_WrongSignatureSize(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	cmd := &protocol.Command{
 		ID:        "cmd-123",
@@ -164,7 +162,7 @@ func TestVerifyCommand_NilPublicKey(t *testing.T) {
 }
 
 func TestVerifyCommand_NilCommand(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
+	pub, _ := newTestKey(t)
 
 	assert.ErrorContains(t, VerifyCommand(nil, "server-456", pub), "nil command")
 }

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -1,12 +1,13 @@
 package signing
 
 import (
-	"bytes"
 	"crypto/ed25519"
 	"encoding/base64"
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/internal/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildCanonicalPayload(t *testing.T) {
@@ -24,9 +25,7 @@ func TestBuildCanonicalPayload(t *testing.T) {
 	// Must match Python's json.dumps(sort_keys=True, separators=(',', ':'))
 	expected := `{"command_id":"test-uuid","groupname":"alpacon","line":"echo hello","server_id":"server-uuid","shell":"system","timestamp":"2026-01-01T00:00:00+00:00","username":"root"}`
 
-	if string(payload) != expected {
-		t.Errorf("canonical payload mismatch\ngot:  %s\nwant: %s", string(payload), expected)
-	}
+	assert.Equal(t, expected, string(payload))
 }
 
 func TestBuildCanonicalPayload_EmptyAnalyzedAt(t *testing.T) {
@@ -41,16 +40,12 @@ func TestBuildCanonicalPayload_EmptyAnalyzedAt(t *testing.T) {
 	payload := BuildCanonicalPayload(cmd, "srv-1")
 	expected := `{"command_id":"cmd-1","groupname":"deploy","line":"ls","server_id":"srv-1","shell":"system","timestamp":"","username":"deploy"}`
 
-	if string(payload) != expected {
-		t.Errorf("canonical payload mismatch\ngot:  %s\nwant: %s", string(payload), expected)
-	}
+	assert.Equal(t, expected, string(payload))
 }
 
 func TestVerifyCommand_Valid(t *testing.T) {
 	pub, priv, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cmd := &protocol.Command{
 		ID:         "cmd-123",
@@ -66,9 +61,7 @@ func TestVerifyCommand_Valid(t *testing.T) {
 	sig := ed25519.Sign(priv, payload)
 	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
 
-	if err := VerifyCommand(cmd, serverID, pub); err != nil {
-		t.Errorf("expected valid signature, got error: %v", err)
-	}
+	assert.NoError(t, VerifyCommand(cmd, serverID, pub))
 }
 
 func TestVerifyCommand_TamperedPayload(t *testing.T) {
@@ -91,10 +84,7 @@ func TestVerifyCommand_TamperedPayload(t *testing.T) {
 	// Tamper with the command
 	cmd.Line = "rm -rf /"
 
-	err := VerifyCommand(cmd, serverID, pub)
-	if err == nil {
-		t.Error("expected verification failure for tampered command")
-	}
+	assert.Error(t, VerifyCommand(cmd, serverID, pub))
 }
 
 func TestVerifyCommand_WrongServerID(t *testing.T) {
@@ -113,10 +103,7 @@ func TestVerifyCommand_WrongServerID(t *testing.T) {
 	sig := ed25519.Sign(priv, payload)
 	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
 
-	err := VerifyCommand(cmd, "different-server", pub)
-	if err == nil {
-		t.Error("expected verification failure for wrong server ID")
-	}
+	assert.Error(t, VerifyCommand(cmd, "different-server", pub))
 }
 
 func TestVerifyCommand_EmptySignature(t *testing.T) {
@@ -130,10 +117,7 @@ func TestVerifyCommand_EmptySignature(t *testing.T) {
 		Group: "root",
 	}
 
-	err := VerifyCommand(cmd, "server-456", pub)
-	if err == nil {
-		t.Error("expected error for empty signature")
-	}
+	assert.Error(t, VerifyCommand(cmd, "server-456", pub))
 }
 
 func TestVerifyCommand_InvalidBase64(t *testing.T) {
@@ -148,10 +132,7 @@ func TestVerifyCommand_InvalidBase64(t *testing.T) {
 		Signature: "not-valid-base64!!!",
 	}
 
-	err := VerifyCommand(cmd, "server-456", pub)
-	if err == nil {
-		t.Error("expected error for invalid base64 signature")
-	}
+	assert.Error(t, VerifyCommand(cmd, "server-456", pub))
 }
 
 func TestVerifyCommand_WrongSignatureSize(t *testing.T) {
@@ -166,10 +147,7 @@ func TestVerifyCommand_WrongSignatureSize(t *testing.T) {
 		Signature: base64.StdEncoding.EncodeToString([]byte("tooshort")),
 	}
 
-	err := VerifyCommand(cmd, "server-456", pub)
-	if err == nil {
-		t.Error("expected error for wrong signature size")
-	}
+	assert.Error(t, VerifyCommand(cmd, "server-456", pub))
 }
 
 func TestVerifyCommand_NilPublicKey(t *testing.T) {
@@ -182,26 +160,17 @@ func TestVerifyCommand_NilPublicKey(t *testing.T) {
 		Signature: base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)),
 	}
 
-	err := VerifyCommand(cmd, "server-456", nil)
-	if err == nil {
-		t.Error("expected error for nil public key")
-	}
+	assert.Error(t, VerifyCommand(cmd, "server-456", nil))
 }
 
 func TestVerifyCommand_NilCommand(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
-	err := VerifyCommand(nil, "server-456", pub)
-	if err == nil {
-		t.Error("expected error for nil command")
-	}
+	assert.Error(t, VerifyCommand(nil, "server-456", pub))
 }
 
 func TestBuildCanonicalPayload_NilCommand(t *testing.T) {
-	payload := BuildCanonicalPayload(nil, "srv-1")
-	if payload != nil {
-		t.Errorf("expected nil payload for nil command, got %s", string(payload))
-	}
+	assert.Nil(t, BuildCanonicalPayload(nil, "srv-1"))
 }
 
 func TestBuildCanonicalPayload_LineSeparators(t *testing.T) {
@@ -217,16 +186,14 @@ func TestBuildCanonicalPayload_LineSeparators(t *testing.T) {
 		AnalyzedAt: "2026-01-01T00:00:00+00:00",
 	}
 
-	payload := BuildCanonicalPayload(cmd, "srv-1")
+	payload := string(BuildCanonicalPayload(cmd, "srv-1"))
 
 	// Payload must contain raw UTF-8 bytes, not \u2028/\u2029 escapes
-	if bytes.Contains(payload, []byte(`\u2028`)) || bytes.Contains(payload, []byte(`\u2029`)) {
-		t.Errorf("U+2028/U+2029 should not be escaped in canonical payload\ngot: %s", string(payload))
-	}
+	assert.NotContains(t, payload, `\u2028`)
+	assert.NotContains(t, payload, `\u2029`)
 	// Verify the raw bytes are present
-	if !bytes.Contains(payload, []byte("\u2028")) || !bytes.Contains(payload, []byte("\u2029")) {
-		t.Error("payload should contain raw U+2028/U+2029 bytes")
-	}
+	assert.Contains(t, payload, "\u2028")
+	assert.Contains(t, payload, "\u2029")
 }
 
 func TestBuildCanonicalPayload_LiteralBackslashU2028(t *testing.T) {
@@ -241,16 +208,14 @@ func TestBuildCanonicalPayload_LiteralBackslashU2028(t *testing.T) {
 		AnalyzedAt: "2026-01-01T00:00:00+00:00",
 	}
 
-	payload := BuildCanonicalPayload(cmd, "srv-1")
+	payload := string(BuildCanonicalPayload(cmd, "srv-1"))
 
 	// Must NOT contain raw U+2028/U+2029 bytes (those would mean corruption)
-	if bytes.Contains(payload, []byte("\u2028")) || bytes.Contains(payload, []byte("\u2029")) {
-		t.Errorf("literal \\u2028/\\u2029 text should not become raw bytes\ngot: %s", string(payload))
-	}
+	assert.NotContains(t, payload, "\u2028")
+	assert.NotContains(t, payload, "\u2029")
 	// JSON should contain the escaped form \\u2028/\\u2029
-	if !bytes.Contains(payload, []byte(`\\u2028`)) || !bytes.Contains(payload, []byte(`\\u2029`)) {
-		t.Errorf("literal \\u2028/\\u2029 should remain as \\\\u2028/\\\\u2029 in JSON\ngot: %s", string(payload))
-	}
+	assert.Contains(t, payload, `\\u2028`)
+	assert.Contains(t, payload, `\\u2029`)
 }
 
 func TestBuildCanonicalPayload_HTMLChars(t *testing.T) {
@@ -267,7 +232,5 @@ func TestBuildCanonicalPayload_HTMLChars(t *testing.T) {
 	payload := BuildCanonicalPayload(cmd, "srv-1")
 	expected := `{"command_id":"cmd-1","groupname":"root","line":"echo '<h1>test</h1>' & cat /etc/passwd","server_id":"srv-1","shell":"system","timestamp":"2026-01-01T00:00:00+00:00","username":"root"}`
 
-	if string(payload) != expected {
-		t.Errorf("HTML chars should not be escaped\ngot:  %s\nwant: %s", string(payload), expected)
-	}
+	assert.Equal(t, expected, string(payload))
 }

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testServerID = "server-456"
+
+func testCommand(sig string) *protocol.Command {
+	return &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "whoami",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		Signature:  sig,
+	}
+}
+
+// signedCommand returns a command carrying a signature valid for serverID.
+func signedCommand(t *testing.T, priv ed25519.PrivateKey, serverID string) *protocol.Command {
+	t.Helper()
+	cmd := testCommand("")
+	cmd.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(priv, BuildCanonicalPayload(cmd, serverID)))
+	return cmd
+}
+
 func TestBuildCanonicalPayload(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -64,72 +86,6 @@ func TestBuildCanonicalPayload(t *testing.T) {
 	}
 }
 
-const testServerID = "server-456"
-
-func testCommand(sig string) *protocol.Command {
-	return &protocol.Command{
-		ID:         "cmd-123",
-		Shell:      "system",
-		Line:       "whoami",
-		User:       "root",
-		Group:      "root",
-		AnalyzedAt: "2026-03-01T12:00:00+00:00",
-		Signature:  sig,
-	}
-}
-
-// signedCommand returns a command carrying a signature valid for serverID.
-func signedCommand(t *testing.T, priv ed25519.PrivateKey, serverID string) *protocol.Command {
-	t.Helper()
-	cmd := testCommand("")
-	cmd.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(priv, BuildCanonicalPayload(cmd, serverID)))
-	return cmd
-}
-
-func TestVerifyCommand_Valid(t *testing.T) {
-	pub, priv := newTestKey(t)
-
-	assert.NoError(t, VerifyCommand(signedCommand(t, priv, testServerID), testServerID, pub))
-}
-
-func TestVerifyCommand_TamperedPayload(t *testing.T) {
-	pub, priv := newTestKey(t)
-
-	cmd := signedCommand(t, priv, testServerID)
-	cmd.Line = "rm -rf /"
-
-	assert.ErrorIs(t, VerifyCommand(cmd, testServerID, pub), ErrSignatureMismatch)
-}
-
-func TestVerifyCommand_WrongServerID(t *testing.T) {
-	pub, priv := newTestKey(t)
-
-	cmd := signedCommand(t, priv, testServerID)
-
-	assert.ErrorIs(t, VerifyCommand(cmd, "different-server", pub), ErrSignatureMismatch)
-}
-
-func TestVerifyCommand_Errors(t *testing.T) {
-	pub, _ := newTestKey(t)
-
-	tests := []struct {
-		name string
-		cmd  *protocol.Command
-		key  ed25519.PublicKey
-		want string
-	}{
-		{"empty signature", testCommand(""), pub, "empty signature"},
-		{"invalid base64", testCommand("not-valid-base64!!!"), pub, "invalid signature encoding"},
-		{"wrong signature size", testCommand(base64.StdEncoding.EncodeToString([]byte("tooshort"))), pub, "invalid signature size"},
-		{"nil public key", testCommand(base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))), nil, "invalid public key size"},
-		{"nil command", nil, pub, "nil command"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.ErrorContains(t, VerifyCommand(tt.cmd, testServerID, tt.key), tt.want)
-		})
-	}
-}
 func TestBuildCanonicalPayload_NilCommand(t *testing.T) {
 	assert.Nil(t, BuildCanonicalPayload(nil, "srv-1"))
 }
@@ -177,4 +133,49 @@ func TestBuildCanonicalPayload_LiteralBackslashU2028(t *testing.T) {
 	// JSON should contain the escaped form \\u2028/\\u2029
 	assert.Contains(t, payload, `\\u2028`)
 	assert.Contains(t, payload, `\\u2029`)
+}
+
+func TestVerifyCommand_Valid(t *testing.T) {
+	pub, priv := newTestKey(t)
+
+	assert.NoError(t, VerifyCommand(signedCommand(t, priv, testServerID), testServerID, pub))
+}
+
+func TestVerifyCommand_TamperedPayload(t *testing.T) {
+	pub, priv := newTestKey(t)
+
+	cmd := signedCommand(t, priv, testServerID)
+	cmd.Line = "rm -rf /"
+
+	assert.ErrorIs(t, VerifyCommand(cmd, testServerID, pub), ErrSignatureMismatch)
+}
+
+func TestVerifyCommand_WrongServerID(t *testing.T) {
+	pub, priv := newTestKey(t)
+
+	cmd := signedCommand(t, priv, testServerID)
+
+	assert.ErrorIs(t, VerifyCommand(cmd, "different-server", pub), ErrSignatureMismatch)
+}
+
+func TestVerifyCommand_Errors(t *testing.T) {
+	pub, _ := newTestKey(t)
+
+	tests := []struct {
+		name string
+		cmd  *protocol.Command
+		key  ed25519.PublicKey
+		want string
+	}{
+		{"empty signature", testCommand(""), pub, "empty signature"},
+		{"invalid base64", testCommand("not-valid-base64!!!"), pub, "invalid signature encoding"},
+		{"wrong signature size", testCommand(base64.StdEncoding.EncodeToString([]byte("tooshort"))), pub, "invalid signature size"},
+		{"nil public key", testCommand(base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))), nil, "invalid public key size"},
+		{"nil command", nil, pub, "nil command"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ErrorContains(t, VerifyCommand(tt.cmd, testServerID, tt.key), tt.want)
+		})
+	}
 }

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -110,13 +110,13 @@ func TestBuildCanonicalPayload_LiteralBackslashU2028(t *testing.T) {
 }
 
 func TestVerifyCommand_Valid(t *testing.T) {
-	pub, priv := newTestKey(t)
+	pub, priv := testKey(t)
 
 	assert.NoError(t, VerifyCommand(signedCommand(t, priv, testServerID), testServerID, pub))
 }
 
 func TestVerifyCommand_TamperedPayload(t *testing.T) {
-	pub, priv := newTestKey(t)
+	pub, priv := testKey(t)
 
 	cmd := signedCommand(t, priv, testServerID)
 	cmd.Line = "rm -rf /"
@@ -125,7 +125,7 @@ func TestVerifyCommand_TamperedPayload(t *testing.T) {
 }
 
 func TestVerifyCommand_WrongServerID(t *testing.T) {
-	pub, priv := newTestKey(t)
+	pub, priv := testKey(t)
 
 	cmd := signedCommand(t, priv, testServerID)
 
@@ -133,7 +133,7 @@ func TestVerifyCommand_WrongServerID(t *testing.T) {
 }
 
 func TestVerifyCommand_Errors(t *testing.T) {
-	pub, _ := newTestKey(t)
+	pub, _ := testKey(t)
 
 	tests := []struct {
 		name string

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -83,10 +83,8 @@ func TestBuildCanonicalPayload_LineSeparators(t *testing.T) {
 
 	payload := string(BuildCanonicalPayload(cmd, "srv-1"))
 
-	// Payload must contain raw UTF-8 bytes, not \u2028/\u2029 escapes
 	assert.NotContains(t, payload, `\u2028`)
 	assert.NotContains(t, payload, `\u2029`)
-	// Verify the raw bytes are present
 	assert.Contains(t, payload, "\u2028")
 	assert.Contains(t, payload, "\u2029")
 }
@@ -105,10 +103,8 @@ func TestBuildCanonicalPayload_LiteralBackslashU2028(t *testing.T) {
 
 	payload := string(BuildCanonicalPayload(cmd, "srv-1"))
 
-	// Must NOT contain raw U+2028/U+2029 bytes (those would mean corruption)
 	assert.NotContains(t, payload, "\u2028")
 	assert.NotContains(t, payload, "\u2029")
-	// JSON should contain the escaped form \\u2028/\\u2029
 	assert.Contains(t, payload, `\\u2028`)
 	assert.Contains(t, payload, `\\u2029`)
 }


### PR DESCRIPTION
Second PR for #370. Scope is `pkg/signing`—`keymanager_test.go` and `verifier_test.go`, which are the only test files in the package, so it reads as testify-only after this.

The first PR (#421) settled how `require` and `assert` get chosen. Here the original code had already made that choice: every `t.Fatal*` stops the test and every `t.Error*` does not. The conversion maps `t.Fatal*` to `require` and `t.Error*` to `assert`, one for one, so what each check does on failure is preserved and the rule itself is something a reviewer can check in a line.

## What changed

Eight commits, one idea each.

`test(signing): unify assertion style on testify`—all 54 hand-written checks become testify. No test was added, removed, or renamed by this commit.

`test(signing): pin each error check to the error it expects`—twelve assertions only checked that *an* error came back. `TestVerifyCommand_NilPublicKey` was the weakest: any `VerifyCommand` failure satisfied it, including one that never reached the key size check. The two signature paths now assert `ErrSignatureMismatch`, the one error worth retrying after a key refresh and therefore the one that has to be told apart from the rest; the others assert the message the code returns.

`test(signing): build keys and key servers through checked helpers`—sixteen call sites dropped the `ed25519.GenerateKey` error and used the key on the next line, and ten tests built their own `httptest` handler, two of them byte for byte identical, every one dropping the error from `json.NewEncoder.Encode`. `newTestKey` checks the generation once. `keyServer` covers the seven handlers that answer every request the same way; the three whose response depends on the request keep a handler but write through `writeKeyResponse`.

`test(signing): table-drive the verifier cases and sign through one helper`—five `VerifyCommand` error tests differed only in the signature they fed in and the message they expected, and three `BuildCanonicalPayload` tests only in the command and the JSON they compared against. `testCommand` builds the repeated command literal and `signedCommand` absorbs the build-sign-encode block the three signature tests each repeated.

`test(signing): order tests the way the code is ordered`—declaration moves only, so each test file follows the order its source file declares.

`test(signing): publish the recorded query from the handler`—two variables were written on the server's goroutine and read on the test's with nothing between them. A single `atomic.Pointer[url.Values]` removes the question rather than answering it, and retires the `authEnvPresent = true // reset` line with it.

`test(signing): keep the shared fixtures in their own file`—`newTestKey` is used by both test files but sat above the keymanager-only HTTP fixtures, where it reads as keymanager's. With every fixture in `fixtures_test.go`, each test file matches one source file.

`test(signing): drop the comments the assertions already make`—21 comments deleted, five compressed. One asserted wider than its code: the comment claiming the payload must contain raw UTF-8 bytes sat above two checks that only assert the escaped forms are absent.

```
pkg/signing/fixtures_test.go   |  80 +++++++
pkg/signing/keymanager_test.go | 505 +++++++++++-----------------------
pkg/signing/verifier_test.go   | 324 +++++++++----------------
3 files changed, 342 insertions(+), 567 deletions(-)
```

## Four conversions that are not mechanical

These are the spots where the obvious testify call is not equivalent to the code it replaces.

**`fetchCount.Load()` returns `int32`.** `assert.Equal(t, 1, fetchCount.Load())` fails on the type mismatch rather than the value, so the expected side is written `int32(1)`.

**`assert.Equal` on `[]byte` separates nil from empty.** The canonical payload comparisons pass `string(payload)` to keep the meaning of the original string comparison, and the nil payload check uses `assert.Nil`—`assert.Equal(t, nil, payload)` compares an untyped nil against an interface holding a nil `[]byte` and fails even when the payload is nil. Same finding as #421.

**Conditions ORed into one `if` split into one assertion each.** Pass and fail are unchanged; a failure now names which half broke.

**The `ed25519` key comparisons use `assert.Equal`, not `assert.True(pub.Equal(key))`.** `assert.True` prints only `false`. The two differ solely when one side is nil and the other empty, since testify falls back to `reflect.DeepEqual` for a named byte-slice type, and every compared key here is a 32-byte `GenerateKey` result that already passed `require.NoError`.

## Eight tests are renamed

Folding into tables turns eight top-level functions into subtests. The number of cases that run is unchanged at 28.

```
TestBuildCanonicalPayload                  -> TestBuildCanonicalPayload/all_fields_set
TestBuildCanonicalPayload_EmptyAnalyzedAt  -> TestBuildCanonicalPayload/empty_analyzed_at
TestBuildCanonicalPayload_HTMLChars        -> TestBuildCanonicalPayload/html_characters
TestVerifyCommand_EmptySignature           -> TestVerifyCommand_Errors/empty_signature
TestVerifyCommand_InvalidBase64            -> TestVerifyCommand_Errors/invalid_base64
TestVerifyCommand_WrongSignatureSize       -> TestVerifyCommand_Errors/wrong_signature_size
TestVerifyCommand_NilPublicKey             -> TestVerifyCommand_Errors/nil_public_key
TestVerifyCommand_NilCommand               -> TestVerifyCommand_Errors/nil_command
```

Anything filtering with `-run` on those names needs updating.

## What behaves differently

Two assertion strengthenings, both deliberate, both in the direction of catching more: `ErrSignatureMismatch` on the two signature paths, and the pinned messages on the other ten.

One fixture change. `testKeyResponse` always sets `valid_from`, so `TestKeyManager_InvalidAlgorithm` and `TestKeyManager_InvalidKeySize` now serve a field they did not before. Nothing reads it—`publicKeyResponse.ValidFrom` is parsed and never used, and both tests turn on `algorithm` and `public_key`.

## Verification

No production code changed.

- `go test ./... -p 1` passes, 45 packages ok
- `go test ./pkg/signing/ -count=20 -race -shuffle=on` passes
- `go vet ./pkg/signing/...` and `gofmt -l pkg/signing/` clean
- Each of the eight commits was checked out on its own and passes `go test ./pkg/signing/`, so any point in the range bisects

Since the value of a style PR is that "behavior unchanged" can be checked by reading, the claim was also measured rather than asserted. Twenty-one bugs were planted in the production code one at a time, and the pre-conversion test files were compared against the post-conversion ones on which tests each bug fails, with the eight renames mapped:

```
18/21 mutations caught identically
```

The eighteen cover HTML escaping, skipped U+2028 unescaping, corrupted literal backslashes, an empty slice returned where nil is expected, a dropped payload field, signature verification disabled, the public key size check removed, a nil command accepted, caching disabled, expiry ignored, `expires_at` ignored, the `auth_env` parameter dropped, corrupted key bytes, a corrupted key id, a mismatched kid accepted, the algorithm check removed, the key size check removed, and a stale key served after a failed refresh.

The three that differ are all cases the new tests catch and the old ones did not: returning a generic error instead of `ErrSignatureMismatch`, removing the signature size check, and removing the empty signature check. Nothing got weaker.

Separately, each of the ten pinned messages was changed to `boom` in turn, and every time exactly the one test naming that message failed. Dropping the `auth_env` parameter and always sending it both fail `TestKeyManager_AuthEnvQueryParam` and nothing else.

## Left for follow-ups on #370

- The rest of the candidate list, with the hand-written checks each still holds: `user` (72), `shell` (61), `system` (122), `updater` (56), `auth_manager_tracker` (50), `multipart_stream` (47), `migrate` (40)
- What #421 left in `pkg/utils`: six `os.CreateTemp("")` sites where `t.TempDir()` would clean up on panic, the order-dependent `TestGetCopyPath` subtests, and the 14 test files still on raw `t.Fatal`/`t.Error`

## Checklist

- [x] Every commit builds and passes tests in isolation
- [x] No production code touched; the number of cases that run is unchanged at 28
- [x] Coverage compared before and after with 21 planted bugs
- [x] `go test ./... -p 1` passes

Refs #370
