### PR TITLE
ci: make the govulncheck step a hard gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,11 +47,20 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
-      # Report findings without gating merges: a newly published CVE in a
-      # transitive dep or stdlib would otherwise turn unrelated PRs red.
-      # Dependabot handles proactive dependency bumps; this job is the
-      # stdlib/reachability signal, surfaced in the step log, not a gate.
-      # Setup failures above still fail the job (only this step is soft).
+      # Hard gate: a called vulnerability fails the job and blocks the PR.
+      # This was previously soft, on the reasoning that a newly published
+      # advisory would turn unrelated PRs red. The cost of that trade showed
+      # up elsewhere in the fleet: a sibling repo carried called standard
+      # library advisories for two weeks without anyone noticing, because a
+      # reported-but-not-gating signal is only read when someone goes looking.
+      # Alpamon ships to customer machines, so it should not rely on that.
+      #
+      # govulncheck reports reachability, not mere presence: an advisory in a
+      # dependency the code does not call does not fail this step. Dependabot
+      # still handles proactive dependency bumps.
+      #
+      # govulncheck has no per-ID exclusion. If this fires on an advisory with
+      # no fix released, unblock with a `continue-on-error: true` naming the
+      # advisory and a tracking issue, and revert it when the fix lands.
       - name: Run govulncheck
         run: govulncheck ./...
-        continue-on-error: true


### PR DESCRIPTION
## Why

The `govulncheck` step in `lint.yml` carried `continue-on-error: true`. A called advisory was printed in the step log and the job still went green.

The original reasoning — that a newly published advisory would turn unrelated PRs red — is a real cost, but the other side of that trade has now been paid in this fleet: a sibling Go repo carried called standard-library advisories for **two weeks** without anyone noticing, because a signal that does not gate is only read when someone goes looking. Alpamon ships to customer machines. It should not depend on someone going looking.

## Measured before changing anything

The important question is not whether a hard gate is desirable but whether it can pass. Run on `main` (`6bdb5ff`) with `govulncheck@v1.7.0` and the repo's pinned `go 1.25.13`, after `go generate ./pkg/db/ent`:

```
No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 0 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call
these vulnerabilities.
```

**exit status 0.** Nothing turns red today.

### GO-2026-5932: present, not called

The single finding is the one worth checking carefully, because it has no fix:

```
Vulnerability #1: GO-2026-5932
    The golang.org/x/crypto/openpgp package is unmaintained, unsafe by design,
    and has known security issues
  More info: https://pkg.go.dev/vuln/GO-2026-5932
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.52.0
    Fixed in: N/A
```

It is reported at **module** level — "modules you require" — not as an imported package and not as a called symbol. `govulncheck` reports reachability, not presence, so this does not fail the step.

That distinction is the whole decision. Had `openpgp` been *called*, a hard gate would block every future PR indefinitely with no upstream fix to wait for, and the right answer would have been to keep the step soft (or scope the gate) rather than ship a gate that cannot pass. It is not called, so the gate is safe.

## Escape hatch

`govulncheck` has no per-ID exclusion. If this ever fires on an advisory with no fix released, the documented remedy — written at the step — is a `continue-on-error: true` naming the advisory plus a tracking issue, reverted when the fix lands. Scoped, visible, and temporary, rather than a permanent blanket.

## Scope

One step in `.github/workflows/lint.yml`: `continue-on-error: true` removed, comment rewritten to explain the gate and the escape hatch. No change to the toolchain, dependencies, or any other job. `verify-tidy`, `golangci-lint` and the build/test matrix are untouched.

## Deploy impact

None. `release.yml` is tag-triggered; nothing ships on a merge to `main`.