### PR TITLE
test(user): unify assertion style on testify

### DIFF
--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -616,7 +616,7 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 
 			// A group-add failure reaches the operator through the output, not err.
 			assert.NoError(t, err)
-			assert.Equal(t, 0, exitCode, "a group-add failure must not change the exit code")
+			assert.Equal(t, 0, exitCode, "the create path exits 0 whether or not the group-add step fails")
 			assert.Equal(t, tt.wantOutput, output)
 			assert.True(t, tt.groupService.AddUserToGroupsCalled, "AddUserToGroups must run when the args carry additional groups")
 		})

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -79,7 +79,8 @@ func TestUserHandler_Execute(t *testing.T) {
 				HomeDirectory: "/home/testuser",
 				Shell:         "/bin/bash",
 				Groupname:     "testgroup",
-				Groups:        []uint64{1002, 1003},
+				// No additional Groups: the group-add path is covered by
+				// TestUserHandler_AddUserWithGroups, which pins its output.
 			},
 			setupMock: func(mock *common.MockCommandExecutor) {
 				mock.SetResult(fmt.Sprintf("/usr/sbin/adduser --home /home/testuser --shell /bin/bash --uid %d --gid %d --gecos Test User --disabled-password testuser", 1001, 1001), 0, "User created", nil)

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -462,7 +462,8 @@ func TestUserHandler_Validate(t *testing.T) {
 				Username: "testuser",
 				// IsServiceAccount=false (default), so UID/GID/HomeDirectory
 				// are required_unless and also missing. Comment/Groupname are
-				// required unconditionally. Shell is defaulted by the helper.
+				// required unconditionally. Shell carries `validate:"required"`
+				// and is deliberately not defaulted (types.go:52), so it fails too.
 			},
 			wantErrFields: []string{"UID", "GID", "Comment", "HomeDirectory", "Shell", "Groupname"},
 		},

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -467,7 +467,7 @@ func TestUserHandler_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "adduser IAM User path must still require uid/gid/home",
+			name: "adduser IAM User path must still require uid, gid and home",
 			cmd:  "adduser",
 			args: &common.CommandArgs{
 				Username:  "john",

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -280,7 +280,7 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 				assert.Contains(t, joined, want, "flag %q must be present", want)
 			}
 			for _, forbid := range tt.forbidFlags {
-				assert.NotContains(t, target.Args, forbid, "args: %s", joined)
+				assert.NotContains(t, joined, forbid, "args: %s", joined)
 			}
 
 			// Service account must NOT use the gid-based groupadd path

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -18,9 +18,23 @@ import (
 
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
+	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// validationFields names the struct fields a ValidateStruct error flags, so a
+// table row can pin exactly which fields failed instead of accepting any error.
+func validationFields(t *testing.T, err error) []string {
+	t.Helper()
+	var verrs validator.ValidationErrors
+	require.ErrorAs(t, err, &verrs)
+	fields := make([]string, 0, len(verrs))
+	for _, verr := range verrs {
+		fields = append(fields, verr.Field())
+	}
+	return fields
+}
 
 // MockGroupService implements services.GroupService for testing
 type MockGroupService struct {
@@ -52,7 +66,7 @@ func TestUserHandler_Execute(t *testing.T) {
 		setupMock    func(*common.MockCommandExecutor)
 		groupService *MockGroupService
 		wantCode     int
-		wantErr      bool
+		wantErrMsg   string
 	}{
 		{
 			name: "adduser success debian",
@@ -72,7 +86,6 @@ func TestUserHandler_Execute(t *testing.T) {
 			},
 			groupService: &MockGroupService{},
 			wantCode:     0,
-			wantErr:      false,
 		},
 		{
 			name: "deluser success",
@@ -86,7 +99,6 @@ func TestUserHandler_Execute(t *testing.T) {
 			},
 			groupService: &MockGroupService{},
 			wantCode:     0,
-			wantErr:      false,
 		},
 		{
 			name: "moduser success",
@@ -102,7 +114,6 @@ func TestUserHandler_Execute(t *testing.T) {
 			},
 			groupService: &MockGroupService{},
 			wantCode:     0,
-			wantErr:      false,
 		},
 		{
 			name:         "unknown command",
@@ -110,7 +121,7 @@ func TestUserHandler_Execute(t *testing.T) {
 			args:         &common.CommandArgs{},
 			groupService: &MockGroupService{},
 			wantCode:     1,
-			wantErr:      true,
+			wantErrMsg:   "unknown user command: unknownuser",
 		},
 		{
 			name: "adduser missing username",
@@ -121,7 +132,6 @@ func TestUserHandler_Execute(t *testing.T) {
 			},
 			groupService: &MockGroupService{},
 			wantCode:     1,
-			wantErr:      false,
 		},
 		{
 			name: "adduser failure",
@@ -140,7 +150,7 @@ func TestUserHandler_Execute(t *testing.T) {
 			},
 			groupService: &MockGroupService{},
 			wantCode:     1,
-			wantErr:      true, // error is returned as part of output, not actual go error
+			wantErrMsg:   "user add error",
 		},
 	}
 
@@ -163,13 +173,13 @@ func TestUserHandler_Execute(t *testing.T) {
 
 			exitCode, output, err := handler.Execute(ctx, tt.cmd, tt.args)
 
-			if tt.wantErr {
-				assert.Error(t, err)
+			if tt.wantErrMsg != "" {
+				assert.EqualError(t, err, tt.wantErrMsg)
 			} else {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.wantCode, exitCode)
-			if exitCode == 0 && !tt.wantErr {
+			if exitCode == 0 && tt.wantErrMsg == "" {
 				assert.NotEmpty(t, output, "a successful command must carry output")
 			}
 		})
@@ -423,10 +433,14 @@ func TestUserHandler_Validate(t *testing.T) {
 	handler := newTestUserHandler(common.NewMockCommandExecutor(t), &MockGroupService{})
 
 	tests := []struct {
-		name    string
-		cmd     string
-		args    *common.CommandArgs
-		wantErr bool
+		name string
+		cmd  string
+		args *common.CommandArgs
+		// wantErrMsg pins a non-validator error to its exact message;
+		// wantErrFields pins a validator error to the exact set of fields it
+		// must flag. Both empty means the args must validate.
+		wantErrMsg    string
+		wantErrFields []string
 	}{
 		{
 			name: "adduser valid",
@@ -440,7 +454,6 @@ func TestUserHandler_Validate(t *testing.T) {
 				Shell:         "/bin/bash",
 				Groupname:     "testgroup",
 			},
-			wantErr: false,
 		},
 		{
 			name: "adduser missing required fields",
@@ -451,7 +464,7 @@ func TestUserHandler_Validate(t *testing.T) {
 				// are required_unless and also missing. Comment/Groupname are
 				// required unconditionally. Shell is defaulted by the helper.
 			},
-			wantErr: true,
+			wantErrFields: []string{"UID", "GID", "Comment", "HomeDirectory", "Shell", "Groupname"},
 		},
 		{
 			name: "adduser uid-less service account valid",
@@ -464,7 +477,6 @@ func TestUserHandler_Validate(t *testing.T) {
 				IsServiceAccount: true,
 				// UID/GID/HomeDirectory intentionally omitted (OS auto-assign)
 			},
-			wantErr: false,
 		},
 		{
 			name: "adduser IAM User path must still require uid, gid and home",
@@ -477,7 +489,7 @@ func TestUserHandler_Validate(t *testing.T) {
 				// IsServiceAccount=false (default)
 				// UID/GID/HomeDirectory missing: must fail
 			},
-			wantErr: true,
+			wantErrFields: []string{"UID", "GID", "HomeDirectory"},
 		},
 		{
 			name: "adduser IAM User with uid=0 must fail (cannot silently auto-assign)",
@@ -492,7 +504,7 @@ func TestUserHandler_Validate(t *testing.T) {
 				Groupname:     "alpacon",
 				// IsServiceAccount=false: uid=0 must be rejected
 			},
-			wantErr: true,
+			wantErrFields: []string{"UID"},
 		},
 		{
 			name: "deluser valid",
@@ -500,7 +512,6 @@ func TestUserHandler_Validate(t *testing.T) {
 			args: &common.CommandArgs{
 				Username: "testuser",
 			},
-			wantErr: false,
 		},
 		{
 			name: "moduser valid",
@@ -510,22 +521,24 @@ func TestUserHandler_Validate(t *testing.T) {
 				Groupnames: []string{"sudo"},
 				Comment:    "Updated",
 			},
-			wantErr: false,
 		},
 		{
-			name:    "unknown command",
-			cmd:     "unknown",
-			args:    &common.CommandArgs{},
-			wantErr: true,
+			name:       "unknown command",
+			cmd:        "unknown",
+			args:       &common.CommandArgs{},
+			wantErrMsg: "unknown user command: unknown",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := handler.Validate(tt.cmd, tt.args)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
+			switch {
+			case tt.wantErrMsg != "":
+				assert.EqualError(t, err, tt.wantErrMsg)
+			case len(tt.wantErrFields) > 0:
+				assert.ElementsMatch(t, tt.wantErrFields, validationFields(t, err))
+			default:
 				assert.NoError(t, err)
 			}
 		})

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -538,7 +538,7 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 		setupMock    func(*common.MockCommandExecutor)
 		groupService *MockGroupService
 		wantCode     int
-		calledGroups bool
+		wantOutput   string
 	}{
 		{
 			name: "add user to groups success",
@@ -547,7 +547,7 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 			},
 			groupService: &MockGroupService{},
 			wantCode:     0,
-			calledGroups: true,
+			wantOutput:   "User 'testuser' added successfully",
 		},
 		{
 			name: "add user to groups failure",
@@ -556,7 +556,7 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 			},
 			groupService: &MockGroupService{AddUserToGroupsError: errors.New("failed to add to groups")},
 			wantCode:     0, // Still want 0 for user creation, group error is logged
-			calledGroups: true,
+			wantOutput:   "User 'testuser' created but failed to add to groups: failed to add to groups",
 		},
 	}
 
@@ -588,14 +588,13 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 				Groups:        []uint64{1002, 1003},
 			}
 
-			exitCode, _, err := handler.Execute(ctx, "adduser", args)
+			exitCode, output, err := handler.Execute(ctx, "adduser", args)
 
-			// A group-add failure is reported through the group service, not err.
-			if !tt.groupService.AddUserToGroupsCalled {
-				assert.NoError(t, err)
-			}
+			// A group-add failure reaches the operator through the output, not err.
+			assert.NoError(t, err)
 			assert.Equal(t, tt.wantCode, exitCode)
-			assert.Equal(t, tt.calledGroups, tt.groupService.AddUserToGroupsCalled, "AddUserToGroups called")
+			assert.Equal(t, tt.wantOutput, output)
+			assert.True(t, tt.groupService.AddUserToGroupsCalled, "AddUserToGroups must run when the args carry additional groups")
 		})
 	}
 }

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -67,6 +67,9 @@ func TestUserHandler_Execute(t *testing.T) {
 		groupService *MockGroupService
 		wantCode     int
 		wantErrMsg   string
+		// wantOutputPart pins the diagnostic a failing row hands the
+		// operator, for the paths that report through output, not err.
+		wantOutputPart string
 	}{
 		{
 			name: "adduser success debian",
@@ -131,8 +134,9 @@ func TestUserHandler_Execute(t *testing.T) {
 				UID: 1001,
 				GID: 1001,
 			},
-			groupService: &MockGroupService{},
-			wantCode:     1,
+			groupService:   &MockGroupService{},
+			wantCode:       1,
+			wantOutputPart: "Username",
 		},
 		{
 			name: "adduser failure",
@@ -180,6 +184,9 @@ func TestUserHandler_Execute(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.wantCode, exitCode)
+			if tt.wantOutputPart != "" {
+				assert.Contains(t, output, tt.wantOutputPart)
+			}
 			if exitCode == 0 && tt.wantErrMsg == "" {
 				assert.NotEmpty(t, output, "a successful command must carry output")
 			}

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -16,11 +16,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MockGroupService implements services.GroupService for testing

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -559,7 +559,6 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 		name         string
 		setupMock    func(*common.MockCommandExecutor)
 		groupService *MockGroupService
-		wantCode     int
 		wantOutput   string
 	}{
 		{
@@ -568,7 +567,6 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 				mock.SetResult(fmt.Sprintf("/usr/sbin/adduser --home /home/testuser --shell /bin/bash --uid %d --gid %d --gecos Test User --disabled-password testuser", 1001, 1001), 0, "User created", nil)
 			},
 			groupService: &MockGroupService{},
-			wantCode:     0,
 			wantOutput:   "User 'testuser' added successfully",
 		},
 		{
@@ -577,7 +575,6 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 				mock.SetResult(fmt.Sprintf("/usr/sbin/adduser --home /home/testuser --shell /bin/bash --uid %d --gid %d --gecos Test User --disabled-password testuser", 1001, 1001), 0, "User created", nil)
 			},
 			groupService: &MockGroupService{AddUserToGroupsError: errors.New("failed to add to groups")},
-			wantCode:     0, // Still want 0 for user creation, group error is logged
 			wantOutput:   "User 'testuser' created but failed to add to groups: failed to add to groups",
 		},
 	}
@@ -614,7 +611,7 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 
 			// A group-add failure reaches the operator through the output, not err.
 			assert.NoError(t, err)
-			assert.Equal(t, tt.wantCode, exitCode)
+			assert.Equal(t, 0, exitCode, "a group-add failure must not change the exit code")
 			assert.Equal(t, tt.wantOutput, output)
 			assert.True(t, tt.groupService.AddUserToGroupsCalled, "AddUserToGroups must run when the args carry additional groups")
 		})

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"os/user"
+	"slices"
 	"strings"
 	"testing"
 
@@ -34,6 +35,19 @@ func validationFields(t *testing.T, err error) []string {
 		fields = append(fields, verr.Field())
 	}
 	return fields
+}
+
+// invokedAt returns the execution order of the first command that ran as
+// program with exactly args, or -1 if none did. The index is what lets a test
+// assert that one command preceded another; common.Invoked answers the plain
+// did-it-run question.
+func invokedAt(mock *common.MockCommandExecutor, program string, args ...string) int {
+	for i, c := range mock.GetExecutedCommands() {
+		if c.Name == program && slices.Equal(c.Args, args) {
+			return i
+		}
+	}
+	return -1
 }
 
 // MockGroupService implements services.GroupService for testing
@@ -251,28 +265,19 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 
 			executed := mock.GetExecutedCommands()
 			var target *common.ExecutedCommand
-			var sawGidGroupadd, sawGroupaddDashF, sawUsermod bool
-			var groupaddDashFIndex, useraddIndex = -1, -1
+			var sawGidGroupadd bool
+			useraddIndex := -1
 			for i := range executed {
 				c := executed[i]
 				if c.Name == tt.wantProgram {
 					target = &executed[i]
 					useraddIndex = i
 				}
-				if c.Name == "/usr/sbin/groupadd" {
-					joined := strings.Join(c.Args, " ")
-					if strings.Contains(joined, "--gid") {
-						sawGidGroupadd = true
-					}
-					if len(c.Args) >= 2 && c.Args[0] == "-f" && c.Args[1] == "alpacon" {
-						sawGroupaddDashF = true
-						groupaddDashFIndex = i
-					}
-				}
-				if c.Name == "/usr/sbin/usermod" {
-					sawUsermod = true
+				if c.Name == "/usr/sbin/groupadd" && strings.Contains(strings.Join(c.Args, " "), "--gid") {
+					sawGidGroupadd = true
 				}
 			}
+			groupaddDashFIndex := invokedAt(mock, "/usr/sbin/groupadd", "-f", "alpacon")
 
 			require.NotNil(t, target, "%s must be invoked, got: %+v", tt.wantProgram, executed)
 			joined := strings.Join(target.Args, " ")
@@ -290,11 +295,11 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 			// (--ingroup on Debian, --gid <name> on RHEL). Post-fact
 			// `usermod -aG` is no longer used.
 			assert.False(t, sawGidGroupadd, "the service-account path must not call groupadd with --gid")
-			assert.True(t, sawGroupaddDashF, "`groupadd -f alpacon` must ensure the named primary group exists")
+			assert.NotEqual(t, -1, groupaddDashFIndex, "`groupadd -f alpacon` must ensure the named primary group exists")
 			if groupaddDashFIndex >= 0 && useraddIndex >= 0 {
 				assert.Less(t, groupaddDashFIndex, useraddIndex, "`groupadd -f` must run before %s", tt.wantProgram)
 			}
-			assert.False(t, sawUsermod, "post-fact `usermod` must not run; the primary group is set during adduser/useradd")
+			assert.False(t, mock.Invoked("/usr/sbin/usermod"), "post-fact `usermod` must not run; the primary group is set during adduser/useradd")
 
 			// Verify the primary-group-by-name flag is on the create command itself.
 			switch tt.platform {
@@ -744,13 +749,7 @@ func TestUserHandler_AddUser_Idempotent_ServiceAccountNameExists(t *testing.T) {
 	// Load-bearing invariant: the `groupadd -f <Groupname>` bootstrap must run
 	// even for an already-present service account, or the named primary group is
 	// not ensured and Demote(ValidateGroup=true) breaks at websh runtime.
-	sawGroupaddDashF := false
-	for _, c := range mock.GetExecutedCommands() {
-		if c.Name == "/usr/sbin/groupadd" && len(c.Args) >= 2 && c.Args[0] == "-f" && c.Args[1] == "alpacon" {
-			sawGroupaddDashF = true
-		}
-	}
-	assert.True(t, sawGroupaddDashF,
+	assert.NotEqual(t, -1, invokedAt(mock, "/usr/sbin/groupadd", "-f", "alpacon"),
 		"`groupadd -f alpacon` must still run for an existing service account; got %+v", mock.GetExecutedCommands())
 }
 

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -16,6 +16,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
 )
@@ -161,14 +164,14 @@ func TestUserHandler_Execute(t *testing.T) {
 
 			exitCode, output, err := handler.Execute(ctx, tt.cmd, tt.args)
 
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
-			if exitCode != tt.wantCode {
-				t.Errorf("Execute() exitCode = %v, want %v", exitCode, tt.wantCode)
-			}
-			if exitCode == 0 && output == "" && !tt.wantErr {
-				t.Error("Execute() returned success but no output")
+			assert.Equal(t, tt.wantCode, exitCode)
+			if exitCode == 0 && !tt.wantErr {
+				assert.NotEmpty(t, output, "a successful command must carry output")
 			}
 		})
 	}
@@ -226,12 +229,8 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 			handler := newTestUserHandler(mock, &MockGroupService{})
 
 			exitCode, _, err := handler.Execute(context.Background(), "adduser", baseArgs)
-			if err != nil {
-				t.Fatalf("Execute() unexpected error: %v", err)
-			}
-			if exitCode != 0 {
-				t.Fatalf("Execute() exitCode = %d, want 0", exitCode)
-			}
+			require.NoError(t, err)
+			require.Equal(t, 0, exitCode)
 
 			executed := mock.GetExecutedCommands()
 			var target *common.ExecutedCommand
@@ -258,21 +257,13 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 				}
 			}
 
-			if target == nil {
-				t.Fatalf("expected %s to be invoked, got commands: %+v", tt.wantProgram, executed)
-			}
+			require.NotNil(t, target, "%s must be invoked, got: %+v", tt.wantProgram, executed)
 			joined := strings.Join(target.Args, " ")
 			for _, want := range tt.wantFlags {
-				if !strings.Contains(joined, want) {
-					t.Errorf("expected flag %q in args, got: %s", want, joined)
-				}
+				assert.Contains(t, joined, want, "flag %q must be present", want)
 			}
 			for _, forbid := range tt.forbidFlags {
-				for _, a := range target.Args {
-					if a == forbid {
-						t.Errorf("flag %q must not appear in args, got: %s", forbid, joined)
-					}
-				}
+				assert.NotContains(t, target.Args, forbid, "args: %s", joined)
 			}
 
 			// Service account must NOT use the gid-based groupadd path
@@ -281,30 +272,19 @@ func TestUserHandler_AddUser_UidLess(t *testing.T) {
 			// and adduser/useradd MUST set the primary group by name
 			// (--ingroup on Debian, --gid <name> on RHEL). Post-fact
 			// `usermod -aG` is no longer used.
-			if sawGidGroupadd {
-				t.Error("service account path must not call groupadd with --gid")
+			assert.False(t, sawGidGroupadd, "the service-account path must not call groupadd with --gid")
+			assert.True(t, sawGroupaddDashF, "`groupadd -f alpacon` must ensure the named primary group exists")
+			if groupaddDashFIndex >= 0 && useraddIndex >= 0 {
+				assert.Less(t, groupaddDashFIndex, useraddIndex, "`groupadd -f` must run before %s", tt.wantProgram)
 			}
-			if !sawGroupaddDashF {
-				t.Error("expected `groupadd -f alpacon` to ensure the named primary group exists")
-			}
-			if groupaddDashFIndex >= 0 && useraddIndex >= 0 && groupaddDashFIndex >= useraddIndex {
-				t.Errorf("`groupadd -f` must run BEFORE %s, got order groupadd=%d useradd=%d",
-					tt.wantProgram, groupaddDashFIndex, useraddIndex)
-			}
-			if sawUsermod {
-				t.Error("post-fact `usermod` should no longer run; primary group is set during adduser/useradd")
-			}
+			assert.False(t, sawUsermod, "post-fact `usermod` must not run; the primary group is set during adduser/useradd")
 
 			// Verify the primary-group-by-name flag is on the create command itself.
 			switch tt.platform {
 			case "debian":
-				if !strings.Contains(joined, "--ingroup alpacon") {
-					t.Errorf("expected `--ingroup alpacon` on adduser, got: %s", joined)
-				}
+				assert.Contains(t, joined, "--ingroup alpacon", "adduser must set the primary group by name")
 			case "rhel":
-				if !strings.Contains(joined, "--gid alpacon") {
-					t.Errorf("expected `--gid alpacon` on useradd, got: %s", joined)
-				}
+				assert.Contains(t, joined, "--gid alpacon", "useradd must set the primary group by name")
 			}
 		})
 	}
@@ -337,12 +317,8 @@ func TestUserHandler_AddUser_ServiceAccountWithExplicitUID(t *testing.T) {
 	}
 
 	exitCode, _, err := handler.Execute(context.Background(), "adduser", args)
-	if err != nil {
-		t.Fatalf("Execute() unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Fatalf("Execute() exitCode = %d, want 0", exitCode)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
 
 	executed := mock.GetExecutedCommands()
 	var useradd *common.ExecutedCommand
@@ -356,18 +332,12 @@ func TestUserHandler_AddUser_ServiceAccountWithExplicitUID(t *testing.T) {
 			}
 		}
 	}
-	if useradd == nil {
-		t.Fatalf("expected useradd to be invoked; got %+v", executed)
-	}
+	require.NotNil(t, useradd, "useradd must be invoked, got: %+v", executed)
 	joined := strings.Join(useradd.Args, " ")
 	for _, want := range []string{"--uid", "7000", "--gid", "7000", "--home-dir", "/var/lib/explicit-svc"} {
-		if !strings.Contains(joined, want) {
-			t.Errorf("expected flag %q on useradd (explicit values must be honored), got: %s", want, joined)
-		}
+		assert.Contains(t, joined, want, "an explicit value must be honored on useradd")
 	}
-	if sawNamedGidUseradd {
-		t.Error("when GID is explicit (non-zero), useradd must NOT use the by-name `--gid alpacon` path")
-	}
+	assert.False(t, sawNamedGidUseradd, "an explicit non-zero GID must not take the by-name `--gid alpacon` path")
 }
 
 // TestUserHandler_AddUser_ServiceAccountGroupaddFails verifies that a
@@ -396,16 +366,11 @@ func TestUserHandler_AddUser_ServiceAccountGroupaddFails(t *testing.T) {
 	}
 
 	exitCode, output, _ := handler.Execute(context.Background(), "adduser", args)
-	if exitCode == 0 {
-		t.Fatalf("expected non-zero exit code when groupadd fails on service-account path, got 0; output=%q", output)
-	}
+	require.NotEqual(t, 0, exitCode, "a failing groupadd on the service-account path must surface, output: %q", output)
 
 	// useradd must not be reached if the primary group cannot be ensured.
-	for _, c := range mock.GetExecutedCommands() {
-		if c.Name == "/usr/sbin/useradd" {
-			t.Errorf("useradd must not run when `groupadd -f` failed; got args=%v", c.Args)
-		}
-	}
+	assert.False(t, mock.Invoked("/usr/sbin/useradd"),
+		"useradd must not run when `groupadd -f` failed; got %+v", mock.GetExecutedCommands())
 }
 
 // TestUserHandler_AddUser_RhelWithUID verifies the existing IAM User path
@@ -431,12 +396,8 @@ func TestUserHandler_AddUser_RhelWithUID(t *testing.T) {
 	}
 
 	exitCode, _, err := handler.Execute(context.Background(), "adduser", args)
-	if err != nil {
-		t.Fatalf("Execute() unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Fatalf("Execute() exitCode = %d, want 0", exitCode)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
 
 	executed := mock.GetExecutedCommands()
 	var sawGroupadd, sawUseradd bool
@@ -444,26 +405,19 @@ func TestUserHandler_AddUser_RhelWithUID(t *testing.T) {
 		if c.Name == "/usr/sbin/groupadd" {
 			sawGroupadd = true
 			joined := strings.Join(c.Args, " ")
-			if !strings.Contains(joined, "--gid 5001") || !strings.Contains(joined, "alpacon") {
-				t.Errorf("groupadd missing expected args: %s", joined)
-			}
+			assert.Contains(t, joined, "--gid 5001")
+			assert.Contains(t, joined, "alpacon")
 		}
 		if c.Name == "/usr/sbin/useradd" {
 			sawUseradd = true
 			joined := strings.Join(c.Args, " ")
 			for _, want := range []string{"--uid", "5001", "--gid", "--home-dir", "/home/john", "--shell", "/bin/bash", "--create-home", "john"} {
-				if !strings.Contains(joined, want) {
-					t.Errorf("useradd missing %q: %s", want, joined)
-				}
+				assert.Contains(t, joined, want, "useradd is missing a flag")
 			}
 		}
 	}
-	if !sawGroupadd {
-		t.Error("expected groupadd to be invoked")
-	}
-	if !sawUseradd {
-		t.Error("expected useradd to be invoked")
-	}
+	assert.True(t, sawGroupadd, "groupadd must be invoked")
+	assert.True(t, sawUseradd, "useradd must be invoked")
 }
 
 func TestUserHandler_Validate(t *testing.T) {
@@ -570,8 +524,10 @@ func TestUserHandler_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := handler.Validate(tt.cmd, tt.args)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -635,18 +591,12 @@ func TestUserHandler_AddUserWithGroups(t *testing.T) {
 
 			exitCode, _, err := handler.Execute(ctx, "adduser", args)
 
-			if err != nil && !tt.groupService.AddUserToGroupsCalled { // only expect error if AddUserToGroups not called
-				t.Errorf("Execute() unexpected error: %v", err)
+			// A group-add failure is reported through the group service, not err.
+			if !tt.groupService.AddUserToGroupsCalled {
+				assert.NoError(t, err)
 			}
-			if exitCode != tt.wantCode {
-				t.Errorf("Execute() exitCode = %v, want %v", exitCode, tt.wantCode)
-			}
-			if tt.calledGroups && !tt.groupService.AddUserToGroupsCalled {
-				t.Error("Execute() did not call AddUserToGroups on group service")
-			}
-			if !tt.calledGroups && tt.groupService.AddUserToGroupsCalled {
-				t.Error("Execute() unexpectedly called AddUserToGroups on group service")
-			}
+			assert.Equal(t, tt.wantCode, exitCode)
+			assert.Equal(t, tt.calledGroups, tt.groupService.AddUserToGroupsCalled, "AddUserToGroups called")
 		})
 	}
 }
@@ -693,34 +643,21 @@ func TestUserHandler_AddUser_Idempotent_ExistingUserSkipsCreate(t *testing.T) {
 			}
 
 			exitCode, output, err := handler.Execute(context.Background(), "adduser", args)
-			if err != nil {
-				t.Fatalf("Execute() unexpected error: %v", err)
-			}
-			if exitCode != 0 {
-				t.Fatalf("Execute() exitCode = %d, want 0 (output=%q)", exitCode, output)
-			}
+			require.NoError(t, err)
+			require.Equal(t, 0, exitCode, "output: %q", output)
 			// The gate-detected idempotent path must report "already exists",
 			// not the misleading "added successfully" (this is the crux #344 path).
-			if !strings.Contains(output, "already exists") || strings.Contains(output, "added successfully") {
-				t.Errorf("existing-user path should report 'already exists', got: %q", output)
-			}
+			assert.Contains(t, output, "already exists")
+			assert.NotContains(t, output, "added successfully")
 
-			if mock.Invoked(tt.createCmd) {
-				t.Errorf("%s must NOT be invoked when the user already exists; got %+v", tt.createCmd, mock.GetExecutedCommands())
-			}
+			assert.False(t, mock.Invoked(tt.createCmd),
+				"%s must not be invoked when the user already exists; got %+v", tt.createCmd, mock.GetExecutedCommands())
 			// RHEL ensures the primary group; when it already exists, groupadd is skipped.
 			if tt.platform == "rhel" {
-				sawGroupadd := mock.Invoked("/usr/sbin/groupadd")
-				if tt.groupExists && sawGroupadd {
-					t.Errorf("groupadd must be skipped when the group already exists with matching gid; got %+v", mock.GetExecutedCommands())
-				}
-				if !tt.groupExists && !sawGroupadd {
-					t.Errorf("groupadd must run to ensure the primary group exists; got %+v", mock.GetExecutedCommands())
-				}
+				assert.Equal(t, !tt.groupExists, mock.Invoked("/usr/sbin/groupadd"),
+					"groupadd runs exactly when the primary group is absent; got %+v", mock.GetExecutedCommands())
 			}
-			if !gs.AddUserToGroupsCalled {
-				t.Error("AddUserToGroups must still run for an existing user so groups converge")
-			}
+			assert.True(t, gs.AddUserToGroupsCalled, "AddUserToGroups must still run for an existing user so groups converge")
 		})
 	}
 }
@@ -750,15 +687,13 @@ func TestUserHandler_AddUser_Idempotent_UIDConflict(t *testing.T) {
 			}
 
 			exitCode, output, _ := handler.Execute(context.Background(), "adduser", args)
-			if exitCode == 0 {
-				t.Fatalf("expected non-zero exit for uid conflict, got 0 (output=%q)", output)
-			}
-			if !strings.Contains(output, "already exists with uid 9999") || !strings.Contains(output, "requested uid 1001") {
-				t.Errorf("conflict message must name both uids, got: %q", output)
-			}
-			if mock.Invoked("/usr/sbin/adduser") || mock.Invoked("/usr/sbin/useradd") {
-				t.Errorf("no create command may run on a uid conflict; got %+v", mock.GetExecutedCommands())
-			}
+			require.NotEqual(t, 0, exitCode, "a uid conflict must surface, output: %q", output)
+			assert.Contains(t, output, "already exists with uid 9999", "the conflict message must name both uids")
+			assert.Contains(t, output, "requested uid 1001", "the conflict message must name both uids")
+			assert.False(t, mock.Invoked("/usr/sbin/adduser"),
+				"no create command may run on a uid conflict; got %+v", mock.GetExecutedCommands())
+			assert.False(t, mock.Invoked("/usr/sbin/useradd"),
+				"no create command may run on a uid conflict; got %+v", mock.GetExecutedCommands())
 		})
 	}
 }
@@ -786,15 +721,9 @@ func TestUserHandler_AddUser_Idempotent_ServiceAccountNameExists(t *testing.T) {
 	}
 
 	exitCode, output, err := handler.Execute(context.Background(), "adduser", args)
-	if err != nil {
-		t.Fatalf("Execute() unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Fatalf("Execute() exitCode = %d, want 0 (output=%q)", exitCode, output)
-	}
-	if mock.Invoked("/usr/sbin/useradd") {
-		t.Error("useradd must not run when the service account already exists by name")
-	}
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "output: %q", output)
+	assert.False(t, mock.Invoked("/usr/sbin/useradd"), "useradd must not run when the service account already exists by name")
 	// Load-bearing invariant: the `groupadd -f <Groupname>` bootstrap must run
 	// even for an already-present service account, or the named primary group is
 	// not ensured and Demote(ValidateGroup=true) breaks at websh runtime.
@@ -804,9 +733,8 @@ func TestUserHandler_AddUser_Idempotent_ServiceAccountNameExists(t *testing.T) {
 			sawGroupaddDashF = true
 		}
 	}
-	if !sawGroupaddDashF {
-		t.Errorf("`groupadd -f alpacon` must still run for an existing service account; got %+v", mock.GetExecutedCommands())
-	}
+	assert.True(t, sawGroupaddDashF,
+		"`groupadd -f alpacon` must still run for an existing service account; got %+v", mock.GetExecutedCommands())
 }
 
 // TestUserHandler_AddUser_Idempotent_LookupError verifies that a lookup error
@@ -834,15 +762,9 @@ func TestUserHandler_AddUser_Idempotent_LookupError(t *testing.T) {
 	}
 
 	exitCode, output, _ := handler.Execute(context.Background(), "adduser", args)
-	if exitCode == 0 {
-		t.Fatalf("expected non-zero exit when the lookup itself fails, got 0 (output=%q)", output)
-	}
-	if !strings.Contains(output, "unable to verify") {
-		t.Errorf("expected an 'unable to verify' message, got: %q", output)
-	}
-	if mock.Invoked("/usr/sbin/adduser") {
-		t.Error("adduser must not run when existence cannot be verified")
-	}
+	require.NotEqual(t, 0, exitCode, "a failing lookup must surface, output: %q", output)
+	assert.Contains(t, output, "unable to verify")
+	assert.False(t, mock.Invoked("/usr/sbin/adduser"), "adduser must not run when existence cannot be verified")
 }
 
 // TestUserHandler_AddUser_SecondaryNet verifies the create-time reconcile net on
@@ -899,17 +821,14 @@ func TestUserHandler_AddUser_SecondaryNet(t *testing.T) {
 			}
 
 			exitCode, output, _ := handler.Execute(context.Background(), "adduser", args)
-			if !mock.Invoked("/usr/sbin/adduser") {
-				t.Fatal("adduser should have been attempted after an absent gate lookup")
+			require.True(t, mock.Invoked("/usr/sbin/adduser"), "adduser must be attempted after an absent gate lookup")
+			if tt.wantExitZero {
+				require.Equal(t, 0, exitCode, "the reconcile must land on idempotent success, output: %q", output)
+			} else {
+				require.NotEqual(t, 0, exitCode, "output: %q", output)
 			}
-			if tt.wantExitZero && exitCode != 0 {
-				t.Fatalf("expected idempotent success (exit 0), got %d (output=%q)", exitCode, output)
-			}
-			if !tt.wantExitZero && exitCode == 0 {
-				t.Fatalf("expected non-zero exit, got 0 (output=%q)", output)
-			}
-			if tt.wantMsgPart != "" && !strings.Contains(output, tt.wantMsgPart) {
-				t.Errorf("expected output to contain %q, got: %q", tt.wantMsgPart, output)
+			if tt.wantMsgPart != "" {
+				assert.Contains(t, output, tt.wantMsgPart)
 			}
 		})
 	}
@@ -955,15 +874,9 @@ func TestUserHandler_AddUser_Rhel_SecondaryNet(t *testing.T) {
 		}
 
 		exitCode, output, _ := handler.Execute(context.Background(), "adduser", baseArgs())
-		if !mock.Invoked("/usr/sbin/useradd") {
-			t.Fatal("useradd should have been attempted")
-		}
-		if exitCode != 0 {
-			t.Fatalf("expected idempotent success, got %d (output=%q)", exitCode, output)
-		}
-		if !strings.Contains(output, "already exists") {
-			t.Errorf("reconciled-success path should report 'already exists', got: %q", output)
-		}
+		require.True(t, mock.Invoked("/usr/sbin/useradd"), "useradd must be attempted")
+		require.Equal(t, 0, exitCode, "the reconcile must land on idempotent success, output: %q", output)
+		assert.Contains(t, output, "already exists", "the reconciled-success path must say so")
 	})
 
 	t.Run("useradd reconcile: raced different uid -> conflict surfaced", func(t *testing.T) {
@@ -986,12 +899,8 @@ func TestUserHandler_AddUser_Rhel_SecondaryNet(t *testing.T) {
 		}
 
 		exitCode, output, _ := handler.Execute(context.Background(), "adduser", baseArgs())
-		if exitCode == 0 {
-			t.Fatalf("expected conflict (non-zero), got 0 (output=%q)", output)
-		}
-		if !strings.Contains(output, "already exists with uid 6006") {
-			t.Errorf("expected uid conflict message, got: %q", output)
-		}
+		require.NotEqual(t, 0, exitCode, "the uid conflict must surface, output: %q", output)
+		assert.Contains(t, output, "already exists with uid 6006")
 	})
 
 	t.Run("primary-group groupadd reconcile: raced NSS group -> tolerated, useradd proceeds", func(t *testing.T) {
@@ -1013,15 +922,10 @@ func TestUserHandler_AddUser_Rhel_SecondaryNet(t *testing.T) {
 		}
 
 		exitCode, output, err := handler.Execute(context.Background(), "adduser", baseArgs())
-		if err != nil || exitCode != 0 {
-			t.Fatalf("expected groupadd reconcile to tolerate; got exitCode=%d err=%v output=%q", exitCode, err, output)
-		}
-		if !mock.Invoked("/usr/sbin/groupadd") {
-			t.Fatal("groupadd should have been attempted after an absent gate lookup")
-		}
-		if !mock.Invoked("/usr/sbin/useradd") {
-			t.Error("useradd must still run after the primary group is reconciled")
-		}
+		require.NoError(t, err, "the groupadd reconcile must tolerate a raced group")
+		require.Equal(t, 0, exitCode, "output: %q", output)
+		require.True(t, mock.Invoked("/usr/sbin/groupadd"), "groupadd must be attempted after an absent gate lookup")
+		assert.True(t, mock.Invoked("/usr/sbin/useradd"), "useradd must still run after the primary group is reconciled")
 	})
 }
 
@@ -1052,15 +956,11 @@ func TestUserHandler_AddUser_Rhel_PrimaryGroupGate(t *testing.T) {
 		handler.lookupGroup = common.ExistingGroupLookup("5001")
 
 		exitCode, output, err := handler.Execute(context.Background(), "adduser", baseArgs())
-		if err != nil || exitCode != 0 {
-			t.Fatalf("Execute() exitCode=%d err=%v output=%q", exitCode, err, output)
-		}
-		if mock.Invoked("/usr/sbin/groupadd") {
-			t.Errorf("groupadd must be skipped when the group already exists with matching gid; got %+v", mock.GetExecutedCommands())
-		}
-		if !mock.Invoked("/usr/sbin/useradd") {
-			t.Error("useradd must still run to create the absent user")
-		}
+		require.NoError(t, err)
+		require.Equal(t, 0, exitCode, "output: %q", output)
+		assert.False(t, mock.Invoked("/usr/sbin/groupadd"),
+			"groupadd must be skipped when the group already exists with a matching gid; got %+v", mock.GetExecutedCommands())
+		assert.True(t, mock.Invoked("/usr/sbin/useradd"), "useradd must still run to create the absent user")
 	})
 
 	t.Run("group exists with different gid -> conflict before useradd", func(t *testing.T) {
@@ -1073,15 +973,9 @@ func TestUserHandler_AddUser_Rhel_PrimaryGroupGate(t *testing.T) {
 		handler.lookupGroup = common.ExistingGroupLookup("7777")
 
 		exitCode, output, _ := handler.Execute(context.Background(), "adduser", baseArgs())
-		if exitCode == 0 {
-			t.Fatalf("expected non-zero exit for group gid conflict, got 0 (output=%q)", output)
-		}
-		if !strings.Contains(output, "already exists with gid 7777") {
-			t.Errorf("expected group conflict message, got: %q", output)
-		}
-		if mock.Invoked("/usr/sbin/useradd") {
-			t.Error("useradd must not run when the primary group gid conflicts")
-		}
+		require.NotEqual(t, 0, exitCode, "a group gid conflict must surface, output: %q", output)
+		assert.Contains(t, output, "already exists with gid 7777")
+		assert.False(t, mock.Invoked("/usr/sbin/useradd"), "useradd must not run when the primary group gid conflicts")
 	})
 }
 
@@ -1110,19 +1004,10 @@ func TestUserHandler_AddUser_ExistingUser_GroupAddSoftFailMessage(t *testing.T) 
 	}
 
 	exitCode, output, err := handler.Execute(context.Background(), "adduser", args)
-	if err != nil {
-		t.Fatalf("Execute() unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Fatalf("group-add soft failure must keep exit 0, got %d (output=%q)", exitCode, output)
-	}
-	if !gs.AddUserToGroupsCalled {
-		t.Error("AddUserToGroups should have been called for an existing user")
-	}
-	if strings.Contains(output, "created") || !strings.Contains(output, "already exists but failed to add to groups") {
-		t.Errorf("soft-failure message should say the user already exists, not 'created'; got: %q", output)
-	}
-	if mock.Invoked("/usr/sbin/adduser") {
-		t.Error("adduser must not run for an existing user")
-	}
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "a group-add soft failure must keep exit 0, output: %q", output)
+	assert.True(t, gs.AddUserToGroupsCalled, "AddUserToGroups must be called for an existing user")
+	assert.NotContains(t, output, "created", "the soft-failure message must not claim the user was created")
+	assert.Contains(t, output, "already exists but failed to add to groups")
+	assert.False(t, mock.Invoked("/usr/sbin/adduser"), "adduser must not run for an existing user")
 }


### PR DESCRIPTION
Fourth PR for #370. Scope is `pkg/executor/handlers/user`—`user_test.go`, the only test file in the package, so it reads as testify-only after this.

The rule the earlier PRs settled applies unchanged: the original code had already chosen where a failure must stop, since every `t.Fatal*` aborts and every `t.Error*` keeps checking. The conversion maps `t.Fatal*` to `require` and `t.Error*` to `assert`, one for one. All 27 `t.Fatal*` became `require` and all 45 `t.Error*` became `assert`; no test was added or removed, and exactly one subtest was renamed.

## What changed

Eleven commits, one idea each. The first five are the conversion; the last six answer the review on it and are described under [The review](#the-review).

| Commit | What it does |
|---|---|
| `1683e54f` | the conversion: every hand-written check in the file becomes testify |
| `f93376dd` | testify joins the local import group, matching the 22 other files in the repo that import both |
| `9ca0ca31` | the group-add table asserted `err` only inside a branch that never ran |
| `1c22d398` | a subtest name carried `/`, which is the `-run` separator |
| `1d698b85` | both tables accepted any error; each row now pins the one it expects |
| `97c4718a` | a row comment said the opposite of the field list below it |
| `1deafdc1` | two tables ran the same scenario with identical args |
| `0c36ed88` | one failing row asserted an exit code and nothing else |
| `affbf18f` | the forbid column compared slice elements while its message printed the joined string |
| `b3490e79` | `wantCode` was a non-varying column, the same reason `calledGroups` had already left |
| `7b535409` | the `groupadd -f` scan existed in two copies |
| `b4964b7d` | an assertion message that fit only one of its two rows |

```
pkg/executor/handlers/user/user_test.go | 439 +++++++++++++-------------------
1 file changed, 170 insertions(+), 269 deletions(-)
```

Commits three through five answer suggestions carried over from the earlier reviews in this series rather than the conversion itself: #427 asked for error checks to be pinned to their message instead of accepting any error, #422's re-review flagged `/` in subtest names for breaking `-run` isolation, and #422 flagged an assertion that two equally wrong values would have passed.

## The counts close exactly

The conversion turned 72 checks into 79 assertions: +9 from splitting compound conditions, -2 from folding two `if` pairs. `72 + 9 - 2 = 79`.

The three follow-up commits take that to 82, which is `require` 30 plus `assert` 52 as counted in the file:

| Commit | Delta | Why |
|---|---|---|
| `9ca0ca31` | +1 `assert` | the output each row produces is now pinned; it was discarded before |
| `1d698b85` | +1 `assert`, +1 `require` | `Validate` splits into three cases instead of two, and the new helper uses `require.ErrorAs` |

Nine conditions ORed into one `if` became one assertion each in the conversion, so a failure names which half broke:

| Original | Became |
|---|---|
| `(err != nil) != tt.wantErr` (`Execute`, `Validate`) | `if tt.wantErr { assert.Error } else { assert.NoError }` |
| `err != nil \|\| exitCode != 0` (two call sites) | `require.NoError` + `require.Equal` |
| `!C("--gid 5001") \|\| !C("alpacon")` | two `assert.Contains` |
| `!C("uid 9999") \|\| !C("requested uid 1001")` | two `assert.Contains` |
| `Invoked(adduser) \|\| Invoked(useradd)` | two `assert.False` |
| `C("created") \|\| !C("already exists but failed…")` | `assert.NotContains` + `assert.Contains` |
| `!C("already exists") \|\| C("added successfully")` | `assert.Contains` + `assert.NotContains` |

The `err != nil || exitCode != 0` pair is the only split that produces two `require` calls rather than two `assert` calls. The original aborted on either half, so both halves stay fatal.

The first row of that table was superseded by `1d698b85`, described below. The `wantErr` boolean it introduced is gone.

## Each row pins the error it expects

`assert.Error(t, err)` passes on whatever came back, so `Execute`'s unknown-command and adduser-failure rows shared one expectation, and `Validate`'s four failing rows shared one across three different validation causes.

`Execute` carries `wantErrMsg` and asserts `EqualError`:

```go
wantErrMsg:   "unknown user command: unknownuser",
wantErrMsg:   "user add error",
```

`Validate` splits by error kind, because the two are not the same shape. The unknown command returns a plain `fmt.Errorf`, so it takes `wantErrMsg`. The rest return `validator.ValidationErrors`, one line per field, so they take `wantErrFields` and assert the exact field set:

```go
wantErrFields: []string{"UID", "GID", "Comment", "HomeDirectory", "Shell", "Groupname"},
wantErrFields: []string{"UID", "GID", "HomeDirectory"},
wantErrFields: []string{"UID"},
```

```go
switch {
case tt.wantErrMsg != "":
	assert.EqualError(t, err, tt.wantErrMsg)
case len(tt.wantErrFields) > 0:
	assert.ElementsMatch(t, tt.wantErrFields, validationFields(t, err))
default:
	assert.NoError(t, err)
}
```

Pinning the whole multi-line validator string would restate the library's own wording, and `assert.ErrorContains` on one representative field would not separate the rows: the missing-fields row and the IAM row both flag `UID`. The field set is what each row is actually about. Every expectation was read off an actual run rather than derived from the struct tags.

The row comment claiming the adduser failure was "returned as part of output, not actual go error" is gone with this commit. The mock returns a real error, which the pinned message now shows.

## The group-add table asserted an error it never reached

`TestUserHandler_AddUserWithGroups` guarded its only `err` assertion behind a branch that could not run:

```go
// before
if !tt.groupService.AddUserToGroupsCalled {
	assert.NoError(t, err)
}
assert.Equal(t, tt.calledGroups, tt.groupService.AddUserToGroupsCalled, "AddUserToGroups called")
```

Both rows set additional groups, so `AddUserToGroups` always runs and the branch never executed. Replacing its body with `t.Fatal("UNREACHABLE BRANCH")` keeps the test passing, which is how this was confirmed. The `err` from `Execute` was therefore unchecked, and since `err` was used nowhere else, deleting the branch alone does not compile.

`calledGroups` was `true` in both rows, which left the table with no varying expectation. It becomes `wantOutput`, so the soft-failure path the test exists for is finally covered—the output was discarded before:

```go
// after
exitCode, output, err := handler.Execute(ctx, "adduser", args)

// A group-add failure reaches the operator through the output, not err.
assert.NoError(t, err)
assert.Equal(t, 0, exitCode, "the create path exits 0 whether or not the group-add step fails")
assert.Equal(t, tt.wantOutput, output)
assert.True(t, tt.groupService.AddUserToGroupsCalled, "AddUserToGroups must run when the args carry additional groups")
```

`handleAddUser` returns a nil `err` on every path this test reaches, including the group-add soft failure at `pkg/executor/handlers/user/user.go:310`, so `NoError` is right for both rows.

## The renamed subtest

`"adduser IAM User path must still require uid/gid/home"` spanned three levels of the `-run` pattern, since `/` is the separator, so the case could not be selected on its own. It is now `"...require uid, gid and home"`, and it is the only name in the file that carried a slash.

## Three loops replaced by an equivalent the package already has

Each was checked against the helper's source, not assumed.

The `forbidFlags` nested loop becomes `assert.NotContains(t, joined, forbid)`. The conversion first kept the original `a == forbid` element comparison; the review pointed out that the failure message printed `joined` either way, so the two columns of the table read as one kind of check and were not. Matching the forbid column against the joined string as well makes both columns substring rules, and it is the stronger of the two: `--uid=1001` is not element-equal to `--uid` and used to pass.

The `useradd` scan in `TestUserHandler_AddUser_ServiceAccountGroupaddFails` becomes `assert.False(t, mock.Invoked("/usr/sbin/useradd"), ...)`. `Invoked` (`pkg/executor/handlers/common/testing.go:134`) walks the same `m.commands` slice with the same exact `c.Name == program` match, and the rest of this file already uses it.

The `groupadd -f` / `useradd` ordering check becomes `assert.Less(t, groupaddDashFIndex, useraddIndex, ...)`, which prints both indices that the original message spelled out by hand. The scan that produces the first index is now `invokedAt`, described below.

## The review

The review on the conversion raised one warning and five suggestions. All six are taken, one commit each.

**The warning** was a comment saying `Shell is defaulted by the helper` three lines above a `wantErrFields` list containing `Shell`. If it were defaulted it could not fail validation. `types.go:52` states the opposite and says why: defaulting `Shell` before `ValidateStruct` would mask an empty `shell` payload and hand a service account an interactive `/bin/bash`. The comment predates this branch, but turning `wantErr: true` into an explicit field list is what made it contradict the line below it, so it is fixed here.

**Two tables ran the same scenario.** `TestUserHandler_Execute/adduser success debian` and `TestUserHandler_AddUserWithGroups/add user to groups success` took character-identical args, down to `Groups: []uint64{1002, 1003}`. Both used to discard the output, so the overlap did not show; pinning the output string exposed it. Dropping `Groups` from the `Execute` row leaves it covering the plain create path, which no other row covers.

**One failing row stayed unpinned.** `"adduser missing username"` asserted `wantCode: 1` and nothing else. That path exits through `user.go:118` as `return 1, err.Error(), nil`, so the string an operator sees rides in `output` and `wantErrMsg` cannot reach it. A `wantOutputPart` column covers that shape, and every failing row in the table now states what it expects to be told.

**`wantCode` was a column both rows filled identically.** `calledGroups` had left the same table for exactly that reason, so the rule was applied once and followed once. The expectation is worth keeping, just not as a column: a group-add failure must not change the exit code, which reads better as a literal `0` with that sentence attached.

**The `groupadd -f alpacon` scan existed twice**, character for character, in `TestUserHandler_AddUser_UidLess` and `TestUserHandler_AddUser_Idempotent_ServiceAccountNameExists`. It is now one helper:

```go
func invokedAt(mock *common.MockCommandExecutor, program string, args ...string) int {
	for i, c := range mock.GetExecutedCommands() {
		if c.Name == program && slices.Equal(c.Args, args) {
			return i
		}
	}
	return -1
}
```

The review suggested an `InvokedWithArgs(program string, args ...string) bool` on the shared mock next to `Invoked`, or a small helper inside this file. This takes the second, and returns an index rather than a bool. The index is what the uid-less test needs, since it asserts that `groupadd -f` ran before adduser/useradd, and a bool cannot express that. It stays in this file because both call sites are here: putting it on `MockCommandExecutor` would add an exported API to a mock nine packages share, for two callers.

The match is the whole argument list rather than the leading two the loops compared. Both call sites run `groupadd -f alpacon` with exactly those arguments, so nothing changes today, and an argument added later will say so instead of passing quietly.

## Verification

No production code changed. `git diff origin/main..HEAD --name-only` is one test file.

The 48 test and subtest PASS lines are the same before and after, apart from the deliberate rename. Names were collected with `go test -v` on `origin/main`'s copy of the file and on this branch, sorted and diffed:

```
$ diff names-old.txt names-new.txt
26c26
<     --- PASS: TestUserHandler_Validate/adduser_IAM_User_path_must_still_require_uid/gid/home
---
>     --- PASS: TestUserHandler_Validate/adduser_IAM_User_path_must_still_require_uid,_gid_and_home
```

`gofmt -l` is empty, `go vet ./pkg/executor/handlers/user/` is clean, and the package passes under `-race -shuffle=on`:

```
ok  github.com/alpacax/alpamon/v2/pkg/executor/handlers/user  1.512s
```

`go test ./... -p 1` passes across all 45 packages.

Behavior preservation for the conversion was checked by mutation. Six bugs were planted in `user.go` one at a time and the old and new test files were run against each:

| Planted bug | Old tests | New tests |
|---|---|---|
| `groupadd -f` failure returned as exit 0 | CAUGHT | CAUGHT |
| lookup error ignored, blind-creates | CAUGHT | CAUGHT |
| uid conflict masked | CAUGHT | CAUGHT |
| `groupadd -f` skipped for service accounts | CAUGHT | CAUGHT |
| `groupadd` runs regardless of the lookup gate | CAUGHT | CAUGHT |
| `--uid` leaks onto the uid-less path | CAUGHT | CAUGHT |

The last two target the folded assertions specifically, since those are the two places where one assertion now covers what two `if` blocks used to.

The three follow-up commits were probed the same way, by breaking each new assertion and confirming it reports:

| Probe | Result |
|---|---|
| an extra field added to a `wantErrFields` set | `FAIL … extra elements in list A` |
| `"user add error"` changed to `"user add errorX"` | `FAIL TestUserHandler_Execute/adduser_failure` |
| `assert.NoError(t, err)` flipped to `require.Error` | both rows FAIL, so the assertion runs on both |

The six review commits were probed the same way:

| Probe | Result |
|---|---|
| `wantOutputPart` changed to a string the output cannot contain | `FAIL … does not contain "Nonexistent"` |
| `--shell` added to the debian row's `forbidFlags` | `FAIL … should not contain "--shell"` |
| `invokedAt` asked for `-f wrong` | both uid-less rows FAIL |
| `invokedAt` asked for `-f` alone, one argument short | debian row FAILs |

`user.go` was restored from a saved copy after each run; `git status` shows only the test file modified.

## Left for a follow-up

The `/usr/sbin/*` program paths repeat as literals: `useradd` 13 times, `adduser` 11, `groupadd` 8. Constants would make a typo in a `mock.Invoked` argument a compile error rather than a silently false assertion, since `Invoked` returns `false` for any name it does not recognise. This was tried and dropped on purpose: production hardcodes the same paths (`user.go:161,218,271,414,466`), so a test-side constant duplicates them, and sharing one constant with production would let a wrong path pass its own test. Doing it properly touches both sides, which is a different diff from an assertion-style pass.

## Remaining candidates

Part of #370, which stays open. Next: `shell_test.go` (61 checks, plus three smaller files in the same package), `updater_test.go` (56), `auth_session_event_test.go` (54), `auth_manager_tracker_test.go` (50), `multipart_stream_test.go` (47).

