### PR TITLE
test: unify assertion style on testify in the remaining primary candidates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ Key packages:
 ## Code conventions
 
 - Run `go test -v ./... -p 1` for tests (sequential due to SQLite locking)
-- Assert with testify: `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. New tests never call `t.Errorf` or `t.Fatalf` directly, except where there is no error value to assert on (the timeout branch of a `select`)
+- Assert with testify: `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison: `require.NoError`, `assert.ErrorContains`, `assert.DirExists`. Read what a helper accepts before reaching for it, because the shorter spelling is sometimes the weaker check: `assert.NoFileExists` treats a directory at the path, and any other `Lstat` error, as absence, so a test that must prove a path was removed asserts `os.ErrNotExist` from `os.Stat` instead. New tests never call `t.Error`, `t.Errorf`, `t.Fatal` or `t.Fatalf` directly; the single exception is a bare `t.Fatal` where there is no error value to assert on, such as the timeout branch of a `select`
 - Run Ent code generation after schema changes; never edit `pkg/db/ent/` manually
 - Platform-specific files use `_darwin.go` / `_linux.go` suffixes
 - Timeout exit code is 124 (GNU `timeout` convention)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ Key packages:
 ## Code conventions
 
 - Run `go test -v ./... -p 1` for tests (sequential due to SQLite locking)
+- Assert with testify: `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. New tests never call `t.Errorf` or `t.Fatalf` directly, except where there is no error value to assert on (the timeout branch of a `select`)
 - Run Ent code generation after schema changes; never edit `pkg/db/ent/` manually
 - Platform-specific files use `_darwin.go` / `_linux.go` suffixes
 - Timeout exit code is 124 (GNU `timeout` convention)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ Key packages:
 ## Code conventions
 
 - Run `go test -v ./... -p 1` for tests (sequential due to SQLite locking)
+<!-- This testing-conventions paragraph is mirrored in CLAUDE.md, README.md and .github/copilot-instructions.md. Edit all three together. -->
 - Assert with testify: `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison: `require.NoError`, `assert.ErrorContains`, `assert.DirExists`. Read what a helper accepts before reaching for it, because the shorter spelling is sometimes the weaker check: `assert.NoFileExists` treats a directory at the path, and any other `Lstat` error, as absence, so a test that must prove a path was removed asserts `os.ErrNotExist` from `os.Stat` instead. New tests never call `t.Error`, `t.Errorf`, `t.Fatal` or `t.Fatalf` directly; the single exception is a bare `t.Fatal` where there is no error value to assert on, such as the timeout branch of a `select`
 - Run Ent code generation after schema changes; never edit `pkg/db/ent/` manually
 - Platform-specific files use `_darwin.go` / `_linux.go` suffixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ go test -v ./... -p 1
 go test -v ./pkg/collector/check/realtime/cpu
 ```
 
+<!-- This testing-conventions paragraph is mirrored in CLAUDE.md, README.md and .github/copilot-instructions.md. Edit all three together. -->
 Assert with [testify](https://github.com/stretchr/testify): `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison: `require.NoError`, `assert.ErrorContains`, `assert.DirExists`. Read what a helper accepts before reaching for it, because the shorter spelling is sometimes the weaker check. `assert.NoFileExists` is the example: it treats a directory at the path, and any other `Lstat` error, as absence, so a test that must prove a path was removed asserts `os.ErrNotExist` from `os.Stat` instead. Write every new test this way. Many older tests still call `t.Errorf` and `t.Fatalf` directly; convert one while you are already editing it rather than as a separate sweep. A bare `t.Fatal` stays correct where there is no error value to assert on, such as the timeout branch of a `select`.
 
 ### Running locally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ go test -v ./... -p 1
 go test -v ./pkg/collector/check/realtime/cpu
 ```
 
+Assert with [testify](https://github.com/stretchr/testify): `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison—`require.NoError`, `assert.ErrorContains`, `assert.NoFileExists`. Write every new test this way. Many older tests still call `t.Errorf` and `t.Fatalf` directly; convert one while you are already editing it rather than as a separate sweep. A bare `t.Fatal` stays correct where there is no error value to assert on, such as the timeout branch of a `select`.
+
 ### Running locally
 ```bash
 # Run from source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ go test -v ./... -p 1
 go test -v ./pkg/collector/check/realtime/cpu
 ```
 
-Assert with [testify](https://github.com/stretchr/testify): `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison—`require.NoError`, `assert.ErrorContains`, `assert.NoFileExists`. Write every new test this way. Many older tests still call `t.Errorf` and `t.Fatalf` directly; convert one while you are already editing it rather than as a separate sweep. A bare `t.Fatal` stays correct where there is no error value to assert on, such as the timeout branch of a `select`.
+Assert with [testify](https://github.com/stretchr/testify): `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison: `require.NoError`, `assert.ErrorContains`, `assert.DirExists`. Read what a helper accepts before reaching for it, because the shorter spelling is sometimes the weaker check. `assert.NoFileExists` is the example: it treats a directory at the path, and any other `Lstat` error, as absence, so a test that must prove a path was removed asserts `os.ErrNotExist` from `os.Stat` instead. Write every new test this way. Many older tests still call `t.Errorf` and `t.Fatalf` directly; convert one while you are already editing it rather than as a separate sweep. A bare `t.Fatal` stays correct where there is no error value to assert on, such as the timeout branch of a `select`.
 
 ### Running locally
 ```bash

--- a/README.md
+++ b/README.md
@@ -204,6 +204,17 @@ atlas migrate diff <migration_name> \
     --dev-url "sqlite://alpamon.db?mode=memory"
 ```
 
+### Tests
+
+```bash
+go test ./... -p 1        # whole suite
+go test -v ./pkg/updater  # one package
+```
+
+`-p 1` is required. The SQLite store and the system resource checks both break when packages run in parallel.
+
+Assert with [testify](https://github.com/stretchr/testify): `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison—`require.NoError`, `assert.ErrorContains`, `assert.NoFileExists`. Write every new test this way. Many older tests still call `t.Errorf` and `t.Fatalf` directly; convert one while you are already editing it rather than as a separate sweep. A bare `t.Fatal` stays correct where there is no error value to assert on, such as the timeout branch of a `select`.
+
 ### Docker testing (Linux distros)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ go test -v ./pkg/updater  # one package
 
 `-p 1` is required. The SQLite store and the system resource checks both break when packages run in parallel.
 
-Assert with [testify](https://github.com/stretchr/testify): `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison—`require.NoError`, `assert.ErrorContains`, `assert.NoFileExists`. Write every new test this way. Many older tests still call `t.Errorf` and `t.Fatalf` directly; convert one while you are already editing it rather than as a separate sweep. A bare `t.Fatal` stays correct where there is no error value to assert on, such as the timeout branch of a `select`.
+Assert with [testify](https://github.com/stretchr/testify): `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison: `require.NoError`, `assert.ErrorContains`, `assert.DirExists`. Read what a helper accepts before reaching for it, because the shorter spelling is sometimes the weaker check. `assert.NoFileExists` is the example: it treats a directory at the path, and any other `Lstat` error, as absence, so a test that must prove a path was removed asserts `os.ErrNotExist` from `os.Stat` instead. Write every new test this way. Many older tests still call `t.Errorf` and `t.Fatalf` directly; convert one while you are already editing it rather than as a separate sweep. A bare `t.Fatal` stays correct where there is no error value to assert on, such as the timeout branch of a `select`.
 
 ### Docker testing (Linux distros)
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ go test -v ./pkg/updater  # one package
 
 `-p 1` is required. The SQLite store and the system resource checks both break when packages run in parallel.
 
+<!-- This testing-conventions paragraph is mirrored in CLAUDE.md, README.md and .github/copilot-instructions.md. Edit all three together. -->
 Assert with [testify](https://github.com/stretchr/testify): `require` when a failed check makes the rest of the test meaningless, `assert` for the checks themselves. Prefer the specific helper over a hand-rolled comparison: `require.NoError`, `assert.ErrorContains`, `assert.DirExists`. Read what a helper accepts before reaching for it, because the shorter spelling is sometimes the weaker check. `assert.NoFileExists` is the example: it treats a directory at the path, and any other `Lstat` error, as absence, so a test that must prove a path was removed asserts `os.ErrNotExist` from `os.Stat` instead. Write every new test this way. Many older tests still call `t.Errorf` and `t.Fatalf` directly; convert one while you are already editing it rather than as a separate sweep. A bare `t.Fatal` stays correct where there is no error value to assert on, such as the timeout branch of a `select`.
 
 ### Docker testing (Linux distros)

--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -1,0 +1,23 @@
+// Package testutil provides filesystem assertions shared by tests in more
+// than one package. It lives under the repo-root internal/ tree so the Go
+// compiler blocks imports from outside this module.
+//
+// This package must only be imported from *_test.go files.
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertGone fails unless path is absent, which os.Stat reports as
+// os.ErrNotExist. assert.NoFileExists is the shorter spelling but it treats a
+// directory at path, and any other Lstat error, as absence, so a test proving
+// that a cleanup step ran would pass on a path that is still there.
+func AssertGone(t *testing.T, path string, msgAndArgs ...any) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist, msgAndArgs...)
+}

--- a/pkg/executor/handlers/file/multipart_stream_test.go
+++ b/pkg/executor/handlers/file/multipart_stream_test.go
@@ -61,6 +61,23 @@ func requireMultipartReader(t *testing.T, body io.Reader, ct string) *multipart.
 	return multipart.NewReader(body, params["boundary"])
 }
 
+// assertSinglePart consumes the next part of mr and checks it is the content
+// field for fileName carrying payload. Comparing sha256 digests keeps a
+// megabyte-sized mismatch out of the failure output.
+func assertSinglePart(t *testing.T, mr *multipart.Reader, fileName string, payload []byte) {
+	t.Helper()
+	part, err := mr.NextPart()
+	require.NoError(t, err)
+	assert.Equal(t, multipartFieldContent, part.FormName())
+	assert.Equal(t, fileName, part.FileName())
+
+	got := sha256.New()
+	_, err = io.Copy(got, part)
+	require.NoError(t, err)
+	want := sha256.Sum256(payload)
+	assert.Equal(t, want[:], got.Sum(nil), "payload digest mismatch")
+}
+
 func TestBuildMultipartStream_Roundtrip(t *testing.T) {
 	payload := bytes.Repeat([]byte{0xAB}, 1<<20)
 	src := io.NopCloser(bytes.NewReader(payload))
@@ -69,16 +86,7 @@ func TestBuildMultipartStream_Roundtrip(t *testing.T) {
 	defer func() { _ = body.Close() }()
 
 	mr := requireMultipartReader(t, body, ct)
-	part, err := mr.NextPart()
-	require.NoError(t, err)
-	assert.Equal(t, multipartFieldContent, part.FormName())
-	assert.Equal(t, "f.bin", part.FileName())
-
-	got := sha256.New()
-	_, err = io.Copy(got, part)
-	require.NoError(t, err)
-	want := sha256.Sum256(payload)
-	assert.Equal(t, want[:], got.Sum(nil), "payload digest mismatch")
+	assertSinglePart(t, mr, "f.bin", payload)
 
 	_, err = mr.NextPart()
 	assert.ErrorIs(t, err, io.EOF)
@@ -182,16 +190,7 @@ func TestBuildMultipartStream_SmallPath_Roundtrip(t *testing.T) {
 	defer func() { _ = body.Close() }()
 
 	mr := requireMultipartReader(t, body, ct)
-	part, err := mr.NextPart()
-	require.NoError(t, err)
-	assert.Equal(t, multipartFieldContent, part.FormName())
-	assert.Equal(t, "small.bin", part.FileName())
-
-	got := sha256.New()
-	_, err = io.Copy(got, part)
-	require.NoError(t, err)
-	want := sha256.Sum256(payload)
-	assert.Equal(t, want[:], got.Sum(nil), "payload digest mismatch")
+	assertSinglePart(t, mr, "small.bin", payload)
 
 	_, err = mr.NextPart()
 	assert.ErrorIs(t, err, io.EOF)
@@ -228,16 +227,7 @@ func TestBuildMultipartStream_BufferedPath_Roundtrip(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, contentLength, n, "wire size must match contentLength")
 
-			part, err := requireMultipartReader(t, &captured, ct).NextPart()
-			require.NoError(t, err)
-			assert.Equal(t, multipartFieldContent, part.FormName())
-			assert.Equal(t, "f.bin", part.FileName())
-
-			got := sha256.New()
-			_, err = io.Copy(got, part)
-			require.NoError(t, err)
-			want := sha256.Sum256(payload)
-			assert.Equal(t, want[:], got.Sum(nil), "payload digest mismatch")
+			assertSinglePart(t, requireMultipartReader(t, &captured, ct), "f.bin", payload)
 		})
 	}
 }

--- a/pkg/executor/handlers/file/multipart_stream_test.go
+++ b/pkg/executor/handlers/file/multipart_stream_test.go
@@ -175,7 +175,7 @@ func TestBuildMultipartStream_EarlyCloseNoLeak(t *testing.T) {
 // path (hint < multipartPipeBufSize, currently 4 MiB) produces a well-formed
 // multipart body with correct payload.
 func TestBuildMultipartStream_SmallPath_Roundtrip(t *testing.T) {
-	payload := bytes.Repeat([]byte{0xCD}, 512<<10) // 512 KiB — well below multipartPipeBufSize (4 MiB)
+	payload := bytes.Repeat([]byte{0xCD}, 512<<10) // 512 KiB, well below multipartPipeBufSize (4 MiB)
 	src := io.NopCloser(bytes.NewReader(payload))
 	body, ct, _, err := buildMultipartStream(src, "small.bin", false, int64(len(payload)))
 	require.NoError(t, err)

--- a/pkg/executor/handlers/file/multipart_stream_test.go
+++ b/pkg/executor/handlers/file/multipart_stream_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type errReader struct {
@@ -44,84 +47,72 @@ func (e *errReader) Close() error {
 	return e.closeErr
 }
 
+// requireMultipartReader parses ct as a multipart/form-data content type and
+// returns a reader over body, failing the test when either step does not hold.
+func requireMultipartReader(t *testing.T, body io.Reader, ct string) *multipart.Reader {
+	t.Helper()
+	mt, params, err := mime.ParseMediaType(ct)
+	require.NoError(t, err, "ct=%q", ct)
+	require.Equal(t, "multipart/form-data", mt)
+	return multipart.NewReader(body, params["boundary"])
+}
+
 func TestBuildMultipartStream_Roundtrip(t *testing.T) {
 	payload := bytes.Repeat([]byte{0xAB}, 1<<20)
 	src := io.NopCloser(bytes.NewReader(payload))
 	body, ct, _, err := buildMultipartStream(src, "f.bin", false, -1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = body.Close() }()
-	mt, params, err := mime.ParseMediaType(ct)
-	if err != nil || mt != "multipart/form-data" {
-		t.Fatalf("ct=%q err=%v", ct, err)
-	}
-	mr := multipart.NewReader(body, params["boundary"])
+
+	mr := requireMultipartReader(t, body, ct)
 	part, err := mr.NextPart()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if part.FormName() != "content" || part.FileName() != "f.bin" {
-		t.Fatalf("name=%q file=%q", part.FormName(), part.FileName())
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "content", part.FormName())
+	assert.Equal(t, "f.bin", part.FileName())
+
 	got := sha256.New()
-	if _, err := io.Copy(got, part); err != nil {
-		t.Fatal(err)
-	}
+	_, err = io.Copy(got, part)
+	require.NoError(t, err)
 	want := sha256.Sum256(payload)
-	if !bytes.Equal(got.Sum(nil), want[:]) {
-		t.Fatal("payload digest mismatch")
-	}
-	if _, err := mr.NextPart(); err != io.EOF {
-		t.Fatalf("expected EOF, got %v", err)
-	}
+	assert.Equal(t, want[:], got.Sum(nil), "payload digest mismatch")
+
+	_, err = mr.NextPart()
+	assert.ErrorIs(t, err, io.EOF)
 }
 
 func TestBuildMultipartStream_Recursive(t *testing.T) {
 	src := io.NopCloser(strings.NewReader("zip-data"))
 	body, ct, _, err := buildMultipartStream(src, "tree.zip", true, -1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = body.Close() }()
-	_, params, _ := mime.ParseMediaType(ct)
-	mr := multipart.NewReader(body, params["boundary"])
+
+	mr := requireMultipartReader(t, body, ct)
 	sawName := false
 	for {
 		part, err := mr.NextPart()
 		if err == io.EOF {
 			break
 		}
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if part.FormName() == "name" {
 			data, _ := io.ReadAll(part)
-			if string(data) != "tree.zip" {
-				t.Fatalf("name=%q", data)
-			}
+			assert.Equal(t, "tree.zip", string(data))
 			sawName = true
 		}
 	}
-	if !sawName {
-		t.Fatal("expected name field for recursive upload")
-	}
+	assert.True(t, sawName, "expected name field for recursive upload")
 }
 
 func TestBuildMultipartStream_SrcErrorPropagates(t *testing.T) {
 	er := &errReader{r: bytes.NewReader(bytes.Repeat([]byte{1}, 1024)), failAt: 256}
 	body, _, _, err := buildMultipartStream(er, "f", false, -1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	_, err = io.Copy(io.Discard, body)
-	if err == nil || !strings.Contains(err.Error(), "synthetic") {
-		t.Fatalf("expected synthetic error, got %v", err)
-	}
+	assert.ErrorContains(t, err, "synthetic")
+
 	_ = body.Close()
-	if er.closeCnt == 0 {
-		t.Fatal("src.Close() was not called")
-	}
+	assert.NotZero(t, er.closeCnt, "src.Close() was not called")
 }
 
 // TestBuildMultipartStream_SrcCloseErrorPropagates exercises the demoted-cat
@@ -148,13 +139,11 @@ func TestBuildMultipartStream_SrcCloseErrorPropagates(t *testing.T) {
 				closeErr: errors.New("synthetic-close-fail"),
 			}
 			body, _, _, err := buildMultipartStream(er, "f.bin", false, tc.hint)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			_, err = io.Copy(io.Discard, body)
-			if err == nil || !strings.Contains(err.Error(), "synthetic-close-fail") {
-				t.Fatalf("expected src.Close error to propagate, got %v", err)
-			}
+			assert.ErrorContains(t, err, "synthetic-close-fail", "expected src.Close error to propagate")
+
 			_ = body.Close()
 		})
 	}
@@ -166,9 +155,7 @@ func TestBuildMultipartStream_EarlyCloseNoLeak(t *testing.T) {
 	// pool puts and a pipe close remain), so the signal proves it exits.
 	er := &errReader{r: bytes.NewReader(bytes.Repeat([]byte{1}, 4<<20)), failAt: 1 << 30, closed: make(chan struct{})}
 	body, _, _, err := buildMultipartStream(er, "f", false, -1)
-	if err != nil {
-		t.Fatalf("buildMultipartStream: %v", err)
-	}
+	require.NoError(t, err, "buildMultipartStream")
 	buf := make([]byte, 64)
 	_, _ = body.Read(buf)
 	_ = body.Close()
@@ -186,34 +173,23 @@ func TestBuildMultipartStream_SmallPath_Roundtrip(t *testing.T) {
 	payload := bytes.Repeat([]byte{0xCD}, 512<<10) // 512 KiB — well below multipartPipeBufSize (4 MiB)
 	src := io.NopCloser(bytes.NewReader(payload))
 	body, ct, _, err := buildMultipartStream(src, "small.bin", false, int64(len(payload)))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = body.Close() }()
 
-	mt, params, err := mime.ParseMediaType(ct)
-	if err != nil || mt != "multipart/form-data" {
-		t.Fatalf("ct=%q err=%v", ct, err)
-	}
-	mr := multipart.NewReader(body, params["boundary"])
+	mr := requireMultipartReader(t, body, ct)
 	part, err := mr.NextPart()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if part.FormName() != multipartFieldContent || part.FileName() != "small.bin" {
-		t.Fatalf("name=%q file=%q", part.FormName(), part.FileName())
-	}
+	require.NoError(t, err)
+	assert.Equal(t, multipartFieldContent, part.FormName())
+	assert.Equal(t, "small.bin", part.FileName())
+
 	got := sha256.New()
-	if _, err := io.Copy(got, part); err != nil {
-		t.Fatal(err)
-	}
+	_, err = io.Copy(got, part)
+	require.NoError(t, err)
 	want := sha256.Sum256(payload)
-	if !bytes.Equal(got.Sum(nil), want[:]) {
-		t.Fatal("payload digest mismatch")
-	}
-	if _, err := mr.NextPart(); err != io.EOF {
-		t.Fatalf("expected EOF, got %v", err)
-	}
+	assert.Equal(t, want[:], got.Sum(nil), "payload digest mismatch")
+
+	_, err = mr.NextPart()
+	assert.ErrorIs(t, err, io.EOF)
 }
 
 // TestBuildMultipartStream_BufferedPath_Roundtrip verifies the buffered path
@@ -233,47 +209,30 @@ func TestBuildMultipartStream_BufferedPath_Roundtrip(t *testing.T) {
 			payload := bytes.Repeat([]byte{0xCD}, tc.size)
 			er := &errReader{r: bytes.NewReader(payload), failAt: 1 << 30}
 			body, ct, contentLength, err := buildMultipartStream(er, "f.bin", tc.recursive, int64(tc.size))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer func() { _ = body.Close() }()
-			if contentLength <= 0 {
-				t.Fatalf("expected positive contentLength, got %d", contentLength)
-			}
-			if er.closeCnt == 0 {
-				t.Fatal("expected src.Close to be called synchronously")
-			}
-			mt, params, err := mime.ParseMediaType(ct)
-			if err != nil || mt != "multipart/form-data" {
-				t.Fatalf("ct=%q err=%v", ct, err)
-			}
+
+			assert.Positive(t, contentLength)
+			assert.NotZero(t, er.closeCnt, "expected src.Close to be called synchronously")
+
 			// Drain into a buffer so we can both verify wire size and parse
 			// (boundary is per-call, so a second buildMultipartStream() would
 			// have a different boundary than the ct we captured here).
 			var captured bytes.Buffer
 			n, err := captured.ReadFrom(body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n != contentLength {
-				t.Fatalf("wire size %d != contentLength %d", n, contentLength)
-			}
-			mr := multipart.NewReader(&captured, params["boundary"])
-			part, err := mr.NextPart()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if part.FormName() != multipartFieldContent || part.FileName() != "f.bin" {
-				t.Fatalf("name=%q file=%q", part.FormName(), part.FileName())
-			}
+			require.NoError(t, err)
+			assert.Equal(t, contentLength, n, "wire size must match contentLength")
+
+			part, err := requireMultipartReader(t, &captured, ct).NextPart()
+			require.NoError(t, err)
+			assert.Equal(t, multipartFieldContent, part.FormName())
+			assert.Equal(t, "f.bin", part.FileName())
+
 			got := sha256.New()
-			if _, err := io.Copy(got, part); err != nil {
-				t.Fatal(err)
-			}
+			_, err = io.Copy(got, part)
+			require.NoError(t, err)
 			want := sha256.Sum256(payload)
-			if !bytes.Equal(got.Sum(nil), want[:]) {
-				t.Fatal("payload digest mismatch")
-			}
+			assert.Equal(t, want[:], got.Sum(nil), "payload digest mismatch")
 		})
 	}
 }
@@ -288,12 +247,7 @@ func TestBuildMultipartStream_BufferedPath_SrcCloseErrorPropagates(t *testing.T)
 		closeErr: errors.New("synthetic-close-fail"),
 	}
 	_, _, _, err := buildMultipartStream(er, "f.bin", false, int64(len("payload")))
-	if err == nil {
-		t.Fatal("expected close error to propagate, got nil")
-	}
-	if !strings.Contains(err.Error(), "synthetic-close-fail") {
-		t.Fatalf("expected synthetic-close-fail, got %v", err)
-	}
+	assert.ErrorContains(t, err, "synthetic-close-fail", "expected close error to propagate")
 }
 
 // TestBuildMultipartStream_SmallPathContentLengthMatchesWire verifies the
@@ -313,20 +267,13 @@ func TestBuildMultipartStream_SmallPathContentLengthMatchesWire(t *testing.T) {
 			payload := bytes.Repeat([]byte{0xEE}, tc.size)
 			src := io.NopCloser(bytes.NewReader(payload))
 			body, _, contentLength, err := buildMultipartStream(src, "f.bin", tc.recursive, int64(tc.size))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer func() { _ = body.Close() }()
-			if contentLength <= 0 {
-				t.Fatalf("expected positive contentLength, got %d", contentLength)
-			}
+
+			assert.Positive(t, contentLength)
 			n, err := io.Copy(io.Discard, body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n != contentLength {
-				t.Fatalf("wire size %d != precomputed contentLength %d", n, contentLength)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, contentLength, n, "wire size must match precomputed contentLength")
 		})
 	}
 }
@@ -346,13 +293,9 @@ func TestBuildMultipartStream_LargePathReturnsMinusOne(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			src := io.NopCloser(bytes.NewReader(bytes.Repeat([]byte{1}, 5<<20)))
 			body, _, contentLength, err := buildMultipartStream(src, "f.bin", false, tc.hint)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer func() { _ = body.Close() }()
-			if contentLength != -1 {
-				t.Fatalf("expected contentLength=-1, got %d", contentLength)
-			}
+			assert.Equal(t, int64(-1), contentLength)
 		})
 	}
 }
@@ -363,31 +306,22 @@ func TestBuildMultipartStream_SmallPath_Recursive(t *testing.T) {
 	payload := []byte("small-zip-data")
 	src := io.NopCloser(bytes.NewReader(payload))
 	body, ct, _, err := buildMultipartStream(src, "arch.zip", true, int64(len(payload)))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = body.Close() }()
 
-	_, params, _ := mime.ParseMediaType(ct)
-	mr := multipart.NewReader(body, params["boundary"])
+	mr := requireMultipartReader(t, body, ct)
 	sawName := false
 	for {
 		part, err := mr.NextPart()
 		if err == io.EOF {
 			break
 		}
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if part.FormName() == multipartFieldName {
 			data, _ := io.ReadAll(part)
-			if string(data) != "arch.zip" {
-				t.Fatalf("name=%q", data)
-			}
+			assert.Equal(t, "arch.zip", string(data))
 			sawName = true
 		}
 	}
-	if !sawName {
-		t.Fatal("expected name field for recursive small upload")
-	}
+	assert.True(t, sawName, "expected name field for recursive small upload")
 }

--- a/pkg/executor/handlers/file/multipart_stream_test.go
+++ b/pkg/executor/handlers/file/multipart_stream_test.go
@@ -67,7 +67,7 @@ func TestBuildMultipartStream_Roundtrip(t *testing.T) {
 	mr := requireMultipartReader(t, body, ct)
 	part, err := mr.NextPart()
 	require.NoError(t, err)
-	assert.Equal(t, "content", part.FormName())
+	assert.Equal(t, multipartFieldContent, part.FormName())
 	assert.Equal(t, "f.bin", part.FileName())
 
 	got := sha256.New()
@@ -90,12 +90,13 @@ func TestBuildMultipartStream_Recursive(t *testing.T) {
 	sawName := false
 	for {
 		part, err := mr.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)
-		if part.FormName() == "name" {
-			data, _ := io.ReadAll(part)
+		if part.FormName() == multipartFieldName {
+			data, err := io.ReadAll(part)
+			require.NoError(t, err, "read name field")
 			assert.Equal(t, "tree.zip", string(data))
 			sawName = true
 		}
@@ -313,12 +314,13 @@ func TestBuildMultipartStream_SmallPath_Recursive(t *testing.T) {
 	sawName := false
 	for {
 		part, err := mr.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)
 		if part.FormName() == multipartFieldName {
-			data, _ := io.ReadAll(part)
+			data, err := io.ReadAll(part)
+			require.NoError(t, err, "read name field")
 			assert.Equal(t, "arch.zip", string(data))
 			sawName = true
 		}

--- a/pkg/executor/handlers/file/multipart_stream_test.go
+++ b/pkg/executor/handlers/file/multipart_stream_test.go
@@ -48,12 +48,16 @@ func (e *errReader) Close() error {
 }
 
 // requireMultipartReader parses ct as a multipart/form-data content type and
-// returns a reader over body, failing the test when either step does not hold.
+// returns a reader over body, failing the test when the type does not parse, is
+// not multipart/form-data, or carries no boundary. Without the boundary check a
+// missing one would surface later as an opaque "boundary is empty" from the
+// reader instead of naming the content type that lacked it.
 func requireMultipartReader(t *testing.T, body io.Reader, ct string) *multipart.Reader {
 	t.Helper()
 	mt, params, err := mime.ParseMediaType(ct)
 	require.NoError(t, err, "ct=%q", ct)
 	require.Equal(t, "multipart/form-data", mt)
+	require.NotEmpty(t, params["boundary"], "ct=%q", ct)
 	return multipart.NewReader(body, params["boundary"])
 }
 

--- a/pkg/executor/handlers/shell/shell_test.go
+++ b/pkg/executor/handlers/shell/shell_test.go
@@ -32,14 +32,11 @@ func TestShellHandler_Name(t *testing.T) {
 func TestShellHandler_Commands(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	handler := NewShellHandler(mockExec)
-	commands := handler.Commands()
 
-	expected := []string{
+	assert.Equal(t, []string{
 		common.ShellCmd.String(),
 		common.Exec.String(),
-	}
-
-	assert.Equal(t, expected, commands)
+	}, handler.Commands())
 }
 
 func TestShellHandler_Execute_Basic(t *testing.T) {

--- a/pkg/executor/handlers/shell/shell_test.go
+++ b/pkg/executor/handlers/shell/shell_test.go
@@ -149,6 +149,7 @@ func TestShellHandler_OrStopsOnSuccess(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	// Only cmd1's output should be present (cmd2 shouldn't run)
 	assert.Contains(t, output, "success")
+	assert.NotContains(t, output, "output2")
 }
 
 func TestShellHandler_Execute_Semicolon(t *testing.T) {

--- a/pkg/executor/handlers/shell/shell_test.go
+++ b/pkg/executor/handlers/shell/shell_test.go
@@ -4,19 +4,29 @@ import (
 	"context"
 	"errors"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// executedUsers lists the user each executed command ran as, so a test can
+// assert on the whole set and see every actual user when the check fails.
+func executedUsers(mock *common.MockCommandExecutor) []string {
+	cmds := mock.GetExecutedCommands()
+	users := make([]string, 0, len(cmds))
+	for _, cmd := range cmds {
+		users = append(users, cmd.User)
+	}
+	return users
+}
 
 func TestShellHandler_Name(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	handler := NewShellHandler(mockExec)
-	if handler.Name() != common.Shell.String() {
-		t.Errorf("expected name %q, got %q", common.Shell.String(), handler.Name())
-	}
+	assert.Equal(t, common.Shell.String(), handler.Name())
 }
 
 func TestShellHandler_Commands(t *testing.T) {
@@ -29,16 +39,7 @@ func TestShellHandler_Commands(t *testing.T) {
 		common.Exec.String(),
 	}
 
-	if len(commands) != len(expected) {
-		t.Errorf("expected %d commands, got %d", len(expected), len(commands))
-		return
-	}
-
-	for i, cmd := range commands {
-		if cmd != expected[i] {
-			t.Errorf("command %d: expected %q, got %q", i, expected[i], cmd)
-		}
-	}
+	assert.Equal(t, expected, commands)
 }
 
 func TestShellHandler_Execute_Basic(t *testing.T) {
@@ -54,15 +55,9 @@ func TestShellHandler_Execute_Basic(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
-	if !strings.Contains(output, "file1.txt") {
-		t.Errorf("expected output to contain 'file1.txt', got %q", output)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, output, "file1.txt")
 }
 
 func TestShellHandler_Execute_Exec(t *testing.T) {
@@ -77,15 +72,9 @@ func TestShellHandler_Execute_Exec(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.Exec.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
-	if !strings.Contains(output, "hello") {
-		t.Errorf("expected output to contain 'hello', got %q", output)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, output, "hello")
 }
 
 func TestShellHandler_Execute_AndOperator(t *testing.T) {
@@ -102,15 +91,10 @@ func TestShellHandler_Execute_AndOperator(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
-	if !strings.Contains(output, "output1") || !strings.Contains(output, "output2") {
-		t.Errorf("expected output to contain both outputs, got %q", output)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, output, "output1")
+	assert.Contains(t, output, "output2")
 }
 
 func TestShellHandler_AndStopsOnFailure(t *testing.T) {
@@ -126,12 +110,8 @@ func TestShellHandler_AndStopsOnFailure(t *testing.T) {
 
 	exitCode, _, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 1 {
-		t.Errorf("expected exit code 1, got %d", exitCode)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 1, exitCode)
 }
 
 func TestShellHandler_Execute_OrOperator(t *testing.T) {
@@ -147,15 +127,9 @@ func TestShellHandler_Execute_OrOperator(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
-	if !strings.Contains(output, "success") {
-		t.Errorf("expected output to contain 'success', got %q", output)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, output, "success")
 }
 
 func TestShellHandler_OrStopsOnSuccess(t *testing.T) {
@@ -171,16 +145,10 @@ func TestShellHandler_OrStopsOnSuccess(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 	// Only cmd1's output should be present (cmd2 shouldn't run)
-	if !strings.Contains(output, "success") {
-		t.Errorf("expected output to contain 'success', got %q", output)
-	}
+	assert.Contains(t, output, "success")
 }
 
 func TestShellHandler_Execute_Semicolon(t *testing.T) {
@@ -196,17 +164,12 @@ func TestShellHandler_Execute_Semicolon(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	// Last command exit code
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0 (from cmd2), got %d", exitCode)
-	}
+	assert.Equal(t, 0, exitCode, "the exit code must come from cmd2")
 	// Both outputs should be present
-	if !strings.Contains(output, "error") || !strings.Contains(output, "success") {
-		t.Errorf("expected output to contain both outputs, got %q", output)
-	}
+	assert.Contains(t, output, "error")
+	assert.Contains(t, output, "success")
 }
 
 func TestShellHandler_CustomUser(t *testing.T) {
@@ -222,26 +185,12 @@ func TestShellHandler_CustomUser(t *testing.T) {
 
 	exitCode, _, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 
-	cmds := mockExec.GetExecutedCommands()
 	// Exec method adds to commands, then calls Run which also adds
 	// So we check that at least one command has the right user
-	foundCorrectUser := false
-	for _, cmd := range cmds {
-		if cmd.User == "testuser" {
-			foundCorrectUser = true
-			break
-		}
-	}
-	if !foundCorrectUser {
-		t.Errorf("expected at least one command with user 'testuser', got %+v", cmds)
-	}
+	assert.Contains(t, executedUsers(mockExec), "testuser")
 }
 
 func TestShellHandler_DefaultUser(t *testing.T) {
@@ -257,21 +206,8 @@ func TestShellHandler_DefaultUser(t *testing.T) {
 
 	_, _, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	cmds := mockExec.GetExecutedCommands()
-	foundRootUser := false
-	for _, cmd := range cmds {
-		if cmd.User == "root" {
-			foundRootUser = true
-			break
-		}
-	}
-	if !foundRootUser {
-		t.Errorf("expected at least one command with default user 'root', got %+v", cmds)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, executedUsers(mockExec), "root")
 }
 
 func TestShellHandler_WithTimeout(t *testing.T) {
@@ -287,12 +223,8 @@ func TestShellHandler_WithTimeout(t *testing.T) {
 
 	exitCode, _, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 }
 
 func TestShellHandler_DefaultTimeout(t *testing.T) {
@@ -308,21 +240,13 @@ func TestShellHandler_DefaultTimeout(t *testing.T) {
 
 	exitCode, _, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 
 	// Verify the default 30m timeout was passed to the executor
 	cmds := mockExec.GetExecutedCommands()
-	if len(cmds) == 0 {
-		t.Fatal("expected at least one executed command")
-	}
-	if cmds[0].Timeout != 30*time.Minute {
-		t.Errorf("expected default timeout 30m, got %v", cmds[0].Timeout)
-	}
+	require.NotEmpty(t, cmds, "expected at least one executed command")
+	assert.Equal(t, 30*time.Minute, cmds[0].Timeout)
 }
 
 func TestShellHandler_Validate_Empty(t *testing.T) {
@@ -335,12 +259,7 @@ func TestShellHandler_Validate_Empty(t *testing.T) {
 
 	err := handler.Validate(common.ShellCmd.String(), args)
 
-	if err == nil {
-		t.Error("expected error for empty command")
-	}
-	if !strings.Contains(err.Error(), "required") {
-		t.Errorf("error should mention 'required', got: %v", err)
-	}
+	assert.ErrorContains(t, err, "required")
 }
 
 func TestShellHandler_Validate_Valid(t *testing.T) {
@@ -353,9 +272,7 @@ func TestShellHandler_Validate_Valid(t *testing.T) {
 
 	err := handler.Validate(common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Errorf("unexpected validation error: %v", err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestShellHandler_UnknownCommand(t *testing.T) {
@@ -369,15 +286,8 @@ func TestShellHandler_UnknownCommand(t *testing.T) {
 
 	exitCode, _, err := handler.Execute(ctx, "unknown_command", args)
 
-	if err == nil {
-		t.Error("expected error for unknown command")
-	}
-	if exitCode != 1 {
-		t.Errorf("expected exit code 1, got %d", exitCode)
-	}
-	if !strings.Contains(err.Error(), "unknown shell command") {
-		t.Errorf("error should mention 'unknown shell command', got: %v", err)
-	}
+	assert.Equal(t, 1, exitCode)
+	assert.ErrorContains(t, err, "unknown shell command")
 }
 
 func TestShellHandler_CommandExecutionError(t *testing.T) {
@@ -393,15 +303,9 @@ func TestShellHandler_CommandExecutionError(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error from Execute: %v", err)
-	}
-	if exitCode != 1 {
-		t.Errorf("expected exit code 1, got %d", exitCode)
-	}
-	if !strings.Contains(output, "not found") {
-		t.Errorf("expected output to contain error message, got %q", output)
-	}
+	require.NoError(t, err, "the executor error must be folded into the output, not returned")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, output, "not found")
 }
 
 func TestShellHandler_WithEnv(t *testing.T) {
@@ -419,12 +323,8 @@ func TestShellHandler_WithEnv(t *testing.T) {
 
 	exitCode, _, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 }
 
 func TestShellHandler_MixedOperators(t *testing.T) {
@@ -444,16 +344,10 @@ func TestShellHandler_MixedOperators(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 	// cmd1's output should be present
-	if !strings.Contains(output, "out1") {
-		t.Errorf("expected output to contain 'out1', got %q", output)
-	}
+	assert.Contains(t, output, "out1")
 }
 
 func TestShellHandler_AllowSh(t *testing.T) {
@@ -478,27 +372,15 @@ func TestShellHandler_AllowSh(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
-	if !strings.Contains(output, "error line 1") {
-		t.Errorf("expected output to contain 'error line 1', got %q", output)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, output, "error line 1")
 
 	// Verify it was called via /bin/sh -c, not split by Fields
 	cmds := mockExec.GetExecutedCommands()
-	if len(cmds) == 0 {
-		t.Fatal("expected at least one executed command")
-	}
-	if cmds[0].Name != "/bin/sh" {
-		t.Errorf("expected command name '/bin/sh', got %q", cmds[0].Name)
-	}
-	if len(cmds[0].Args) != 2 || cmds[0].Args[0] != "-c" || cmds[0].Args[1] != "grep err /log | head" {
-		t.Errorf("expected args ['-c', 'grep err /log | head'], got %v", cmds[0].Args)
-	}
+	require.NotEmpty(t, cmds, "expected at least one executed command")
+	assert.Equal(t, "/bin/sh", cmds[0].Name)
+	assert.Equal(t, []string{"-c", "grep err /log | head"}, cmds[0].Args)
 }
 
 func TestShellHandler_AllowSh_False_UsesDirectExec(t *testing.T) {
@@ -515,21 +397,13 @@ func TestShellHandler_AllowSh_False_UsesDirectExec(t *testing.T) {
 
 	exitCode, _, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 
 	// Verify it was NOT called via /bin/sh
 	cmds := mockExec.GetExecutedCommands()
-	if len(cmds) == 0 {
-		t.Fatal("expected at least one executed command")
-	}
-	if cmds[0].Name == "/bin/sh" {
-		t.Error("expected direct exec, not /bin/sh")
-	}
+	require.NotEmpty(t, cmds, "expected at least one executed command")
+	assert.NotEqual(t, "/bin/sh", cmds[0].Name, "expected direct exec, not /bin/sh")
 }
 
 func TestShellHandler_MultiWordCommand(t *testing.T) {
@@ -547,13 +421,7 @@ func TestShellHandler_MultiWordCommand(t *testing.T) {
 
 	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if exitCode != 0 {
-		t.Errorf("expected exit code 0, got %d", exitCode)
-	}
-	if !strings.Contains(output, "total") {
-		t.Errorf("expected output to contain 'total', got %q", output)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, output, "total")
 }

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -295,7 +295,7 @@ func TestStartWatchdog_CancelDisarmsBeforeTimer(t *testing.T) {
 		fired.Add(1)
 	})
 
-	// Disarm before the timer would fire — mirrors the on-connect-success
+	// Disarm before the timer would fire: mirrors the on-connect-success
 	// path that races against the watchdog.
 	time.Sleep(200 * time.Millisecond)
 	cancelWatchdog()

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -30,6 +30,16 @@ func writeFile(t *testing.T, path, content string) {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600), "write %s", path)
 }
 
+// assertGone fails unless path is absent, which os.Stat reports as
+// os.ErrNotExist. assert.NoFileExists is the shorter spelling but it treats a
+// directory at path, and any other Lstat error, as absence; every caller here
+// is proving that a cleanup step ran, so nothing but a missing path passes.
+func assertGone(t *testing.T, path, msg string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist, msg)
+}
+
 func TestWritePending_AndLoadPending_RoundTrip(t *testing.T) {
 	setupTempDataDir(t)
 
@@ -51,7 +61,7 @@ func TestWritePending_AndLoadPending_RoundTrip(t *testing.T) {
 	assert.Equal(t, st.NewServerID, got.NewServerID)
 
 	// No .tmp leftover after a successful atomic rename.
-	assert.NoFileExists(t, MarkerPath()+".tmp", "expected marker .tmp to be cleaned up")
+	assertGone(t, MarkerPath()+".tmp", "expected marker .tmp to be cleaned up")
 }
 
 func TestLoadPending_NoFile_ReturnsNilNil(t *testing.T) {
@@ -76,8 +86,8 @@ func TestConfirm_RemovesMarkerAndBackup(t *testing.T) {
 
 	Confirm(st)
 
-	assert.NoFileExists(t, MarkerPath(), "Confirm did not remove the marker")
-	assert.NoFileExists(t, backup, "Confirm did not remove the backup")
+	assertGone(t, MarkerPath(), "Confirm did not remove the marker")
+	assertGone(t, backup, "Confirm did not remove the backup")
 	// Sanity: dataDir still exists.
 	assert.DirExists(t, dataDir, "dataDir unexpectedly removed")
 }
@@ -111,7 +121,7 @@ func TestWriteConfAtomic_LeavesNoTmpFile(t *testing.T) {
 	got, err := os.ReadFile(conf)
 	require.NoError(t, err, "read conf")
 	assert.Equal(t, "new content", string(got))
-	assert.NoFileExists(t, conf+".new", "expected .new to be cleaned up")
+	assertGone(t, conf+".new", "expected .new to be cleaned up")
 }
 
 func TestRestoreBackup_RestoresContent(t *testing.T) {

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacax/alpamon/v2/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,16 +29,6 @@ func setupTempDataDir(t *testing.T) string {
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600), "write %s", path)
-}
-
-// assertGone fails unless path is absent, which os.Stat reports as
-// os.ErrNotExist. assert.NoFileExists is the shorter spelling but it treats a
-// directory at path, and any other Lstat error, as absence; every caller here
-// is proving that a cleanup step ran, so nothing but a missing path passes.
-func assertGone(t *testing.T, path, msg string) {
-	t.Helper()
-	_, err := os.Stat(path)
-	assert.ErrorIs(t, err, os.ErrNotExist, msg)
 }
 
 func TestWritePending_AndLoadPending_RoundTrip(t *testing.T) {
@@ -61,7 +52,7 @@ func TestWritePending_AndLoadPending_RoundTrip(t *testing.T) {
 	assert.Equal(t, st.NewServerID, got.NewServerID)
 
 	// No .tmp leftover after a successful atomic rename.
-	assertGone(t, MarkerPath()+".tmp", "expected marker .tmp to be cleaned up")
+	testutil.AssertGone(t, MarkerPath()+".tmp", "expected marker .tmp to be cleaned up")
 }
 
 func TestLoadPending_NoFile_ReturnsNilNil(t *testing.T) {
@@ -86,8 +77,8 @@ func TestConfirm_RemovesMarkerAndBackup(t *testing.T) {
 
 	Confirm(st)
 
-	assertGone(t, MarkerPath(), "Confirm did not remove the marker")
-	assertGone(t, backup, "Confirm did not remove the backup")
+	testutil.AssertGone(t, MarkerPath(), "Confirm did not remove the marker")
+	testutil.AssertGone(t, backup, "Confirm did not remove the backup")
 	// Sanity: dataDir still exists.
 	assert.DirExists(t, dataDir, "dataDir unexpectedly removed")
 }
@@ -121,7 +112,7 @@ func TestWriteConfAtomic_LeavesNoTmpFile(t *testing.T) {
 	got, err := os.ReadFile(conf)
 	require.NoError(t, err, "read conf")
 	assert.Equal(t, "new content", string(got))
-	assertGone(t, conf+".new", "expected .new to be cleaned up")
+	testutil.AssertGone(t, conf+".new", "expected .new to be cleaned up")
 }
 
 func TestRestoreBackup_RestoresContent(t *testing.T) {

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -25,7 +25,7 @@ func setupTempDataDir(t *testing.T) string {
 	return dir
 }
 
-func writeFile(t *testing.T, path string, content string) {
+func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600), "write %s", path)
 }
@@ -123,7 +123,8 @@ func TestRestoreBackup_RestoresContent(t *testing.T) {
 
 	require.NoError(t, RestoreBackup(backup, dest))
 
-	got, _ := os.ReadFile(dest)
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err, "read dest")
 	assert.Equal(t, "[server]\nold=true\n", string(got))
 }
 
@@ -153,7 +154,8 @@ func TestRollback_RestoresConf(t *testing.T) {
 	_ = Rollback(st, confPath, false, "")
 
 	// Conf must be restored to backup content.
-	got, _ := os.ReadFile(confPath)
+	got, err := os.ReadFile(confPath)
+	require.NoError(t, err, "read conf")
 	assert.Equal(t, "[server]\nurl=https://a.example.com\n", string(got), "conf not restored")
 	// When ScheduleSelfRestart fails, the marker and backup must remain
 	// so the next agent startup's watchdog can retry. This is the
@@ -174,7 +176,7 @@ func TestRollback_TolerantOfMissingBackup(t *testing.T) {
 		NewURL:         "https://invalid.example.invalid",
 		NewServerID:    "srv-xyz",
 		NewServerKey:   "key-xyz",
-		ExpiresAt:      time.Now().Add(-1 * time.Minute),
+		ExpiresAt:      time.Now().Add(-time.Minute),
 	}
 	require.NoError(t, WritePending(st))
 
@@ -183,7 +185,8 @@ func TestRollback_TolerantOfMissingBackup(t *testing.T) {
 	// so we only assert on the no-overwrite invariant.
 	_ = Rollback(st, confPath, false, "")
 
-	got, _ := os.ReadFile(confPath)
+	got, err := os.ReadFile(confPath)
+	require.NoError(t, err, "read conf")
 	assert.Equal(t, "restored already", string(got), "Rollback overwrote conf when backup was missing")
 }
 
@@ -257,7 +260,7 @@ func TestStartWatchdog_FiresImmediatelyIfAlreadyExpired(t *testing.T) {
 	st := &PendingState{
 		BackupConfPath: "/tmp/whatever",
 		NewURL:         "https://b.example.com",
-		ExpiresAt:      time.Now().Add(-1 * time.Minute),
+		ExpiresAt:      time.Now().Add(-time.Minute),
 	}
 	require.NoError(t, WritePending(st))
 
@@ -312,7 +315,7 @@ func TestStartWatchdog_StopsOnContextCancel(t *testing.T) {
 	require.NoError(t, WritePending(st))
 
 	var fired atomic.Int32
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	_ = StartWatchdog(ctx, st, func(_ *PendingState) {
 		fired.Add(1)

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -7,6 +7,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // setupTempDataDir reroutes dataDirFn at a temporary directory so MarkerPath
@@ -24,9 +27,7 @@ func setupTempDataDir(t *testing.T) string {
 
 func writeFile(t *testing.T, path string, content string) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600), "write %s", path)
 }
 
 func TestWritePending_AndLoadPending_RoundTrip(t *testing.T) {
@@ -41,36 +42,23 @@ func TestWritePending_AndLoadPending_RoundTrip(t *testing.T) {
 		StartedAt:      time.Now().UTC(),
 		ExpiresAt:      time.Now().UTC().Add(5 * time.Minute),
 	}
-	if err := WritePending(st); err != nil {
-		t.Fatalf("WritePending: %v", err)
-	}
+	require.NoError(t, WritePending(st))
 
 	got, err := LoadPending()
-	if err != nil {
-		t.Fatalf("LoadPending: %v", err)
-	}
-	if got == nil {
-		t.Fatalf("LoadPending returned nil after WritePending")
-	}
-	if got.NewURL != st.NewURL || got.NewServerID != st.NewServerID {
-		t.Fatalf("LoadPending round-trip mismatch: %+v", got)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, got, "LoadPending returned nil after WritePending")
+	assert.Equal(t, st.NewURL, got.NewURL)
+	assert.Equal(t, st.NewServerID, got.NewServerID)
 
 	// No .tmp leftover after a successful atomic rename.
-	if _, err := os.Stat(MarkerPath() + ".tmp"); !os.IsNotExist(err) {
-		t.Fatalf("expected marker .tmp to be cleaned up; stat err=%v", err)
-	}
+	assert.NoFileExists(t, MarkerPath()+".tmp", "expected marker .tmp to be cleaned up")
 }
 
 func TestLoadPending_NoFile_ReturnsNilNil(t *testing.T) {
 	setupTempDataDir(t)
 	got, err := LoadPending()
-	if err != nil {
-		t.Fatalf("LoadPending on missing file: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("LoadPending on missing file: got %+v, want nil", got)
-	}
+	require.NoError(t, err, "LoadPending on missing file")
+	assert.Nil(t, got, "LoadPending on missing file must return a nil state")
 }
 
 func TestConfirm_RemovesMarkerAndBackup(t *testing.T) {
@@ -84,27 +72,19 @@ func TestConfirm_RemovesMarkerAndBackup(t *testing.T) {
 		NewURL:         "https://b.example.com",
 		ExpiresAt:      time.Now().Add(5 * time.Minute),
 	}
-	if err := WritePending(st); err != nil {
-		t.Fatalf("WritePending: %v", err)
-	}
+	require.NoError(t, WritePending(st))
 
 	Confirm(st)
 
-	if _, err := os.Stat(MarkerPath()); !os.IsNotExist(err) {
-		t.Fatalf("Confirm did not remove marker at %s (err=%v)", MarkerPath(), err)
-	}
-	if _, err := os.Stat(backup); !os.IsNotExist(err) {
-		t.Fatalf("Confirm did not remove backup at %s (err=%v)", backup, err)
-	}
+	assert.NoFileExists(t, MarkerPath(), "Confirm did not remove the marker")
+	assert.NoFileExists(t, backup, "Confirm did not remove the backup")
 	// Sanity: dataDir still exists.
-	if _, err := os.Stat(dataDir); err != nil {
-		t.Fatalf("dataDir unexpectedly removed: %v", err)
-	}
+	assert.DirExists(t, dataDir, "dataDir unexpectedly removed")
 }
 
 func TestConfirm_NilState_IsNoop(t *testing.T) {
 	setupTempDataDir(t)
-	Confirm(nil) // must not panic
+	assert.NotPanics(t, func() { Confirm(nil) })
 }
 
 func TestBackupConf_PreservesContentAndCleansUpOnNoError(t *testing.T) {
@@ -114,38 +94,24 @@ func TestBackupConf_PreservesContentAndCleansUpOnNoError(t *testing.T) {
 	writeFile(t, src, content)
 
 	backup, err := BackupConf(src)
-	if err != nil {
-		t.Fatalf("BackupConf: %v", err)
-	}
-	if backup == src {
-		t.Fatalf("backup path equals source")
-	}
+	require.NoError(t, err)
+	assert.NotEqual(t, src, backup, "backup path must differ from the source")
+
 	got, err := os.ReadFile(backup)
-	if err != nil {
-		t.Fatalf("read backup: %v", err)
-	}
-	if string(got) != content {
-		t.Fatalf("backup content mismatch:\nwant %q\ngot  %q", content, string(got))
-	}
+	require.NoError(t, err, "read backup")
+	assert.Equal(t, content, string(got), "backup content mismatch")
 }
 
 func TestWriteConfAtomic_LeavesNoTmpFile(t *testing.T) {
 	dir := t.TempDir()
 	conf := filepath.Join(dir, "alpamon.conf")
 
-	if err := WriteConfAtomic(conf, []byte("new content"), 0600); err != nil {
-		t.Fatalf("WriteConfAtomic: %v", err)
-	}
+	require.NoError(t, WriteConfAtomic(conf, []byte("new content"), 0600))
+
 	got, err := os.ReadFile(conf)
-	if err != nil {
-		t.Fatalf("read conf: %v", err)
-	}
-	if string(got) != "new content" {
-		t.Fatalf("conf content mismatch: %q", string(got))
-	}
-	if _, err := os.Stat(conf + ".new"); !os.IsNotExist(err) {
-		t.Fatalf("expected .new to be cleaned up; stat err=%v", err)
-	}
+	require.NoError(t, err, "read conf")
+	assert.Equal(t, "new content", string(got))
+	assert.NoFileExists(t, conf+".new", "expected .new to be cleaned up")
 }
 
 func TestRestoreBackup_RestoresContent(t *testing.T) {
@@ -155,13 +121,10 @@ func TestRestoreBackup_RestoresContent(t *testing.T) {
 	writeFile(t, backup, "[server]\nold=true\n")
 	writeFile(t, dest, "[server]\nnew=true\n")
 
-	if err := RestoreBackup(backup, dest); err != nil {
-		t.Fatalf("RestoreBackup: %v", err)
-	}
+	require.NoError(t, RestoreBackup(backup, dest))
+
 	got, _ := os.ReadFile(dest)
-	if string(got) != "[server]\nold=true\n" {
-		t.Fatalf("RestoreBackup content mismatch: %q", string(got))
-	}
+	assert.Equal(t, "[server]\nold=true\n", string(got))
 }
 
 func TestRollback_RestoresConf(t *testing.T) {
@@ -182,9 +145,7 @@ func TestRollback_RestoresConf(t *testing.T) {
 		StartedAt:      time.Now().Add(-10 * time.Minute),
 		ExpiresAt:      time.Now().Add(-5 * time.Minute),
 	}
-	if err := WritePending(st); err != nil {
-		t.Fatalf("WritePending: %v", err)
-	}
+	require.NoError(t, WritePending(st))
 
 	// We deliberately do not assert on Rollback's return value: without
 	// systemd, ScheduleSelfRestart fails and Rollback returns that error,
@@ -193,19 +154,13 @@ func TestRollback_RestoresConf(t *testing.T) {
 
 	// Conf must be restored to backup content.
 	got, _ := os.ReadFile(confPath)
-	if string(got) != "[server]\nurl=https://a.example.com\n" {
-		t.Fatalf("conf not restored, got %q", string(got))
-	}
+	assert.Equal(t, "[server]\nurl=https://a.example.com\n", string(got), "conf not restored")
 	// When ScheduleSelfRestart fails, the marker and backup must remain
 	// so the next agent startup's watchdog can retry. This is the
 	// post-review ordering: clean up durable state only after the restart
 	// is queued.
-	if _, err := os.Stat(backupPath); err != nil {
-		t.Fatalf("backup unexpectedly removed before restart was scheduled: %v", err)
-	}
-	if _, err := os.Stat(MarkerPath()); err != nil {
-		t.Fatalf("marker unexpectedly removed before restart was scheduled: %v", err)
-	}
+	assert.FileExists(t, backupPath, "backup unexpectedly removed before restart was scheduled")
+	assert.FileExists(t, MarkerPath(), "marker unexpectedly removed before restart was scheduled")
 }
 
 func TestRollback_TolerantOfMissingBackup(t *testing.T) {
@@ -221,24 +176,19 @@ func TestRollback_TolerantOfMissingBackup(t *testing.T) {
 		NewServerKey:   "key-xyz",
 		ExpiresAt:      time.Now().Add(-1 * time.Minute),
 	}
-	if err := WritePending(st); err != nil {
-		t.Fatalf("WritePending: %v", err)
-	}
+	require.NoError(t, WritePending(st))
 
 	// With backup gone, the restore step is skipped (warn logged) and
 	// the rest of Rollback runs. ScheduleSelfRestart still fails on CI,
 	// so we only assert on the no-overwrite invariant.
 	_ = Rollback(st, confPath, false, "")
 
-	if got, _ := os.ReadFile(confPath); string(got) != "restored already" {
-		t.Fatalf("Rollback overwrote conf when backup was missing: %q", string(got))
-	}
+	got, _ := os.ReadFile(confPath)
+	assert.Equal(t, "restored already", string(got), "Rollback overwrote conf when backup was missing")
 }
 
 func TestRollback_NilState_ReturnsError(t *testing.T) {
-	if err := Rollback(nil, "/tmp/x", false, ""); err == nil {
-		t.Fatalf("expected error from Rollback(nil), got nil")
-	}
+	assert.Error(t, Rollback(nil, "/tmp/x", false, ""), "expected error from Rollback(nil)")
 }
 
 func TestStartWatchdog_FiresOnTimeout(t *testing.T) {
@@ -253,9 +203,7 @@ func TestStartWatchdog_FiresOnTimeout(t *testing.T) {
 		NewURL:         "https://b.example.com",
 		ExpiresAt:      time.Now().Add(1 * time.Second),
 	}
-	if err := WritePending(st); err != nil {
-		t.Fatalf("WritePending: %v", err)
-	}
+	require.NoError(t, WritePending(st))
 
 	var fired atomic.Int32
 	done := make(chan struct{})
@@ -268,11 +216,9 @@ func TestStartWatchdog_FiresOnTimeout(t *testing.T) {
 
 	select {
 	case <-done:
-		if fired.Load() != 1 {
-			t.Fatalf("expected single fire, got %d", fired.Load())
-		}
+		assert.Equal(t, int32(1), fired.Load(), "expected a single fire")
 	case <-time.After(5 * time.Second):
-		t.Fatalf("watchdog did not fire within deadline")
+		t.Fatal("watchdog did not fire within deadline")
 	}
 }
 
@@ -286,9 +232,7 @@ func TestStartWatchdog_DoesNotFireAfterConfirm(t *testing.T) {
 		NewURL:         "https://b.example.com",
 		ExpiresAt:      time.Now().Add(3 * time.Second),
 	}
-	if err := WritePending(st); err != nil {
-		t.Fatalf("WritePending: %v", err)
-	}
+	require.NoError(t, WritePending(st))
 
 	var fired atomic.Int32
 	ctx := t.Context()
@@ -304,9 +248,7 @@ func TestStartWatchdog_DoesNotFireAfterConfirm(t *testing.T) {
 	// Wait past the original deadline plus jitter.
 	time.Sleep(4 * time.Second)
 
-	if fired.Load() != 0 {
-		t.Fatalf("watchdog fired despite Confirm: count=%d", fired.Load())
-	}
+	assert.Zero(t, fired.Load(), "watchdog fired despite Confirm")
 }
 
 func TestStartWatchdog_FiresImmediatelyIfAlreadyExpired(t *testing.T) {
@@ -317,9 +259,7 @@ func TestStartWatchdog_FiresImmediatelyIfAlreadyExpired(t *testing.T) {
 		NewURL:         "https://b.example.com",
 		ExpiresAt:      time.Now().Add(-1 * time.Minute),
 	}
-	if err := WritePending(st); err != nil {
-		t.Fatalf("WritePending: %v", err)
-	}
+	require.NoError(t, WritePending(st))
 
 	done := make(chan struct{})
 	ctx := t.Context()
@@ -331,7 +271,7 @@ func TestStartWatchdog_FiresImmediatelyIfAlreadyExpired(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatalf("watchdog did not fire immediately for expired marker")
+		t.Fatal("watchdog did not fire immediately for expired marker")
 	}
 }
 
@@ -343,9 +283,7 @@ func TestStartWatchdog_CancelDisarmsBeforeTimer(t *testing.T) {
 		NewURL:         "https://b.example.com",
 		ExpiresAt:      time.Now().Add(3 * time.Second),
 	}
-	if err := WritePending(st); err != nil {
-		t.Fatalf("WritePending: %v", err)
-	}
+	require.NoError(t, WritePending(st))
 
 	var fired atomic.Int32
 	ctx := t.Context()
@@ -360,9 +298,7 @@ func TestStartWatchdog_CancelDisarmsBeforeTimer(t *testing.T) {
 	cancelWatchdog()
 
 	time.Sleep(4 * time.Second)
-	if fired.Load() != 0 {
-		t.Fatalf("watchdog fired despite cancel: count=%d", fired.Load())
-	}
+	assert.Zero(t, fired.Load(), "watchdog fired despite cancel")
 }
 
 func TestStartWatchdog_StopsOnContextCancel(t *testing.T) {
@@ -373,9 +309,7 @@ func TestStartWatchdog_StopsOnContextCancel(t *testing.T) {
 		NewURL:         "https://b.example.com",
 		ExpiresAt:      time.Now().Add(3 * time.Second),
 	}
-	if err := WritePending(st); err != nil {
-		t.Fatalf("WritePending: %v", err)
-	}
+	require.NoError(t, WritePending(st))
 
 	var fired atomic.Int32
 	ctx, cancel := context.WithCancel(context.Background())
@@ -387,7 +321,5 @@ func TestStartWatchdog_StopsOnContextCancel(t *testing.T) {
 	cancel()
 	time.Sleep(4 * time.Second)
 
-	if fired.Load() != 0 {
-		t.Fatalf("watchdog fired after ctx cancel: count=%d", fired.Load())
-	}
+	assert.Zero(t, fired.Load(), "watchdog fired after ctx cancel")
 }

--- a/pkg/runner/auth_manager_tracker_test.go
+++ b/pkg/runner/auth_manager_tracker_test.go
@@ -294,7 +294,8 @@ func TestAddPIDCommandMapping_OverwritesStaleEntry(t *testing.T) {
 	am.AddPIDCommandMapping(4001, "old-cmd", "alice")
 	am.AddPIDCommandMapping(4001, "new-cmd", "bob")
 
-	entry, _ := am.LookupPID(4001)
+	entry, ok := am.LookupPID(4001)
+	require.True(t, ok, "entry should survive the overwrite")
 	assert.Equal(t, "new-cmd", entry.CommandID)
 	assert.Equal(t, "bob", entry.Username)
 }

--- a/pkg/runner/auth_manager_tracker_test.go
+++ b/pkg/runner/auth_manager_tracker_test.go
@@ -69,7 +69,7 @@ func TestRemovePIDCommandMapping_PIDReuseGuard(t *testing.T) {
 }
 
 // TestRemovePIDCommandMapping_LeavesWebshEntryAlone verifies that a
-// Command-style remove does not touch a websh entry that happens to
+// Command-style remove does not touch a Websh entry that happens to
 // share the same pid (defence in depth).
 func TestRemovePIDCommandMapping_LeavesWebshEntryAlone(t *testing.T) {
 	am := newTestAuthManager()
@@ -85,7 +85,7 @@ func TestRemovePIDCommandMapping_LeavesWebshEntryAlone(t *testing.T) {
 	am.RemovePIDCommandMapping(3333, "cmd-bystander")
 
 	entry, ok := am.LookupPID(3333)
-	require.True(t, ok, "websh entry should not have been removed")
+	require.True(t, ok, "Websh entry should not have been removed")
 	assert.Equal(t, TrackerKindWebsh, entry.Kind)
 }
 
@@ -141,13 +141,13 @@ func TestLegacyWebshEntry_ReadsAsWebsh(t *testing.T) {
 
 	entry, ok := am.LookupPID(7777)
 	require.True(t, ok, "legacy entry missing")
-	assert.Equal(t, TrackerKindWebsh, entry.Kind, "legacy entry should default to websh")
+	assert.Equal(t, TrackerKindWebsh, entry.Kind, "legacy entry should default to the Websh kind")
 	assert.Equal(t, "legacy-session", entry.SessionID)
 }
 
-// TestAddPIDSessionMapping_NormalisesWebshKind verifies that websh
-// registrations always end up with Kind=websh and no CommandID, even
-// when the caller forgot to set the fields explicitly.
+// TestAddPIDSessionMapping_NormalisesWebshKind verifies that Websh
+// registrations always end up with Kind == TrackerKindWebsh and no
+// CommandID, even when the caller forgot to set the fields explicitly.
 func TestAddPIDSessionMapping_NormalisesWebshKind(t *testing.T) {
 	am := newTestAuthManager()
 
@@ -226,9 +226,9 @@ func TestSudoApprovalRequest_JSONTagsOmitEmpty(t *testing.T) {
 		Username:  "alice",
 	}
 	webshJSON, err := json.Marshal(webshReq)
-	require.NoError(t, err, "marshal websh request")
+	require.NoError(t, err, "marshal Websh request")
 	assert.Contains(t, string(webshJSON), `"session_id":"session-uuid"`)
-	assert.NotContains(t, string(webshJSON), `"command_id"`, "websh payload must omit command_id")
+	assert.NotContains(t, string(webshJSON), `"command_id"`, "Websh payload must omit command_id")
 
 	// Neither-set path: both identifier keys must be absent, making the
 	// payload unambiguous for the server's 2-branch resolver.
@@ -246,7 +246,7 @@ func TestSudoApprovalRequest_JSONTagsOmitEmpty(t *testing.T) {
 
 // TestSudoApprovalResponse_ErrorCodePassthrough verifies that the optional
 // error_code field round-trips through the response struct and stays off the
-// wire when empty. alpacon-server emits error_code on denial; alpamon
+// wire when empty. alpacon-server emits error_code on denial; Alpamon
 // unmarshals the server control message into SudoApprovalResponse and
 // re-marshals it onto the auth socket, so the field must survive that hop. The
 // omitempty guard keeps older servers (which never send error_code) wire-

--- a/pkg/runner/auth_manager_tracker_test.go
+++ b/pkg/runner/auth_manager_tracker_test.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -293,10 +292,6 @@ func TestLookupPID_Missing(t *testing.T) {
 func TestAddPIDCommandMapping_OverwritesStaleEntry(t *testing.T) {
 	am := newTestAuthManager()
 	am.AddPIDCommandMapping(4001, "old-cmd", "alice")
-	// Force a distinguishable time gap without sleeping.
-	if entry, ok := am.LookupPID(4001); ok {
-		entry.StartedAt = time.Now().Add(-time.Hour)
-	}
 	am.AddPIDCommandMapping(4001, "new-cmd", "bob")
 
 	entry, _ := am.LookupPID(4001)

--- a/pkg/runner/auth_manager_tracker_test.go
+++ b/pkg/runner/auth_manager_tracker_test.go
@@ -2,9 +2,11 @@ package runner
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The shipped helper already builds exactly what these tests need.
@@ -20,24 +22,12 @@ func TestAddPIDCommandMapping_RegistersCommandKind(t *testing.T) {
 	am.AddPIDCommandMapping(4242, "cmd-uuid-1", "alice")
 
 	entry, ok := am.LookupPID(4242)
-	if !ok {
-		t.Fatal("expected tracker entry to be registered")
-	}
-	if entry.Kind != TrackerKindCommand {
-		t.Errorf("Kind: got %q, want %q", entry.Kind, TrackerKindCommand)
-	}
-	if entry.CommandID != "cmd-uuid-1" {
-		t.Errorf("CommandID: got %q, want cmd-uuid-1", entry.CommandID)
-	}
-	if entry.SessionID != "" {
-		t.Errorf("SessionID should be empty for command entries, got %q", entry.SessionID)
-	}
-	if entry.Username != "alice" {
-		t.Errorf("Username: got %q, want alice", entry.Username)
-	}
-	if entry.StartedAt.IsZero() {
-		t.Error("StartedAt should be set")
-	}
+	require.True(t, ok, "expected tracker entry to be registered")
+	assert.Equal(t, TrackerKindCommand, entry.Kind)
+	assert.Equal(t, "cmd-uuid-1", entry.CommandID)
+	assert.Empty(t, entry.SessionID, "SessionID should be empty for command entries")
+	assert.Equal(t, "alice", entry.Username)
+	assert.False(t, entry.StartedAt.IsZero(), "StartedAt should be set")
 }
 
 // TestAddPIDCommandMapping_IgnoresInvalidInput verifies that bogus
@@ -49,9 +39,7 @@ func TestAddPIDCommandMapping_IgnoresInvalidInput(t *testing.T) {
 	am.AddPIDCommandMapping(-1, "cmd", "user")
 	am.AddPIDCommandMapping(100, "", "user")
 
-	if len(am.pidToSessionMap) != 0 {
-		t.Errorf("expected no entries, got %d", len(am.pidToSessionMap))
-	}
+	assert.Empty(t, am.pidToSessionMap, "expected no entries")
 }
 
 // TestRemovePIDCommandMapping_RemovesMatchingEntry verifies removal on
@@ -62,9 +50,8 @@ func TestRemovePIDCommandMapping_RemovesMatchingEntry(t *testing.T) {
 
 	am.RemovePIDCommandMapping(1111, "cmd-a")
 
-	if _, ok := am.LookupPID(1111); ok {
-		t.Fatal("entry should have been removed")
-	}
+	_, ok := am.LookupPID(1111)
+	assert.False(t, ok, "entry should have been removed")
 }
 
 // TestRemovePIDCommandMapping_PIDReuseGuard verifies that removing with
@@ -78,12 +65,8 @@ func TestRemovePIDCommandMapping_PIDReuseGuard(t *testing.T) {
 	am.RemovePIDCommandMapping(2222, "some-other-command-id")
 
 	entry, ok := am.LookupPID(2222)
-	if !ok {
-		t.Fatal("entry should still exist after mismatched remove")
-	}
-	if entry.CommandID != "cmd-b" {
-		t.Errorf("CommandID: got %q, want cmd-b", entry.CommandID)
-	}
+	require.True(t, ok, "entry should still exist after mismatched remove")
+	assert.Equal(t, "cmd-b", entry.CommandID)
 }
 
 // TestRemovePIDCommandMapping_LeavesWebshEntryAlone verifies that a
@@ -103,12 +86,8 @@ func TestRemovePIDCommandMapping_LeavesWebshEntryAlone(t *testing.T) {
 	am.RemovePIDCommandMapping(3333, "cmd-bystander")
 
 	entry, ok := am.LookupPID(3333)
-	if !ok {
-		t.Fatal("websh entry should not have been removed")
-	}
-	if entry.Kind != TrackerKindWebsh {
-		t.Errorf("Kind: got %q, want websh", entry.Kind)
-	}
+	require.True(t, ok, "websh entry should not have been removed")
+	assert.Equal(t, TrackerKindWebsh, entry.Kind)
 }
 
 // TestParallelCommands_TrackedIndependently verifies concurrent
@@ -131,29 +110,21 @@ func TestParallelCommands_TrackedIndependently(t *testing.T) {
 	}
 	for _, tc := range cases {
 		entry, ok := am.LookupPID(tc.pid)
-		if !ok {
-			t.Errorf("pid %d: expected entry, got none", tc.pid)
+		if !assert.True(t, ok, "pid %d: expected entry, got none", tc.pid) {
 			continue
 		}
-		if entry.CommandID != tc.commandID {
-			t.Errorf("pid %d: CommandID got %q, want %q", tc.pid, entry.CommandID, tc.commandID)
-		}
-		if entry.Username != tc.username {
-			t.Errorf("pid %d: Username got %q, want %q", tc.pid, entry.Username, tc.username)
-		}
+		assert.Equal(t, tc.commandID, entry.CommandID, "pid %d: CommandID", tc.pid)
+		assert.Equal(t, tc.username, entry.Username, "pid %d: Username", tc.pid)
 	}
 
 	// Remove middle entry, verify others survive.
 	am.RemovePIDCommandMapping(5002, "cmd-parallel-2")
-	if _, ok := am.LookupPID(5002); ok {
-		t.Error("5002 should have been removed")
-	}
-	if _, ok := am.LookupPID(5001); !ok {
-		t.Error("5001 should still exist")
-	}
-	if _, ok := am.LookupPID(5003); !ok {
-		t.Error("5003 should still exist")
-	}
+	_, ok := am.LookupPID(5002)
+	assert.False(t, ok, "5002 should have been removed")
+	_, ok = am.LookupPID(5001)
+	assert.True(t, ok, "5001 should still exist")
+	_, ok = am.LookupPID(5003)
+	assert.True(t, ok, "5003 should still exist")
 }
 
 // TestLegacyWebshEntry_ReadsAsWebsh verifies backward compatibility with
@@ -170,15 +141,9 @@ func TestLegacyWebshEntry_ReadsAsWebsh(t *testing.T) {
 	}
 
 	entry, ok := am.LookupPID(7777)
-	if !ok {
-		t.Fatal("legacy entry missing")
-	}
-	if entry.Kind != TrackerKindWebsh {
-		t.Errorf("legacy entry should default to %q, got %q", TrackerKindWebsh, entry.Kind)
-	}
-	if entry.SessionID != "legacy-session" {
-		t.Errorf("SessionID: got %q, want legacy-session", entry.SessionID)
-	}
+	require.True(t, ok, "legacy entry missing")
+	assert.Equal(t, TrackerKindWebsh, entry.Kind, "legacy entry should default to websh")
+	assert.Equal(t, "legacy-session", entry.SessionID)
 }
 
 // TestAddPIDSessionMapping_NormalisesWebshKind verifies that websh
@@ -195,18 +160,10 @@ func TestAddPIDSessionMapping_NormalisesWebshKind(t *testing.T) {
 	})
 
 	entry, ok := am.LookupPID(8888)
-	if !ok {
-		t.Fatal("expected entry")
-	}
-	if entry.Kind != TrackerKindWebsh {
-		t.Errorf("Kind: got %q, want %q", entry.Kind, TrackerKindWebsh)
-	}
-	if entry.CommandID != "" {
-		t.Errorf("CommandID should have been cleared, got %q", entry.CommandID)
-	}
-	if entry.StartedAt.IsZero() {
-		t.Error("StartedAt should be populated by AddPIDSessionMapping when unset")
-	}
+	require.True(t, ok, "expected entry")
+	assert.Equal(t, TrackerKindWebsh, entry.Kind)
+	assert.Empty(t, entry.CommandID, "CommandID should have been cleared")
+	assert.False(t, entry.StartedAt.IsZero(), "StartedAt should be populated by AddPIDSessionMapping when unset")
 }
 
 // TestRegisterCommandPID_NoopWithoutManager verifies that the package-
@@ -218,11 +175,9 @@ func TestRegisterCommandPID_NoopWithoutManager(t *testing.T) {
 	t.Cleanup(func() { authManager = prev })
 
 	cleanup := RegisterCommandPID(123, "cmd", "user")
-	if cleanup == nil {
-		t.Error("RegisterCommandPID should always return a non-nil cleanup closure")
-	}
+	require.NotNil(t, cleanup, "RegisterCommandPID should always return a non-nil cleanup closure")
 	// Must not panic even when the AuthManager is absent.
-	cleanup()
+	assert.NotPanics(t, cleanup)
 }
 
 // TestRegisterCommandPID_RoundTrip exercises the package-level helper
@@ -233,21 +188,14 @@ func TestRegisterCommandPID_RoundTrip(t *testing.T) {
 	t.Cleanup(func() { authManager = prev })
 
 	cleanup := RegisterCommandPID(9001, "cmd-round", "eve")
-	if cleanup == nil {
-		t.Fatal("RegisterCommandPID returned a nil cleanup closure")
-	}
+	require.NotNil(t, cleanup, "RegisterCommandPID returned a nil cleanup closure")
 	entry, ok := authManager.LookupPID(9001)
-	if !ok {
-		t.Fatal("entry should be present after RegisterCommandPID")
-	}
-	if entry.CommandID != "cmd-round" {
-		t.Errorf("CommandID: got %q, want cmd-round", entry.CommandID)
-	}
+	require.True(t, ok, "entry should be present after RegisterCommandPID")
+	assert.Equal(t, "cmd-round", entry.CommandID)
 
 	cleanup()
-	if _, ok := authManager.LookupPID(9001); ok {
-		t.Error("entry should be gone after cleanup()")
-	}
+	_, ok = authManager.LookupPID(9001)
+	assert.False(t, ok, "entry should be gone after cleanup()")
 }
 
 // TestSudoApprovalRequest_JSONTagsOmitEmpty is a guardrail against
@@ -266,15 +214,9 @@ func TestSudoApprovalRequest_JSONTagsOmitEmpty(t *testing.T) {
 		Username:  "alice",
 	}
 	cmdJSON, err := json.Marshal(cmdReq)
-	if err != nil {
-		t.Fatalf("marshal command request: %v", err)
-	}
-	if !strings.Contains(string(cmdJSON), `"command_id":"cmd-uuid"`) {
-		t.Errorf("expected command_id in payload, got %s", cmdJSON)
-	}
-	if strings.Contains(string(cmdJSON), `"session_id"`) {
-		t.Errorf("deploy shell payload must omit session_id, got %s", cmdJSON)
-	}
+	require.NoError(t, err, "marshal command request")
+	assert.Contains(t, string(cmdJSON), `"command_id":"cmd-uuid"`)
+	assert.NotContains(t, string(cmdJSON), `"session_id"`, "deploy shell payload must omit session_id")
 
 	// Websh path: session_id set, command_id must be omitted.
 	webshReq := SudoApprovalRequest{
@@ -285,15 +227,9 @@ func TestSudoApprovalRequest_JSONTagsOmitEmpty(t *testing.T) {
 		Username:  "alice",
 	}
 	webshJSON, err := json.Marshal(webshReq)
-	if err != nil {
-		t.Fatalf("marshal websh request: %v", err)
-	}
-	if !strings.Contains(string(webshJSON), `"session_id":"session-uuid"`) {
-		t.Errorf("expected session_id in payload, got %s", webshJSON)
-	}
-	if strings.Contains(string(webshJSON), `"command_id"`) {
-		t.Errorf("websh payload must omit command_id, got %s", webshJSON)
-	}
+	require.NoError(t, err, "marshal websh request")
+	assert.Contains(t, string(webshJSON), `"session_id":"session-uuid"`)
+	assert.NotContains(t, string(webshJSON), `"command_id"`, "websh payload must omit command_id")
 
 	// Neither-set path: both identifier keys must be absent, making the
 	// payload unambiguous for the server's 2-branch resolver.
@@ -304,13 +240,9 @@ func TestSudoApprovalRequest_JSONTagsOmitEmpty(t *testing.T) {
 		Username: "alice",
 	}
 	emptyJSON, err := json.Marshal(emptyReq)
-	if err != nil {
-		t.Fatalf("marshal empty-id request: %v", err)
-	}
-	if strings.Contains(string(emptyJSON), `"session_id"`) ||
-		strings.Contains(string(emptyJSON), `"command_id"`) {
-		t.Errorf("payload with neither id must omit both keys, got %s", emptyJSON)
-	}
+	require.NoError(t, err, "marshal empty-id request")
+	assert.NotContains(t, string(emptyJSON), `"session_id"`, "payload with neither id must omit both keys")
+	assert.NotContains(t, string(emptyJSON), `"command_id"`, "payload with neither id must omit both keys")
 }
 
 // TestSudoApprovalResponse_ErrorCodePassthrough verifies that the optional
@@ -324,41 +256,25 @@ func TestSudoApprovalResponse_ErrorCodePassthrough(t *testing.T) {
 	// Server sends error_code on denial: it must survive unmarshal→marshal.
 	serverMsg := `{"type":"sudo_approval_response","request_id":"r1","approved":false,"reason":"sudo_no_worksession_policy","error_code":"SUDO_NO_WORKSESSION_POLICY"}`
 	var resp SudoApprovalResponse
-	if err := json.Unmarshal([]byte(serverMsg), &resp); err != nil {
-		t.Fatalf("unmarshal server message: %v", err)
-	}
-	if resp.ErrorCode != "SUDO_NO_WORKSESSION_POLICY" {
-		t.Errorf("expected error_code to be parsed, got %q", resp.ErrorCode)
-	}
+	require.NoError(t, json.Unmarshal([]byte(serverMsg), &resp), "unmarshal server message")
+	assert.Equal(t, "SUDO_NO_WORKSESSION_POLICY", resp.ErrorCode, "expected error_code to be parsed")
 	out, err := json.Marshal(resp)
-	if err != nil {
-		t.Fatalf("marshal response: %v", err)
-	}
-	if !strings.Contains(string(out), `"error_code":"SUDO_NO_WORKSESSION_POLICY"`) {
-		t.Errorf("expected error_code in re-marshaled payload, got %s", out)
-	}
+	require.NoError(t, err, "marshal response")
+	assert.Contains(t, string(out), `"error_code":"SUDO_NO_WORKSESSION_POLICY"`)
 
 	// Backward compat: a server that omits error_code (or an approval) must not
 	// introduce the key on the wire, so clients predating the field are
 	// unaffected.
 	approved := SudoApprovalResponse{Type: "sudo_approval_response", RequestID: "r2", Approved: true}
 	approvedJSON, err := json.Marshal(approved)
-	if err != nil {
-		t.Fatalf("marshal approved response: %v", err)
-	}
-	if strings.Contains(string(approvedJSON), `"error_code"`) {
-		t.Errorf("empty error_code must be omitted from payload, got %s", approvedJSON)
-	}
+	require.NoError(t, err, "marshal approved response")
+	assert.NotContains(t, string(approvedJSON), `"error_code"`, "empty error_code must be omitted from payload")
 
 	// Older server omits error_code entirely: it must unmarshal to "".
 	var legacy SudoApprovalResponse
 	legacyMsg := `{"type":"sudo_approval_response","request_id":"r3","approved":false,"reason":"denied"}`
-	if err := json.Unmarshal([]byte(legacyMsg), &legacy); err != nil {
-		t.Fatalf("unmarshal legacy message: %v", err)
-	}
-	if legacy.ErrorCode != "" {
-		t.Errorf("absent error_code must unmarshal to empty, got %q", legacy.ErrorCode)
-	}
+	require.NoError(t, json.Unmarshal([]byte(legacyMsg), &legacy), "unmarshal legacy message")
+	assert.Empty(t, legacy.ErrorCode, "absent error_code must unmarshal to empty")
 }
 
 // TestLookupPID_Missing verifies Lookup for a non-existent pid returns
@@ -366,13 +282,8 @@ func TestSudoApprovalResponse_ErrorCodePassthrough(t *testing.T) {
 func TestLookupPID_Missing(t *testing.T) {
 	am := newTestAuthManager()
 	entry, ok := am.LookupPID(99999)
-	if ok {
-		t.Error("expected ok=false for missing pid")
-	}
-	var zero TrackerEntry
-	if entry != zero {
-		t.Errorf("expected zero TrackerEntry, got %+v", entry)
-	}
+	assert.False(t, ok, "expected ok=false for missing pid")
+	assert.Equal(t, TrackerEntry{}, entry, "expected zero TrackerEntry")
 }
 
 // TestAddPIDCommandMapping_OverwritesStaleEntry verifies that if the
@@ -389,10 +300,6 @@ func TestAddPIDCommandMapping_OverwritesStaleEntry(t *testing.T) {
 	am.AddPIDCommandMapping(4001, "new-cmd", "bob")
 
 	entry, _ := am.LookupPID(4001)
-	if entry.CommandID != "new-cmd" {
-		t.Errorf("CommandID: got %q, want new-cmd", entry.CommandID)
-	}
-	if entry.Username != "bob" {
-		t.Errorf("Username: got %q, want bob", entry.Username)
-	}
+	assert.Equal(t, "new-cmd", entry.CommandID)
+	assert.Equal(t, "bob", entry.Username)
 }

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -6,16 +6,17 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // createTestArchive creates a tar.gz archive containing a fake alpamon binary.
@@ -30,9 +31,7 @@ func createTestArchive(t *testing.T, binaryContent []byte) []byte {
 func createTestArchiveNamed(t *testing.T, entryName string, binaryContent []byte) []byte {
 	t.Helper()
 	tmpFile, err := os.CreateTemp("", "test-archive-*.tar.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() {
 		_ = tmpFile.Close()
 		_ = os.Remove(tmpFile.Name())
@@ -46,20 +45,15 @@ func createTestArchiveNamed(t *testing.T, entryName string, binaryContent []byte
 		Mode: 0755,
 		Size: int64(len(binaryContent)),
 	}
-	if err := tw.WriteHeader(hdr); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tw.Write(binaryContent); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, tw.WriteHeader(hdr))
+	_, err = tw.Write(binaryContent)
+	require.NoError(t, err)
 
 	_ = tw.Close()
 	_ = gw.Close()
 
 	data, err := os.ReadFile(tmpFile.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return data
 }
 
@@ -69,19 +63,13 @@ func sha256Hex(data []byte) string {
 }
 
 func TestArchiveFilename(t *testing.T) {
-	got := archiveFilename("v1.2.3")
 	expected := fmt.Sprintf("alpamon-1.2.3-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
-	if got != expected {
-		t.Errorf("archiveFilename(v1.2.3) = %q, want %q", got, expected)
-	}
+	assert.Equal(t, expected, archiveFilename("v1.2.3"))
 }
 
 func TestChecksumURL(t *testing.T) {
-	got := checksumURL(defaultReleaseBaseURL, "v1.2.3")
 	expected := "https://github.com/alpacax/alpamon/releases/download/v1.2.3/alpamon-1.2.3-checksums.sha256"
-	if got != expected {
-		t.Errorf("checksumURL() = %q, want %q", got, expected)
-	}
+	assert.Equal(t, expected, checksumURL(defaultReleaseBaseURL, "v1.2.3"))
 }
 
 func TestDownloadFile(t *testing.T) {
@@ -92,27 +80,18 @@ func TestDownloadFile(t *testing.T) {
 	defer server.Close()
 
 	destPath := filepath.Join(t.TempDir(), "downloaded")
-	if err := downloadFile(context.Background(), server.URL, destPath); err != nil {
-		t.Fatalf("downloadFile() error: %v", err)
-	}
+	require.NoError(t, downloadFile(context.Background(), server.URL, destPath))
 
 	got, err := os.ReadFile(destPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != string(content) {
-		t.Errorf("downloaded content = %q, want %q", got, content)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, string(content), string(got))
 
 	// Verify file permissions are restrictive (Unix only — Windows doesn't enforce Unix perms)
 	if runtime.GOOS != "windows" {
 		info, err := os.Stat(destPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if info.Mode().Perm()&0077 != 0 {
-			t.Errorf("downloaded file should not be group/world accessible, got %o", info.Mode().Perm())
-		}
+		require.NoError(t, err)
+		assert.Zero(t, info.Mode().Perm()&0077,
+			"downloaded file should not be group/world accessible, got %o", info.Mode().Perm())
 	}
 }
 
@@ -122,12 +101,7 @@ func TestDownloadFile_NotFound(t *testing.T) {
 
 	destPath := filepath.Join(t.TempDir(), "downloaded")
 	err := downloadFile(context.Background(), server.URL, destPath)
-	if err == nil {
-		t.Fatal("expected error for 404 response")
-	}
-	if !strings.Contains(err.Error(), "404") {
-		t.Errorf("error should mention 404, got: %v", err)
-	}
+	assert.ErrorContains(t, err, "404")
 }
 
 func TestVerifyChecksum(t *testing.T) {
@@ -144,14 +118,10 @@ func TestVerifyChecksum(t *testing.T) {
 
 	tempDir := t.TempDir()
 	archivePath := filepath.Join(tempDir, archiveName)
-	if err := os.WriteFile(archivePath, archiveContent, 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(archivePath, archiveContent, 0644))
 
 	err := verifyChecksum(context.Background(), archivePath, archiveName, server.URL+"/checksums.sha256")
-	if err != nil {
-		t.Fatalf("verifyChecksum() error: %v", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestVerifyChecksum_Mismatch(t *testing.T) {
@@ -165,17 +135,10 @@ func TestVerifyChecksum_Mismatch(t *testing.T) {
 
 	tempDir := t.TempDir()
 	archivePath := filepath.Join(tempDir, archiveName)
-	if err := os.WriteFile(archivePath, []byte("different content"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(archivePath, []byte("different content"), 0644))
 
 	err := verifyChecksum(context.Background(), archivePath, archiveName, server.URL+"/checksums.sha256")
-	if err == nil {
-		t.Fatal("expected checksum mismatch error")
-	}
-	if !strings.Contains(err.Error(), "mismatch") {
-		t.Errorf("error should mention mismatch, got: %v", err)
-	}
+	assert.ErrorContains(t, err, "mismatch")
 }
 
 func TestExtractBinary(t *testing.T) {
@@ -184,29 +147,19 @@ func TestExtractBinary(t *testing.T) {
 
 	tempDir := t.TempDir()
 	archivePath := filepath.Join(tempDir, "test.tar.gz")
-	if err := os.WriteFile(archivePath, archive, 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(archivePath, archive, 0644))
 
 	destPath := filepath.Join(tempDir, "extracted")
-	if err := extractBinary(archivePath, destPath); err != nil {
-		t.Fatalf("extractBinary() error: %v", err)
-	}
+	require.NoError(t, extractBinary(archivePath, destPath))
 
 	got, err := os.ReadFile(destPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != string(binaryContent) {
-		t.Errorf("extracted content = %q, want %q", got, binaryContent)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, string(binaryContent), string(got))
 
-	info, statErr := os.Stat(destPath)
-	if statErr != nil {
-		t.Fatalf("failed to stat extracted binary: %v", statErr)
-	}
-	if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
-		t.Error("extracted binary should be executable")
+	info, err := os.Stat(destPath)
+	require.NoError(t, err, "failed to stat extracted binary")
+	if runtime.GOOS != "windows" {
+		assert.NotZero(t, info.Mode()&0111, "extracted binary should be executable")
 	}
 }
 
@@ -219,30 +172,20 @@ func TestExtractBinary_WindowsExe(t *testing.T) {
 
 	tempDir := t.TempDir()
 	archivePath := filepath.Join(tempDir, "test.tar.gz")
-	if err := os.WriteFile(archivePath, archive, 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(archivePath, archive, 0644))
 
 	destPath := filepath.Join(tempDir, "extracted")
-	if err := extractBinary(archivePath, destPath); err != nil {
-		t.Fatalf("extractBinary() error on alpamon.exe entry: %v", err)
-	}
+	require.NoError(t, extractBinary(archivePath, destPath), "extractBinary() must accept an alpamon.exe entry")
 
 	got, err := os.ReadFile(destPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != string(binaryContent) {
-		t.Errorf("extracted content = %q, want %q", got, binaryContent)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, string(binaryContent), string(got))
 }
 
 func TestExtractBinary_NotFound(t *testing.T) {
 	// Archive with a different filename
 	tmpFile, err := os.CreateTemp("", "test-archive-*.tar.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	gw := gzip.NewWriter(tmpFile)
@@ -256,55 +199,34 @@ func TestExtractBinary_NotFound(t *testing.T) {
 
 	destPath := filepath.Join(t.TempDir(), "extracted")
 	err = extractBinary(tmpFile.Name(), destPath)
-	if err == nil {
-		t.Fatal("expected error when binary not found in archive")
-	}
-	if !strings.Contains(err.Error(), "not found in archive") {
-		t.Errorf("error should mention not found, got: %v", err)
-	}
+	assert.ErrorContains(t, err, "not found in archive")
 }
 
 func TestReplaceBinary(t *testing.T) {
 	tempDir := t.TempDir()
 
 	currentPath := filepath.Join(tempDir, "alpamon")
-	if err := os.WriteFile(currentPath, []byte("old"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(currentPath, []byte("old"), 0755))
 
 	newPath := filepath.Join(tempDir, "alpamon-new")
-	if err := os.WriteFile(newPath, []byte("new"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(newPath, []byte("new"), 0755))
 
-	if err := replaceBinary(newPath, currentPath); err != nil {
-		t.Fatalf("replaceBinary() error: %v", err)
-	}
+	require.NoError(t, replaceBinary(newPath, currentPath))
 
 	got, err := os.ReadFile(currentPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "new" {
-		t.Errorf("binary content = %q, want %q", got, "new")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
 
 	info, err := os.Stat(currentPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if runtime.GOOS != "windows" && info.Mode().Perm() != 0755 {
-		t.Errorf("permissions = %o, want 0755", info.Mode().Perm())
+	require.NoError(t, err)
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
 	}
 
-	if _, err := os.Stat(currentPath + ".new"); !os.IsNotExist(err) {
-		t.Error("staged file should be cleaned up")
-	}
+	assert.NoFileExists(t, currentPath+".new", "staged file should be cleaned up")
 
 	// Backup should be removed on success
-	if _, err := os.Stat(currentPath + ".bak"); !os.IsNotExist(err) {
-		t.Error("backup file should be cleaned up on success")
-	}
+	assert.NoFileExists(t, currentPath+".bak", "backup file should be cleaned up on success")
 }
 
 func TestSelfUpdate_InvalidVersion(t *testing.T) {
@@ -322,48 +244,31 @@ func TestSelfUpdate_InvalidVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := SelfUpdate(context.Background(), tt.version, Options{})
-			if err == nil {
-				t.Fatal("expected error for invalid version")
-			}
-			if !strings.Contains(err.Error(), "invalid version format") {
-				t.Errorf("error should mention invalid version format, got: %v", err)
-			}
+			assert.ErrorContains(t, err, "invalid version format")
 		})
 	}
 }
 
 func TestSelfUpdate_AlreadyInProgress(t *testing.T) {
-	if !selfUpdateInFlight.CompareAndSwap(false, true) {
-		t.Fatal("in-flight flag unexpectedly set before test")
-	}
+	require.True(t, selfUpdateInFlight.CompareAndSwap(false, true), "in-flight flag unexpectedly set before test")
 	defer selfUpdateInFlight.Store(false)
 
 	err := SelfUpdate(context.Background(), "v1.0.0", Options{})
-	if !errors.Is(err, ErrSelfUpdateInProgress) {
-		t.Fatalf("expected ErrSelfUpdateInProgress, got: %v", err)
-	}
+	assert.ErrorIs(t, err, ErrSelfUpdateInProgress)
 }
 
 func TestSelfUpdate_InFlightFlagResets(t *testing.T) {
 	// A failed run (invalid version) must clear the flag for the next call.
-	if err := SelfUpdate(context.Background(), "not-a-version", Options{}); err == nil {
-		t.Fatal("expected error for invalid version")
-	}
-	if selfUpdateInFlight.Load() {
-		t.Fatal("in-flight flag not reset after failed SelfUpdate returned")
-	}
+	require.Error(t, SelfUpdate(context.Background(), "not-a-version", Options{}), "expected error for invalid version")
+	assert.False(t, selfUpdateInFlight.Load(), "in-flight flag not reset after failed SelfUpdate returned")
 }
 
 func TestReleaseSelfUpdateLatch(t *testing.T) {
-	if !selfUpdateInFlight.CompareAndSwap(false, true) {
-		t.Fatal("in-flight flag unexpectedly set before test")
-	}
+	require.True(t, selfUpdateInFlight.CompareAndSwap(false, true), "in-flight flag unexpectedly set before test")
 	defer selfUpdateInFlight.Store(false)
 
 	ReleaseSelfUpdateLatch()
-	if selfUpdateInFlight.Load() {
-		t.Fatal("ReleaseSelfUpdateLatch did not clear the latch")
-	}
+	assert.False(t, selfUpdateInFlight.Load(), "ReleaseSelfUpdateLatch did not clear the latch")
 }
 
 func TestDownloadFile_Oversize(t *testing.T) {
@@ -382,12 +287,7 @@ func TestDownloadFile_Oversize(t *testing.T) {
 
 	destPath := filepath.Join(t.TempDir(), "downloaded")
 	err := downloadFile(context.Background(), server.URL, destPath)
-	if err == nil {
-		t.Fatal("expected error for oversize response")
-	}
-	if !strings.Contains(err.Error(), "too large") {
-		t.Errorf("error should mention too large, got: %v", err)
-	}
+	assert.ErrorContains(t, err, "too large")
 }
 
 func TestDownloadFile_ContextCancelled(t *testing.T) {
@@ -404,10 +304,7 @@ func TestDownloadFile_ContextCancelled(t *testing.T) {
 	cancel() // Cancel immediately
 
 	destPath := filepath.Join(t.TempDir(), "downloaded")
-	err := downloadFile(ctx, server.URL, destPath)
-	if err == nil {
-		t.Fatal("expected error for cancelled context")
-	}
+	assert.Error(t, downloadFile(ctx, server.URL, destPath), "expected error for cancelled context")
 }
 
 func TestIsMachO(t *testing.T) {
@@ -430,9 +327,7 @@ func TestIsMachO(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isMachO(tt.magic); got != tt.want {
-				t.Errorf("isMachO(%x) = %v, want %v", tt.magic, got, tt.want)
-			}
+			assert.Equal(t, tt.want, isMachO(tt.magic), "magic %x", tt.magic)
 		})
 	}
 }
@@ -442,13 +337,8 @@ func TestValidateBinaryFormat(t *testing.T) {
 
 	// Test with invalid file
 	invalidPath := filepath.Join(tempDir, "invalid")
-	if err := os.WriteFile(invalidPath, []byte("not a binary"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	err := validateBinaryFormat(invalidPath)
-	if err == nil {
-		t.Error("expected error for invalid binary format")
-	}
+	require.NoError(t, os.WriteFile(invalidPath, []byte("not a binary"), 0755))
+	assert.Error(t, validateBinaryFormat(invalidPath), "expected error for invalid binary format")
 
 	// Test with valid binary for the current platform
 	var magic []byte
@@ -463,10 +353,6 @@ func TestValidateBinaryFormat(t *testing.T) {
 
 	validPath := filepath.Join(tempDir, "valid")
 	content := append(magic, []byte("dummy")...)
-	if err := os.WriteFile(validPath, content, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := validateBinaryFormat(validPath); err != nil {
-		t.Errorf("expected valid binary format, got error: %v", err)
-	}
+	require.NoError(t, os.WriteFile(validPath, content, 0755))
+	assert.NoError(t, validateBinaryFormat(validPath), "expected valid binary format")
 }

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -21,6 +21,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// writeTestArchive writes archive into a fresh temporary directory and returns
+// the archive path together with the extraction destination beside it.
+func writeTestArchive(t *testing.T, archive []byte) (archivePath, destPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	archivePath = filepath.Join(dir, "test.tar.gz")
+	require.NoError(t, os.WriteFile(archivePath, archive, 0644))
+	return archivePath, filepath.Join(dir, "extracted")
+}
+
 // createTestArchive creates a tar.gz archive containing a fake alpamon binary.
 func createTestArchive(t *testing.T, binaryContent []byte) []byte {
 	t.Helper()
@@ -172,11 +182,7 @@ func TestExtractBinary(t *testing.T) {
 	binaryContent := []byte("#!/bin/sh\necho hello")
 	archive := createTestArchive(t, binaryContent)
 
-	tempDir := t.TempDir()
-	archivePath := filepath.Join(tempDir, "test.tar.gz")
-	require.NoError(t, os.WriteFile(archivePath, archive, 0644))
-
-	destPath := filepath.Join(tempDir, "extracted")
+	archivePath, destPath := writeTestArchive(t, archive)
 	require.NoError(t, extractBinary(archivePath, destPath))
 
 	got, err := os.ReadFile(destPath)
@@ -197,11 +203,7 @@ func TestExtractBinary_WindowsExe(t *testing.T) {
 	binaryContent := []byte("fake pe binary")
 	archive := createTestArchiveNamed(t, "alpamon.exe", binaryContent)
 
-	tempDir := t.TempDir()
-	archivePath := filepath.Join(tempDir, "test.tar.gz")
-	require.NoError(t, os.WriteFile(archivePath, archive, 0644))
-
-	destPath := filepath.Join(tempDir, "extracted")
+	archivePath, destPath := writeTestArchive(t, archive)
 	require.NoError(t, extractBinary(archivePath, destPath), "extractBinary() must accept an alpamon.exe entry")
 
 	got, err := os.ReadFile(destPath)
@@ -213,11 +215,9 @@ func TestExtractBinary_NotFound(t *testing.T) {
 	// Archive whose only entry is not the alpamon binary.
 	archive := createTestArchiveNamed(t, "not-alpamon", []byte("hello"))
 
-	tempDir := t.TempDir()
-	archivePath := filepath.Join(tempDir, "test.tar.gz")
-	require.NoError(t, os.WriteFile(archivePath, archive, 0644))
+	archivePath, destPath := writeTestArchive(t, archive)
 
-	err := extractBinary(archivePath, filepath.Join(tempDir, "extracted"))
+	err := extractBinary(archivePath, destPath)
 	assert.ErrorContains(t, err, "not found in archive")
 }
 

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -30,31 +31,22 @@ func createTestArchive(t *testing.T, binaryContent []byte) []byte {
 // and Windows-style "alpamon.exe" archive entries.
 func createTestArchiveNamed(t *testing.T, entryName string, binaryContent []byte) []byte {
 	t.Helper()
-	tmpFile, err := os.CreateTemp("", "test-archive-*.tar.gz")
-	require.NoError(t, err)
-	defer func() {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-	}()
-
-	gw := gzip.NewWriter(tmpFile)
+	var archive bytes.Buffer
+	gw := gzip.NewWriter(&archive)
 	tw := tar.NewWriter(gw)
 
-	hdr := &tar.Header{
+	require.NoError(t, tw.WriteHeader(&tar.Header{
 		Name: entryName,
 		Mode: 0755,
 		Size: int64(len(binaryContent)),
-	}
-	require.NoError(t, tw.WriteHeader(hdr))
-	_, err = tw.Write(binaryContent)
+	}))
+	_, err := tw.Write(binaryContent)
 	require.NoError(t, err)
 
-	_ = tw.Close()
-	_ = gw.Close()
-
-	data, err := os.ReadFile(tmpFile.Name())
-	require.NoError(t, err)
-	return data
+	// Both Close calls flush, so a failure here means a truncated archive.
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	return archive.Bytes()
 }
 
 func sha256Hex(data []byte) string {
@@ -63,13 +55,13 @@ func sha256Hex(data []byte) string {
 }
 
 func TestArchiveFilename(t *testing.T) {
-	expected := fmt.Sprintf("alpamon-1.2.3-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
-	assert.Equal(t, expected, archiveFilename("v1.2.3"))
+	assert.Equal(t, fmt.Sprintf("alpamon-1.2.3-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH), archiveFilename("v1.2.3"))
 }
 
 func TestChecksumURL(t *testing.T) {
-	expected := "https://github.com/alpacax/alpamon/releases/download/v1.2.3/alpamon-1.2.3-checksums.sha256"
-	assert.Equal(t, expected, checksumURL(defaultReleaseBaseURL, "v1.2.3"))
+	assert.Equal(t,
+		"https://github.com/alpacax/alpamon/releases/download/v1.2.3/alpamon-1.2.3-checksums.sha256",
+		checksumURL(defaultReleaseBaseURL, "v1.2.3"))
 }
 
 func TestDownloadFile(t *testing.T) {
@@ -104,6 +96,42 @@ func TestDownloadFile_NotFound(t *testing.T) {
 	assert.ErrorContains(t, err, "404")
 }
 
+func TestDownloadFile_Oversize(t *testing.T) {
+	// Server streams more than maxArchiveSize without Content-Length
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Write maxArchiveSize+1 bytes in chunks to avoid setting Content-Length
+		chunk := make([]byte, 32*1024)
+		remaining := int64(maxArchiveSize) + 1
+		for remaining > 0 {
+			n := min(int64(len(chunk)), remaining)
+			_, _ = w.Write(chunk[:n])
+			remaining -= n
+		}
+	}))
+	defer server.Close()
+
+	destPath := filepath.Join(t.TempDir(), "downloaded")
+	err := downloadFile(context.Background(), server.URL, destPath)
+	assert.ErrorContains(t, err, "too large")
+}
+
+func TestDownloadFile_ContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slow server that never finishes
+		select {
+		case <-r.Context().Done():
+		case <-time.After(10 * time.Second):
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	destPath := filepath.Join(t.TempDir(), "downloaded")
+	assert.Error(t, downloadFile(ctx, server.URL, destPath), "expected error for cancelled context")
+}
+
 func TestVerifyChecksum(t *testing.T) {
 	archiveContent := []byte("fake archive content")
 	hash := sha256Hex(archiveContent)
@@ -116,8 +144,7 @@ func TestVerifyChecksum(t *testing.T) {
 	}))
 	defer server.Close()
 
-	tempDir := t.TempDir()
-	archivePath := filepath.Join(tempDir, archiveName)
+	archivePath := filepath.Join(t.TempDir(), archiveName)
 	require.NoError(t, os.WriteFile(archivePath, archiveContent, 0644))
 
 	err := verifyChecksum(context.Background(), archivePath, archiveName, server.URL+"/checksums.sha256")
@@ -133,8 +160,7 @@ func TestVerifyChecksum_Mismatch(t *testing.T) {
 	}))
 	defer server.Close()
 
-	tempDir := t.TempDir()
-	archivePath := filepath.Join(tempDir, archiveName)
+	archivePath := filepath.Join(t.TempDir(), archiveName)
 	require.NoError(t, os.WriteFile(archivePath, []byte("different content"), 0644))
 
 	err := verifyChecksum(context.Background(), archivePath, archiveName, server.URL+"/checksums.sha256")
@@ -183,22 +209,14 @@ func TestExtractBinary_WindowsExe(t *testing.T) {
 }
 
 func TestExtractBinary_NotFound(t *testing.T) {
-	// Archive with a different filename
-	tmpFile, err := os.CreateTemp("", "test-archive-*.tar.gz")
-	require.NoError(t, err)
-	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	// Archive whose only entry is not the alpamon binary.
+	archive := createTestArchiveNamed(t, "not-alpamon", []byte("hello"))
 
-	gw := gzip.NewWriter(tmpFile)
-	tw := tar.NewWriter(gw)
-	hdr := &tar.Header{Name: "not-alpamon", Mode: 0755, Size: 5}
-	_ = tw.WriteHeader(hdr)
-	_, _ = tw.Write([]byte("hello"))
-	_ = tw.Close()
-	_ = gw.Close()
-	_ = tmpFile.Close()
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "test.tar.gz")
+	require.NoError(t, os.WriteFile(archivePath, archive, 0644))
 
-	destPath := filepath.Join(t.TempDir(), "extracted")
-	err = extractBinary(tmpFile.Name(), destPath)
+	err := extractBinary(archivePath, filepath.Join(tempDir, "extracted"))
 	assert.ErrorContains(t, err, "not found in archive")
 }
 
@@ -269,42 +287,6 @@ func TestReleaseSelfUpdateLatch(t *testing.T) {
 
 	ReleaseSelfUpdateLatch()
 	assert.False(t, selfUpdateInFlight.Load(), "ReleaseSelfUpdateLatch did not clear the latch")
-}
-
-func TestDownloadFile_Oversize(t *testing.T) {
-	// Server streams more than maxArchiveSize without Content-Length
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Write maxArchiveSize+1 bytes in chunks to avoid setting Content-Length
-		chunk := make([]byte, 32*1024)
-		remaining := int64(maxArchiveSize) + 1
-		for remaining > 0 {
-			n := min(int64(len(chunk)), remaining)
-			_, _ = w.Write(chunk[:n])
-			remaining -= n
-		}
-	}))
-	defer server.Close()
-
-	destPath := filepath.Join(t.TempDir(), "downloaded")
-	err := downloadFile(context.Background(), server.URL, destPath)
-	assert.ErrorContains(t, err, "too large")
-}
-
-func TestDownloadFile_ContextCancelled(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Slow server that never finishes
-		select {
-		case <-r.Context().Done():
-		case <-time.After(10 * time.Second):
-		}
-	}))
-	defer server.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
-
-	destPath := filepath.Join(t.TempDir(), "downloaded")
-	assert.Error(t, downloadFile(ctx, server.URL, destPath), "expected error for cancelled context")
 }
 
 func TestIsMachO(t *testing.T) {

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -16,19 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacax/alpamon/v2/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// assertGone fails unless path is absent, which os.Stat reports as
-// os.ErrNotExist. assert.NoFileExists is the shorter spelling but it treats a
-// directory at path, and any other Lstat error, as absence; both callers here
-// are proving that a cleanup step ran, so nothing but a missing path passes.
-func assertGone(t *testing.T, path, msg string) {
-	t.Helper()
-	_, err := os.Stat(path)
-	assert.ErrorIs(t, err, os.ErrNotExist, msg)
-}
 
 // createTestArchive creates a tar.gz archive containing a fake alpamon binary.
 func createTestArchive(t *testing.T, binaryContent []byte) []byte {
@@ -251,10 +242,10 @@ func TestReplaceBinary(t *testing.T) {
 		assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
 	}
 
-	assertGone(t, currentPath+".new", "staged file should be cleaned up")
+	testutil.AssertGone(t, currentPath+".new", "staged file should be cleaned up")
 
 	// Backup should be removed on success
-	assertGone(t, currentPath+".bak", "backup file should be cleaned up on success")
+	testutil.AssertGone(t, currentPath+".bak", "backup file should be cleaned up on success")
 }
 
 func TestSelfUpdate_InvalidVersion(t *testing.T) {

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -20,6 +20,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// assertGone fails unless path is absent, which os.Stat reports as
+// os.ErrNotExist. assert.NoFileExists is the shorter spelling but it treats a
+// directory at path, and any other Lstat error, as absence; both callers here
+// are proving that a cleanup step ran, so nothing but a missing path passes.
+func assertGone(t *testing.T, path, msg string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist, msg)
+}
+
 // createTestArchive creates a tar.gz archive containing a fake alpamon binary.
 func createTestArchive(t *testing.T, binaryContent []byte) []byte {
 	t.Helper()
@@ -241,10 +251,10 @@ func TestReplaceBinary(t *testing.T) {
 		assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
 	}
 
-	assert.NoFileExists(t, currentPath+".new", "staged file should be cleaned up")
+	assertGone(t, currentPath+".new", "staged file should be cleaned up")
 
 	// Backup should be removed on success
-	assert.NoFileExists(t, currentPath+".bak", "backup file should be cleaned up on success")
+	assertGone(t, currentPath+".bak", "backup file should be cleaned up on success")
 }
 
 func TestSelfUpdate_InvalidVersion(t *testing.T) {

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -78,7 +78,7 @@ func TestDownloadFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(content), string(got))
 
-	// Verify file permissions are restrictive (Unix only — Windows doesn't enforce Unix perms)
+	// Verify file permissions are restrictive (Unix only: Windows doesn't enforce Unix perms)
 	if runtime.GOOS != "windows" {
 		info, err := os.Stat(destPath)
 		require.NoError(t, err)


### PR DESCRIPTION
Fifth and last PR for the primary candidate list in #370. Scope is the five files the issue named that were still unconverted: `multipart_stream_test.go`, `shell_test.go`, `migrate_test.go`, `auth_manager_tracker_test.go`, `updater_test.go`. With #421, #422, #427 and #428 merged, every file under the issue's "Candidates that would benefit most" now asserts through testify.

The rule the earlier PRs settled applies unchanged: `require` where a failed check makes the rest of the test meaningless, `assert` where the test can keep checking. No production code changed, and no test was added or removed.

This PR also writes that rule down, which nothing in the repo did before. See [The convention](#the-convention).

## What changed

Twenty-two commits, one idea each. The first five are the conversion, one file per commit. The next six are defects and leftovers found while reading the converted files. Then the convention, and last ten review follow-ups.

| Commit | What it does |
|---|---|
| `11a5fd69` | `multipart_stream_test.go`: every hand-rolled check becomes testify, and five copies of the parse-and-open-a-reader preamble become `requireMultipartReader` |
| `a6ecbd39` | `migrate_test.go`: the same conversion; `os.Stat` existence checks become `DirExists` / `FileExists`, and `Confirm(nil)` gets `assert.NotPanics` instead of a comment |
| `0394e09e` | `auth_manager_tracker_test.go`: the same conversion; lookups whose result the next line dereferences move to `require` |
| `a366f92e` | `updater_test.go`: the same conversion; `!os.IsNotExist(err)` becomes `assert.NoFileExists` |
| `cf5bdcb6` | `shell_test.go`: the same conversion; two hand-rolled found-flag loops become `assert.Contains` over `executedUsers` |
| `f36827a4` | `TestShellHandler_OrStopsOnSuccess` said in a comment that cmd2 must not run, and asserted only that cmd1's output was there. The mock returns `output2` for cmd2, so the run the comment forbids used to pass |
| `7b154f1e` | a no-op write in the pid-reuse test: `LookupPID` returns `TrackerEntry` by value, so the `StartedAt` assignment landed on a copy and the time gap its comment claimed never existed. No assertion read the field |
| `ae52d6a9` | the two recursive multipart tests compared field names against `"name"` literals while their siblings used `multipartFieldName`, and broke the loop on `err == io.EOF` instead of `errors.Is`. The discarded `io.ReadAll` error is now asserted |
| `b9f47e60` | three `os.ReadFile` calls dropped their error into `_`, so a failed read reported as a content mismatch against `""` instead of the real cause |
| `38a55c33` | `createTestArchiveNamed` builds the tar.gz in a `bytes.Buffer` instead of writing a temp file and reading it back, and checks both `Close` calls since they flush. `TestExtractBinary_NotFound` reuses it instead of hand-rolling the same archive. The two `TestDownloadFile_*` cases move next to their siblings |
| `fb5b8cf0` | single-use locals inlined in the `Commands` test |
| `f9c59ee5` | the convention, in `README.md`, `CLAUDE.md` and `.github/copilot-instructions.md` |
| `8a044a3c` | `requireMultipartReader` handed `params["boundary"]` to the reader without checking it, so a content type that parses but carries no boundary failed later as an opaque `boundary is empty`. `require.NotEmpty` moves the failure to the parsing step and names the content type |
| `bcdd02f7` | six prose spellings of "websh" become "Websh", and one "alpamon" becomes "Alpamon", per the proper-noun rule in `CLAUDE.md`. Values, identifiers and the `alpacon-server` repository name stay lowercase |
| `f4a36d14` | three comments used a spaced em-dash, which `CLAUDE.md` forbids. Two become colons, one a comma |
| `aa068009` | the six `assert.NoFileExists` calls become one `assertGone` helper per package that asserts `os.ErrNotExist` from `os.Stat`. The weakening turned out to be demonstrable, not theoretical: see [Testing](#testing) |
| `b2d3d28b` | the three convention copies disagreed, and all three offered `assert.NoFileExists` as the helper to prefer, which `aa068009` had just stopped using |
| `2d17a076` | the two `assertGone` copies become one `internal/testutil.AssertGone` taking `msgAndArgs ...any`. `aa068009` called the two copies the package boundary; the convention it wrote down makes a third copy a matter of time, and `internal/runnertest` is the precedent for a test-only internal package |
| `41fcacd0` | the three extract-binary tests opened with the same `t.TempDir()`, path join and `os.WriteFile`; `writeTestArchive` returns the archive path and the extraction destination beside it |
| `6fa0c5d8` | the pid-reuse test was the only lookup in the file that dropped `ok`, so an entry that stopped being found would have reported `"new-cmd" != ""` and hidden the cause |
| `df6ccd64` | the single-part roundtrip block, `NextPart` through the two names to the sha256 comparison, repeated in three tests and becomes `assertSinglePart` |
| `27714ca0` | nothing in the three convention copies said the other two existed. Each now carries an HTML comment naming all three, which renders as nothing and reaches whoever opens the file |

```
 .github/copilot-instructions.md                    |   2 +
 CLAUDE.md                                          |   3 +
 README.md                                          |  12 +
 internal/testutil/fs.go                            |  23 ++
 .../handlers/file/multipart_stream_test.go         | 256 ++++++--------
 pkg/executor/handlers/shell/shell_test.go          | 284 +++++-----------
 pkg/migrate/migrate_test.go                        | 184 ++++------
 pkg/runner/auth_manager_tracker_test.go            | 231 ++++---------
 pkg/updater/updater_test.go                        | 369 +++++++--------------
 9 files changed, 454 insertions(+), 910 deletions(-)
```

## The counts, and why two files do not map one for one

| File | `main` `t.Fatal*` | `main` `t.Error*` | `require` | `assert` | `t.Fatal` kept |
|---|---|---|---|---|---|
| `shell_test.go` | 20 | 41 | 20 | 41 | 0 |
| `auth_manager_tracker_test.go` | 15 | 35 | 16 | 37 | 0 |
| `multipart_stream_test.go` | 47 | 0 | 21 | 19 | 1 |
| `migrate_test.go` | 40 | 0 | 21 | 18 | 2 |
| `updater_test.go` | 37 | 19 | 26 | 21 | 0 |

`shell_test.go` maps exactly, because its original had already chosen where a failure must stop: every `t.Fatal*` aborts and every `t.Error*` keeps going, so the mapping is mechanical. `auth_manager_tracker_test.go` maps the same way apart from three additions described below.

The other three cannot map that way. `multipart_stream_test.go` and `migrate_test.go` used `t.Fatalf` for every check and `updater_test.go` for most of them, so a literal mapping would make every assertion fatal and lose the distinction the issue asks for. Those files were split by whether the following lines depend on the result: a failed `require` there would have left the next line reading a nil reader or an unwritten file anyway.

Three effects move the totals:

- Helper extraction folds repeats. `requireMultipartReader` covers 5 call sites, `assertSinglePart` 3, `createTestArchiveNamed` 3, `writeTestArchive` 3, `executedUsers` 2, and `testutil.AssertGone` 4 in `migrate_test.go` and 2 in `updater_test.go`. `requireMultipartReader` holds one `require` more than the assertions it replaced, because of the boundary check described below. `AssertGone` turns six `assert` calls into one, `assertSinglePart` turns nine `assert` and six `require` calls into three and two, and `writeTestArchive` turns three `require` calls into one. The counts above are per file, so a helper that moved to `internal/testutil` no longer shows in either.
- `assert.ErrorContains` folds pairs. Several files tested `err == nil` with `t.Error` and then called `err.Error()` on the next line, which would have panicked on the very failure being reported. One call covers both halves, without the hole.
- `||` conditions split into one assertion per half, so a failure names which half broke: 8 in `multipart_stream_test.go`, 3 in `shell_test.go`, 1 each in `migrate_test.go` and `auth_manager_tracker_test.go`.

The three `t.Fatal` calls that stay are all the timeout branch of a `select`, where there is no error value to assert on.

## Where the strength changed on purpose

Seven checks got stronger:

- `os.Stat` existence checks in `migrate_test.go` become `assert.DirExists` and `assert.FileExists`, which also pin the kind.
- The six path-absence checks keep the original `os.ErrNotExist` semantics through `internal/testutil.AssertGone`, now one helper for the whole module. The first pass used `assert.NoFileExists`, which is shorter and weaker; review caught it and [Testing](#testing) shows the case it let through.
- `requireMultipartReader` requires a non-empty `boundary`, which the original inline code never checked either. Without it a parsed content type with no boundary reached `multipart.NewReader` and failed there as `boundary is empty`, naming neither the content type nor the call site.
- `RegisterCommandPID`'s nil-cleanup check was `t.Error`, which reports and then calls that nil closure. `require.NotNil` stops there, and the call itself, whose comment said it must not panic, is now `assert.NotPanics`.
- `Confirm(nil)` was a bare call under a comment saying it must not panic; `assert.NotPanics` states it in code.
- The pid-reuse test read the `LookupPID` result without its `ok`, so a missing entry surfaced as `"new-cmd" != ""`. `require.True` stops the test at the lookup and says what was expected to survive.
- `assert.ErrorContains` closes the `err.Error()`-on-nil hole described above.

One got weaker, deliberately:

- `assert.ErrorIs(t, err, io.EOF)` replaces `err != io.EOF` at two places in `multipart_stream_test.go`. `errors.Is` unwraps, so a wrapped EOF would now pass. `multipart.Reader.NextPart` returns a bare `io.EOF`, and the looser form is the one that survives the stdlib wrapping it later.

## The convention

The issue says which style to use, but the repo did not. On `main` the suite splits 46 files that import testify against 71 that assert by hand; after this PR it is 51 against 66. Closing the primary list does not stop the next test from landing in the legacy style, so the rule is now written in three places, one per reader: `README.md` for people, `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for Copilot.

`README.md` had no test instructions at all beyond the Docker distro matrix, so its new Tests section also carries the `go test` invocations and the reason `-p 1` is mandatory.

Three copies are only worth keeping if they agree, and the first pass failed that on both counts: the Copilot copy listed fewer legacy calls than the other two and blurred which one the exception covers, and all three named `assert.NoFileExists` as a helper to prefer. `b2d3d28b` fixes both, and the wording now carries the lesson the review produced: read what a helper accepts, because the shorter spelling is sometimes the weaker check.

The wording says `require` for a failed check that makes the rest meaningless, `assert` for the checks themselves, the specific helper over a hand-rolled comparison, and a bare `t.Fatal` only where there is no error value to assert on. Legacy tests convert while someone is already editing them, not as a separate sweep.

## Testing

No production code changed. `git diff origin/main..HEAD --name-only` is five test files, three documents and `internal/testutil/fs.go`. That last one is a `.go` file rather than a `_test.go` file, but it holds one assertion helper, lives under `internal/` so nothing outside the module can import it, and is imported only from `_test.go` files, which is the same arrangement `internal/runnertest` already uses. No shipped code path reaches it.

The PASS line set of each of the five packages is identical before and after. Names were collected with `go test -v` on `origin/main`'s copy of each file and on this branch, then sorted and diffed:

| Package | PASS | SKIP | `diff` |
|---|---|---|---|
| `pkg/executor/handlers/file` | 75 | 1 | empty |
| `pkg/executor/handlers/shell` | 52 | 0 | empty |
| `pkg/migrate` | 15 | 0 | empty |
| `pkg/runner` | 235 | 0 | empty |
| `pkg/updater` | 34 | 0 | empty |

No test was renamed, so unlike #428 there is no line to show here. No FAIL line appears in any run. The one SKIP is `TestFileHandler_Execute_Rm/refused_on_Windows`, a platform gate that lives in `file_test.go`, which this PR does not touch and which skips the same way on `main`.

`gofmt -l .` is empty and `go vet ./...` is clean. All 46 packages with tests pass under `go test ./... -p 1`, and the five touched packages also pass under `-race`:

```
ok  github.com/alpacax/alpamon/v2/pkg/executor/handlers/file   1.588s
ok  github.com/alpacax/alpamon/v2/pkg/executor/handlers/shell  1.478s
ok  github.com/alpacax/alpamon/v2/pkg/migrate                  14.988s
ok  github.com/alpacax/alpamon/v2/pkg/runner                    38.163s
ok  github.com/alpacax/alpamon/v2/pkg/updater                   1.757s
```

`assert.NoFileExists` was shown to be the weaker check before `aa068009` replaced it, rather than argued about. Creating a directory at `MarkerPath()` after `Confirm()` ran leaves `assert.NoFileExists` silent, while the path-absence helper on the same path in the same run reports:

```
--- FAIL: TestConfirm_RemovesMarkerAndBackup (0.01s)
    Error:      Expected error with "file does not exist" in chain but got nil.
    Messages:   Confirm did not remove the marker
```

The boundary assertion added in `8a044a3c` was seen failing before it was trusted. Forcing `params["boundary"] = ""` inside the helper fails all five call sites with the content type in the message:

```
--- FAIL: TestBuildMultipartStream_Roundtrip (0.00s)
    Error:      Should NOT be empty, but was
    Messages:   ct="multipart/form-data; boundary=d6593740a987c93cac042ceb027d27e7f9c60264f9e2c43287e4fd122d11"
```

The four helpers the review follow-ups introduced or tightened were each seen failing before being trusted, one mutation at a time, reverted after.

`testutil.AssertGone` pointed at a path that is still there:

```
--- FAIL: TestReplaceBinary (0.00s)
    Error:      Expected error with "file does not exist" in chain but got nil.
    Messages:   MUTANT: existing path must fail
```

`assertSinglePart` given the wrong file name, which is the argument the fold made a parameter:

```
--- FAIL: TestBuildMultipartStream_Roundtrip (0.00s)
    Error:      Not equal:
                expected: "f.WRONG"
                actual  : "f.bin"
```

The new `require.True` in the pid-reuse test, with the lookup pointed at a pid that was never registered:

```
--- FAIL: TestAddPIDCommandMapping_OverwritesStaleEntry (0.00s)
    Error:      Should be true
    Messages:   entry should survive the overwrite
```

`writeTestArchive` writing something other than the archive it was handed, which breaks all three of its callers at once and shows the helper is what feeds them:

```
--- FAIL: TestExtractBinary (0.00s)
--- FAIL: TestExtractBinary_WindowsExe (0.00s)
--- FAIL: TestExtractBinary_NotFound (0.00s)
    Error:      Error "failed to open gzip: unexpected EOF" does not contain "not found in archive"
```

The no-op `StartedAt` write in `7b154f1e` was confirmed dead before removal: `LookupPID` returns a value (`pkg/runner/auth_manager.go:787`), the assignment target is that copy, and no assertion in the test reads `StartedAt`. Deleting the block leaves `time` unused in the file, which is the compiler agreeing.

## Remaining

Part of #370, which stays open. The primary candidate list is complete; what remains are the partial candidates the issue lists, where only the plain value-checking tests should move and the concurrency and timing tests stay as they are: `terminal_manager_test.go`, `integration_test.go`, `chunk_writer_test.go`, `process_tree_*_test.go`, `regression_test.go`.

