### PR TITLE
Verify a file's digest against the descriptor it executes (ADR 0053)

### DIFF
--- a/internal/protocol/file_exec.go
+++ b/internal/protocol/file_exec.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -57,7 +56,7 @@ func (c *Command) ParseFileExecPayload() (*FileExecPayload, error) {
 	switch {
 	case payload.Path == "":
 		return nil, errors.New("file command payload has no path")
-	case !filepath.IsAbs(payload.Path):
+	case !isPOSIXAbsolute(payload.Path):
 		return nil, fmt.Errorf("file command path is not absolute: %q", payload.Path)
 	case payload.Interpreter == "":
 		return nil, errors.New("file command payload has no interpreter")
@@ -67,7 +66,7 @@ func (c *Command) ParseFileExecPayload() (*FileExecPayload, error) {
 	// interpreter is a way to swap what actually runs while the approved digest
 	// still matches. The server validates this too; the agent does not take its
 	// word for it, because the agent is where the guarantee is kept.
-	case !filepath.IsAbs(payload.Interpreter):
+	case !isPOSIXAbsolute(payload.Interpreter):
 		return nil, fmt.Errorf(
 			"file command interpreter is not absolute: %q", payload.Interpreter,
 		)
@@ -82,4 +81,15 @@ func (c *Command) ParseFileExecPayload() (*FileExecPayload, error) {
 // compare against a computed sum.
 func (p *FileExecPayload) ExpectedDigest() string {
 	return strings.TrimPrefix(p.SHA256, "sha256:")
+}
+
+// isPOSIXAbsolute reports whether a wire path is absolute in POSIX terms.
+//
+// Deliberately not filepath.IsAbs: that is evaluated against the *building*
+// OS, so a Windows build would read "/opt/deploy.sh" as relative and refuse a
+// payload every other build accepts. The wire contract is a POSIX path — the
+// lane declines on Windows before a payload is ever parsed — so the check has
+// to mean the same thing wherever it compiles.
+func isPOSIXAbsolute(p string) bool {
+	return strings.HasPrefix(p, "/")
 }

--- a/internal/protocol/file_exec.go
+++ b/internal/protocol/file_exec.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -56,8 +57,20 @@ func (c *Command) ParseFileExecPayload() (*FileExecPayload, error) {
 	switch {
 	case payload.Path == "":
 		return nil, errors.New("file command payload has no path")
+	case !filepath.IsAbs(payload.Path):
+		return nil, fmt.Errorf("file command path is not absolute: %q", payload.Path)
 	case payload.Interpreter == "":
 		return nil, errors.New("file command payload has no interpreter")
+	// A bare name would be resolved through PATH at exec time, and PATH is
+	// influenced by the command's own environment. The digest binds the script
+	// but says nothing about the program interpreting it, so a relative
+	// interpreter is a way to swap what actually runs while the approved digest
+	// still matches. The server validates this too; the agent does not take its
+	// word for it, because the agent is where the guarantee is kept.
+	case !filepath.IsAbs(payload.Interpreter):
+		return nil, fmt.Errorf(
+			"file command interpreter is not absolute: %q", payload.Interpreter,
+		)
 	case !sha256DigestPattern.MatchString(payload.SHA256):
 		return nil, fmt.Errorf("file command payload has no valid sha256 digest: %q", payload.SHA256)
 	}

--- a/internal/protocol/file_exec.go
+++ b/internal/protocol/file_exec.go
@@ -1,0 +1,72 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// FileExecPayload is the structured instruction carried in Command.Data when
+// Command.Shell is "file" (ADR 0053).
+//
+// It is the only thing that decides what runs. Command.Line renders the same
+// intent for humans—display, audit, and the Ed25519 signing payload—and must
+// never be parsed to derive the entrypoint, the interpreter, or the arguments.
+type FileExecPayload struct {
+	// Path is where the entrypoint is opened from. It selects the object to
+	// verify; what an approval binds is the digest, not the path.
+	Path string `json:"path"`
+
+	// Interpreter runs the entrypoint. There is no shell wrapping it, so
+	// composition belongs inside the script.
+	Interpreter string `json:"interpreter"`
+
+	// Args are handed to the entrypoint verbatim, one argv entry each.
+	Args []string `json:"args"`
+
+	// SHA256 is the approved digest, in the "sha256:<64 hex>" shape Alpamon
+	// and the server already speak for sync hashes.
+	SHA256 string `json:"sha256"`
+}
+
+// sha256DigestPattern matches the "sha256:<64 hex>" digest shape.
+var sha256DigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// ParseFileExecPayload parses and validates Command.Data as a file execution
+// instruction.
+//
+// Every field it needs is required and a malformed payload is refused rather
+// than guessed at: a guess here would run bytes that no approval covers.
+func (c *Command) ParseFileExecPayload() (*FileExecPayload, error) {
+	if strings.TrimSpace(c.Data) == "" {
+		return nil, errors.New("file command carries no data payload")
+	}
+
+	var payload FileExecPayload
+	if err := json.Unmarshal([]byte(c.Data), &payload); err != nil {
+		return nil, fmt.Errorf("file command payload is not valid JSON: %w", err)
+	}
+
+	// Hex case is not part of the digest's identity, so normalize before the
+	// shape check rather than refusing an upper-case but otherwise valid one.
+	payload.SHA256 = strings.ToLower(payload.SHA256)
+
+	switch {
+	case payload.Path == "":
+		return nil, errors.New("file command payload has no path")
+	case payload.Interpreter == "":
+		return nil, errors.New("file command payload has no interpreter")
+	case !sha256DigestPattern.MatchString(payload.SHA256):
+		return nil, fmt.Errorf("file command payload has no valid sha256 digest: %q", payload.SHA256)
+	}
+
+	return &payload, nil
+}
+
+// ExpectedDigest returns the hex digest without the "sha256:" prefix, ready to
+// compare against a computed sum.
+func (p *FileExecPayload) ExpectedDigest() string {
+	return strings.TrimPrefix(p.SHA256, "sha256:")
+}

--- a/internal/protocol/file_exec_test.go
+++ b/internal/protocol/file_exec_test.go
@@ -146,3 +146,35 @@ func TestParseFileExecPayload_Malformed(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFileExecPayload_RelativeInterpreterRefused(t *testing.T) {
+	// A bare name resolves through PATH at exec time, and PATH comes from the
+	// command's own environment. The digest binds the script, never the program
+	// interpreting it, so this would swap what actually runs while the approved
+	// digest still matched.
+	cmd := &Command{Data: `{
+		"path": "/opt/deploy.sh",
+		"interpreter": "bash",
+		"args": [],
+		"sha256": "sha256:` + strings.Repeat("a", 64) + `"
+	}`}
+
+	_, err := cmd.ParseFileExecPayload()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "interpreter is not absolute")
+}
+
+func TestParseFileExecPayload_RelativePathRefused(t *testing.T) {
+	cmd := &Command{Data: `{
+		"path": "deploy.sh",
+		"interpreter": "/bin/bash",
+		"args": [],
+		"sha256": "sha256:` + strings.Repeat("a", 64) + `"
+	}`}
+
+	_, err := cmd.ParseFileExecPayload()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path is not absolute")
+}

--- a/internal/protocol/file_exec_test.go
+++ b/internal/protocol/file_exec_test.go
@@ -1,0 +1,148 @@
+package protocol
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDigest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func TestParseFileExecPayload_Valid(t *testing.T) {
+	cmd := &Command{
+		Shell: "file",
+		Line:  "/bin/bash /opt/deploy.sh --fast",
+		Data:  `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","args":["--fast"],"sha256":"` + testDigest + `"}`,
+	}
+
+	payload, err := cmd.ParseFileExecPayload()
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/deploy.sh", payload.Path)
+	assert.Equal(t, "/bin/bash", payload.Interpreter)
+	assert.Equal(t, []string{"--fast"}, payload.Args)
+	assert.Equal(t, strings.TrimPrefix(testDigest, "sha256:"), payload.ExpectedDigest())
+}
+
+func TestParseFileExecPayload_NoArgsIsValid(t *testing.T) {
+	cmd := &Command{
+		Shell: "file",
+		Data:  `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","sha256":"` + testDigest + `"}`,
+	}
+
+	payload, err := cmd.ParseFileExecPayload()
+	require.NoError(t, err)
+	assert.Empty(t, payload.Args)
+}
+
+func TestParseFileExecPayload_UpperCaseDigestIsNormalized(t *testing.T) {
+	cmd := &Command{
+		Shell: "file",
+		Data:  `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","sha256":"` + strings.ToUpper(testDigest) + `"}`,
+	}
+
+	payload, err := cmd.ParseFileExecPayload()
+	require.NoError(t, err)
+	assert.Equal(t, strings.TrimPrefix(testDigest, "sha256:"), payload.ExpectedDigest())
+}
+
+func TestParseFileExecPayload_UnknownFieldsAreIgnored(t *testing.T) {
+	// Forward compatibility: a newer server adding a field must not turn every
+	// file command into a refusal on an older agent.
+	cmd := &Command{
+		Shell: "file",
+		Data:  `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","sha256":"` + testDigest + `","future":"value"}`,
+	}
+
+	_, err := cmd.ParseFileExecPayload()
+	assert.NoError(t, err)
+}
+
+// Malformed payloads must fail closed with an error naming what is wrong,
+// never a panic and never a usable payload.
+func TestParseFileExecPayload_Malformed(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		wantErr string
+	}{
+		{
+			name:    "empty data",
+			data:    "",
+			wantErr: "no data payload",
+		},
+		{
+			name:    "blank data",
+			data:    "   ",
+			wantErr: "no data payload",
+		},
+		{
+			name:    "not json",
+			data:    "/bin/bash /opt/deploy.sh",
+			wantErr: "not valid JSON",
+		},
+		{
+			name:    "truncated json",
+			data:    `{"path":"/opt/deploy.sh"`,
+			wantErr: "not valid JSON",
+		},
+		{
+			name:    "json array",
+			data:    `["/bin/bash","/opt/deploy.sh"]`,
+			wantErr: "not valid JSON",
+		},
+		{
+			name:    "wrong type for args",
+			data:    `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","args":"--fast","sha256":"` + testDigest + `"}`,
+			wantErr: "not valid JSON",
+		},
+		{
+			name:    "missing path",
+			data:    `{"interpreter":"/bin/bash","sha256":"` + testDigest + `"}`,
+			wantErr: "no path",
+		},
+		{
+			name:    "missing interpreter",
+			data:    `{"path":"/opt/deploy.sh","sha256":"` + testDigest + `"}`,
+			wantErr: "no interpreter",
+		},
+		{
+			name:    "missing digest",
+			data:    `{"path":"/opt/deploy.sh","interpreter":"/bin/bash"}`,
+			wantErr: "no valid sha256 digest",
+		},
+		{
+			name:    "digest without algorithm prefix",
+			data:    `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+			wantErr: "no valid sha256 digest",
+		},
+		{
+			name:    "digest too short",
+			data:    `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","sha256":"sha256:abcd"}`,
+			wantErr: "no valid sha256 digest",
+		},
+		{
+			name:    "digest not hex",
+			data:    `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","sha256":"sha256:zzz0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+			wantErr: "no valid sha256 digest",
+		},
+		{
+			name:    "wrong algorithm",
+			data:    `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","sha256":"md5:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+			wantErr: "no valid sha256 digest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &Command{Shell: "file", Data: tt.data}
+
+			payload, err := cmd.ParseFileExecPayload()
+
+			require.Error(t, err)
+			assert.Nil(t, payload)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/pkg/executor/exec_file_unix_test.go
+++ b/pkg/executor/exec_file_unix_test.go
@@ -1,0 +1,127 @@
+//go:build !windows
+
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// verifiedFileArgv builds the argv for a verified entrypoint: the interpreter,
+// the descriptor path, then the script arguments. It mirrors what the runner
+// builds after the digest check, and it never names the original path.
+func verifiedFileArgv(t *testing.T, interpreter string, scriptArgs ...string) []string {
+	t.Helper()
+	fdPath, err := common.VerifiedFilePath()
+	if err != nil {
+		t.Skipf("verified file execution is unsupported here: %v", err)
+	}
+	return append([]string{interpreter, fdPath}, scriptArgs...)
+}
+
+// openScript writes content at path and returns an open descriptor on it,
+// standing in for the descriptor the runner hands over after verification.
+func openScript(t *testing.T, path string, content string) *os.File {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o700))
+	file, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+	return file
+}
+
+func TestExecFileWithStreamingHook_RunsInheritedDescriptor(t *testing.T) {
+	e := NewExecutor()
+	file := openScript(t, filepath.Join(t.TempDir(), "deploy.sh"), "printf 'ORIGINAL\\n'\n")
+
+	exitCode, output, err := e.ExecFileWithStreamingHook(
+		context.Background(), file, verifiedFileArgv(t, "/bin/sh"), "", "", nil, 30*time.Second, nil, nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "ORIGINAL\n", output)
+}
+
+// TestExecFileWithStreamingHook_SwapAtPathRunsVerifiedBytes is the end-to-end
+// form of the fd invariant: the file behind the path is replaced after the
+// descriptor was opened, and the child still runs the original bytes. The
+// second half of the test executes the same path directly to show that a
+// path-based implementation would have run the attacker's script instead.
+func TestExecFileWithStreamingHook_SwapAtPathRunsVerifiedBytes(t *testing.T) {
+	e := NewExecutor()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deploy.sh")
+	file := openScript(t, path, "printf 'ORIGINAL\\n'\n")
+
+	// Atomically swap a different script in at the path, exactly as an
+	// attacker would in the window between the digest check and the exec.
+	decoy := filepath.Join(dir, "decoy.sh")
+	require.NoError(t, os.WriteFile(decoy, []byte("printf 'SWAPPED\\n'\n"), 0o700))
+	require.NoError(t, os.Rename(decoy, path))
+
+	_, output, err := e.ExecFileWithStreamingHook(
+		context.Background(), file, verifiedFileArgv(t, "/bin/sh"), "", "", nil, 30*time.Second, nil, nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ORIGINAL\n", output, "the executed object must be the verified one")
+
+	// Control: naming the path instead of the descriptor runs the swap.
+	_, pathOutput, err := e.Exec(context.Background(), []string{"/bin/sh", path}, "", "", nil, 30*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "SWAPPED\n", pathOutput, "the swap must be live or this test proves nothing")
+}
+
+// TestExecFileWithStreamingHook_ArgsArePassedLiterally covers arguments a shell
+// would mangle. There is no shell between the agent and the entrypoint, so each
+// argument must arrive as exactly one argv entry, unsplit and unexpanded.
+func TestExecFileWithStreamingHook_ArgsArePassedLiterally(t *testing.T) {
+	e := NewExecutor()
+	file := openScript(t, filepath.Join(t.TempDir(), "deploy.sh"),
+		"for arg in \"$@\"; do printf '[%s]\\n' \"$arg\"; done\n")
+	scriptArgs := []string{"--fast", "a b", "; rm -rf /", "$HOME", "*", "&& echo chained"}
+
+	_, output, err := e.ExecFileWithStreamingHook(
+		context.Background(), file, verifiedFileArgv(t, "/bin/sh", scriptArgs...),
+		"", "", map[string]string{"HOME": "/should/not/appear"}, 30*time.Second, nil, nil,
+	)
+
+	require.NoError(t, err)
+	want := "[" + strings.Join(scriptArgs, "]\n[") + "]\n"
+	assert.Equal(t, want, output)
+}
+
+func TestExecFileWithStreamingHook_StreamsChunks(t *testing.T) {
+	e := NewExecutor()
+	file := openScript(t, filepath.Join(t.TempDir(), "deploy.sh"), "printf 'STREAMED\\n'\n")
+
+	var streamed strings.Builder
+	_, output, err := e.ExecFileWithStreamingHook(
+		context.Background(), file, verifiedFileArgv(t, "/bin/sh"), "", "", nil, 30*time.Second, nil,
+		func(content string) { streamed.WriteString(content) },
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "STREAMED\n", output)
+	assert.Equal(t, "STREAMED\n", streamed.String())
+}
+
+func TestExecFileWithStreamingHook_PropagatesExitCode(t *testing.T) {
+	e := NewExecutor()
+	file := openScript(t, filepath.Join(t.TempDir(), "deploy.sh"), "exit 42\n")
+
+	exitCode, _, _ := e.ExecFileWithStreamingHook(
+		context.Background(), file, verifiedFileArgv(t, "/bin/sh"), "", "", nil, 30*time.Second, nil, nil,
+	)
+
+	assert.Equal(t, 42, exitCode)
+}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -200,7 +200,13 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 	// Build the environment for the (possibly demoted) command and expand
 	// any variable references in the arguments using it.
 	env := e.buildEnv(opts.Username, opts.Env)
-	args := e.expandArgs(opts.Args, env)
+	// A verified entrypoint's argv is itself part of the approved instruction,
+	// so it is passed through exactly as given—no expansion here, and no shell
+	// downstream to split words or honor operators.
+	args := opts.Args
+	if opts.ExecFile == nil {
+		args = e.expandArgs(opts.Args, env)
+	}
 
 	// Setup context with timeout if specified
 	if opts.Timeout > 0 {
@@ -220,6 +226,15 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 	// rather than falling back to the service PATH; Windows keeps the standard
 	// resolution.
 	utils.ApplyCommandPath(cmd, args[0], env["PATH"])
+
+	// Hand the already-verified descriptor to the child. os/exec dups
+	// ExtraFiles[i] onto fd 3+i without close-on-exec, so it survives the exec
+	// and args can name it as common.VerifiedFilePath(). Nothing here reopens
+	// the original path, which is what keeps hashed-object and executed-object
+	// the same object.
+	if opts.ExecFile != nil {
+		cmd.ExtraFiles = []*os.File{opts.ExecFile}
+	}
 
 	var cw *chunkWriter
 	if opts.ChunkCallback != nil {
@@ -388,6 +403,13 @@ type CommandOptions struct {
 	WorkingDir string            // Working directory
 	Timeout    time.Duration     // Command timeout
 	Input      string            // Input to provide via stdin
+
+	// ExecFile, when non-nil, is an already-opened and digest-verified
+	// entrypoint. It is inherited by the child at common.VerifiedFileChildFD
+	// and must already be named in Args by common.VerifiedFilePath(). Setting
+	// it also suppresses argument expansion. The caller keeps ownership and
+	// closes it after Execute returns.
+	ExecFile *os.File
 
 	// PIDHook, if non-nil, receives the child's pid after Start so the
 	// shell handler can register it with the PAM tracker before the
@@ -562,6 +584,22 @@ func (e *Executor) ExecWithHook(ctx context.Context, args []string, username, gr
 func (e *Executor) ExecWithStreamingHook(ctx context.Context, args []string, username, groupname string, env map[string]string, timeout time.Duration, pidHook func(pid int), chunkCallback func(content string)) (int, string, error) {
 	return e.Execute(ctx, CommandOptions{
 		Args:          args,
+		Username:      username,
+		Groupname:     groupname,
+		Env:           env,
+		Timeout:       timeout,
+		PIDHook:       pidHook,
+		ChunkCallback: chunkCallback,
+	})
+}
+
+// ExecFileWithStreamingHook is ExecWithStreamingHook for a digest-verified
+// entrypoint: file is inherited by the child and args names it by its
+// descriptor path, so the verified object is the one that runs.
+func (e *Executor) ExecFileWithStreamingHook(ctx context.Context, file *os.File, args []string, username, groupname string, env map[string]string, timeout time.Duration, pidHook func(pid int), chunkCallback func(content string)) (int, string, error) {
+	return e.Execute(ctx, CommandOptions{
+		Args:          args,
+		ExecFile:      file,
 		Username:      username,
 		Groupname:     groupname,
 		Env:           env,

--- a/pkg/executor/handlers/common/args.go
+++ b/pkg/executor/handlers/common/args.go
@@ -1,6 +1,9 @@
 package common
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
 // CommandArgs is a strongly-typed struct for all command arguments
 type CommandArgs struct {
@@ -38,6 +41,15 @@ type CommandArgs struct {
 	AllowOverwrite bool
 	AllowUnzip     bool
 	UseBlob        bool
+
+	// Verified file execution (shell type "file", ADR 0053).
+	// VerifiedFile is an open descriptor whose sha256 already matched the
+	// approved digest. The child inherits that descriptor and ExecArgs names
+	// it by its descriptor path, so the object that was verified is the object
+	// that runs—nothing between the check and the exec resolves the path
+	// again. The runner owns the descriptor and closes it after execution.
+	VerifiedFile *os.File
+	ExecArgs     []string
 
 	// Terminal operations
 	Rows  uint16

--- a/pkg/executor/handlers/common/interfaces.go
+++ b/pkg/executor/handlers/common/interfaces.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"io"
+	"os"
 	"time"
 )
 
@@ -55,6 +56,15 @@ type CommandExecutor interface {
 	// receives streamed stdout/stderr chunks. Sequencing is the caller's
 	// responsibility.
 	ExecWithStreamingHook(ctx context.Context, args []string, username, groupname string, env map[string]string, timeout time.Duration, pidHook func(pid int), chunkCallback func(content string)) (int, string, error)
+
+	// ExecFileWithStreamingHook is ExecWithStreamingHook for a digest-verified
+	// entrypoint. file is handed to the child as an inherited descriptor at
+	// VerifiedFileChildFD, and args must already name it by VerifiedFilePath()
+	// rather than by its original path, so the bytes that were hashed are the
+	// bytes that run. args is passed through literally: no environment
+	// expansion, and no shell to split words or honor operators. The caller
+	// retains ownership of file and closes it once this returns.
+	ExecFileWithStreamingHook(ctx context.Context, file *os.File, args []string, username, groupname string, env map[string]string, timeout time.Duration, pidHook func(pid int), chunkCallback func(content string)) (int, string, error)
 }
 
 // WSClient interface for WebSocket client operations

--- a/pkg/executor/handlers/common/testing.go
+++ b/pkg/executor/handlers/common/testing.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"os"
 	"os/user"
 	"strings"
 	"sync/atomic"
@@ -32,6 +33,9 @@ type ExecutedCommand struct {
 	User    string
 	Env     map[string]string
 	Timeout time.Duration
+	// File is the inherited descriptor for a verified file execution, so
+	// tests can assert which open object was handed to the child.
+	File *os.File
 }
 
 // CommandResult represents the result of a mocked command execution.
@@ -116,6 +120,27 @@ func (m *MockCommandExecutor) ExecWithStreamingHook(ctx context.Context, args []
 		pidHook(pid)
 	}
 	exitCode, output, err := m.Exec(ctx, args, username, groupname, env, timeout)
+	if chunkCallback != nil && output != "" {
+		chunkCallback(output)
+	}
+	return exitCode, output, err
+}
+
+// ExecFileWithStreamingHook mirrors ExecWithStreamingHook and additionally
+// records the inherited descriptor, so tests can assert that the object handed
+// to the child is the one the verifier opened.
+func (m *MockCommandExecutor) ExecFileWithStreamingHook(ctx context.Context, file *os.File, args []string, username, groupname string, env map[string]string, timeout time.Duration, pidHook func(pid int), chunkCallback func(content string)) (int, string, error) {
+	if len(args) == 0 {
+		return 0, "", nil
+	}
+	if pidHook != nil {
+		pid := int(mockSyntheticPIDBase + mockSyntheticPID.Add(1))
+		pidHook(pid)
+	}
+	m.commands = append(m.commands, ExecutedCommand{
+		Name: args[0], Args: args[1:], User: username, Env: env, Timeout: timeout, File: file,
+	})
+	exitCode, output, err := m.lookupResult(args[0], args[1:]...)
 	if chunkCallback != nil && output != "" {
 		chunkCallback(output)
 	}

--- a/pkg/executor/handlers/common/types.go
+++ b/pkg/executor/handlers/common/types.go
@@ -43,6 +43,8 @@ const (
 	// Shell commands
 	ShellCmd CommandType = "shell"
 	Exec     CommandType = "exec"
+	// ExecFile runs a digest-verified entrypoint (shell type "file").
+	ExecFile CommandType = "execfile"
 
 	// User commands
 	AddUser CommandType = "adduser"

--- a/pkg/executor/handlers/common/verified_file.go
+++ b/pkg/executor/handlers/common/verified_file.go
@@ -1,0 +1,6 @@
+package common
+
+// VerifiedFileChildFD is the descriptor number a digest-verified entrypoint
+// lands on in the child process. os/exec maps ExtraFiles[i] to fd 3+i and the
+// file execution path passes exactly one file, so it is always 3.
+const VerifiedFileChildFD = 3

--- a/pkg/executor/handlers/common/verified_file_darwin.go
+++ b/pkg/executor/handlers/common/verified_file_darwin.go
@@ -1,0 +1,15 @@
+package common
+
+import "fmt"
+
+// VerifiedFilePath returns the child-visible path naming the inherited,
+// digest-verified descriptor.
+//
+// macOS has no /proc, but opening /dev/fd/N duplicates the descriptor rather
+// than resolving the original path again, which preserves the same property:
+// a file swapped in at the path after verification is not what runs. The
+// duplicate shares the descriptor's offset, which is why the verifier rewinds
+// it after hashing.
+func VerifiedFilePath() (string, error) {
+	return fmt.Sprintf("/dev/fd/%d", VerifiedFileChildFD), nil
+}

--- a/pkg/executor/handlers/common/verified_file_darwin.go
+++ b/pkg/executor/handlers/common/verified_file_darwin.go
@@ -5,11 +5,19 @@ import "fmt"
 // VerifiedFilePath returns the child-visible path naming the inherited,
 // digest-verified descriptor.
 //
-// macOS has no /proc, but opening /dev/fd/N duplicates the descriptor rather
-// than resolving the original path again, which preserves the same property:
-// a file swapped in at the path after verification is not what runs. The
-// duplicate shares the descriptor's offset, which is why the verifier rewinds
-// it after hashing.
+// The descriptor does not refer to the file on disk. It refers to the unlinked
+// copy the agent made once the digest matched, and macOS resolves /dev/fd/N by
+// duplicating the descriptor rather than by walking a path, so neither
+// replacing the original nor rewriting it in place changes what the child
+// reads. The duplicate shares the descriptor's offset, which is why the
+// verifier rewinds it after hashing.
+//
+// Two consequences are deliberate. The copy belongs to the agent, so the
+// source file's mode no longer gates who may run it—see the Linux counterpart
+// for why that trade is the intended one. And because /dev/fd duplicates the
+// descriptor's access mode, the child can write to the copy through its own
+// descriptor; runner.sealFile documents why that residue is narrower than the
+// window the copy closes.
 func VerifiedFilePath() (string, error) {
 	return fmt.Sprintf("/dev/fd/%d", VerifiedFileChildFD), nil
 }

--- a/pkg/executor/handlers/common/verified_file_linux.go
+++ b/pkg/executor/handlers/common/verified_file_linux.go
@@ -5,14 +5,20 @@ import "fmt"
 // VerifiedFilePath returns the child-visible path naming the inherited,
 // digest-verified descriptor.
 //
-// Opening /proc/self/fd/N reopens the very inode the descriptor holds instead
-// of resolving the original path a second time. That is the whole point: a
-// file swapped in at the path after verification is a different inode, so it
-// cannot be substituted for the bytes that were hashed.
+// The descriptor does not refer to the file on disk. It refers to the sealed
+// anonymous copy the agent made once the digest matched, so opening
+// /proc/self/fd/N reopens that copy: an object with no name for the requester
+// to replace, and sealed against writes even through the descriptors that
+// already exist. Neither replacing the original path nor rewriting it in place
+// changes what the child reads.
 //
-// The reopen re-checks permissions against that inode, so the entrypoint must
-// be readable by the user the command runs as. A file the target user cannot
-// read fails the reopen outright rather than running something else.
+// One consequence is deliberate and worth stating plainly, because it changes
+// existing behavior: the copy belongs to the agent, so the kernel's permission
+// check on reopen is against the copy rather than against the source file's
+// mode. A script only root can read therefore becomes executable as a demoted
+// account, which was not true while the descriptor pointed at the original
+// inode. That is the intended trade—the approval is the authorization on this
+// lane, and the approver saw the content and named the account it runs as.
 func VerifiedFilePath() (string, error) {
 	return fmt.Sprintf("/proc/self/fd/%d", VerifiedFileChildFD), nil
 }

--- a/pkg/executor/handlers/common/verified_file_linux.go
+++ b/pkg/executor/handlers/common/verified_file_linux.go
@@ -1,0 +1,18 @@
+package common
+
+import "fmt"
+
+// VerifiedFilePath returns the child-visible path naming the inherited,
+// digest-verified descriptor.
+//
+// Opening /proc/self/fd/N reopens the very inode the descriptor holds instead
+// of resolving the original path a second time. That is the whole point: a
+// file swapped in at the path after verification is a different inode, so it
+// cannot be substituted for the bytes that were hashed.
+//
+// The reopen re-checks permissions against that inode, so the entrypoint must
+// be readable by the user the command runs as. A file the target user cannot
+// read fails the reopen outright rather than running something else.
+func VerifiedFilePath() (string, error) {
+	return fmt.Sprintf("/proc/self/fd/%d", VerifiedFileChildFD), nil
+}

--- a/pkg/executor/handlers/common/verified_file_other.go
+++ b/pkg/executor/handlers/common/verified_file_other.go
@@ -1,0 +1,18 @@
+//go:build !linux && !darwin
+
+package common
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// VerifiedFilePath declines on platforms with no path form that reopens the
+// descriptor itself.
+//
+// Naming the original path instead would let the file be swapped between the
+// digest check and the exec, which is exactly the attack the digest exists to
+// close, so the handler refuses rather than running unverified bytes.
+func VerifiedFilePath() (string, error) {
+	return "", fmt.Errorf("file execution is not supported on %s: no path form reopens the verified descriptor", runtime.GOOS)
+}

--- a/pkg/executor/handlers/shell/exec_file_test.go
+++ b/pkg/executor/handlers/shell/exec_file_test.go
@@ -1,0 +1,86 @@
+package shell
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openTempFile stands in for the descriptor the runner opens and verifies
+// before dispatch.
+func openTempFile(t *testing.T) *os.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "deploy.sh")
+	require.NoError(t, os.WriteFile(path, []byte("printf 'ok\\n'\n"), 0o700))
+	file, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+	return file
+}
+
+func TestShellHandler_ExecFile_ForwardsDescriptorAndArgs(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	handler := NewShellHandler(mockExec)
+	file := openTempFile(t)
+	execArgs := []string{"/bin/bash", "/proc/self/fd/3", "--fast", "a b"}
+
+	exitCode, _, err := handler.Execute(context.Background(), common.ExecFile.String(), &common.CommandArgs{
+		VerifiedFile: file,
+		ExecArgs:     execArgs,
+		Username:     "deploy",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	executed := mockExec.GetExecutedCommands()
+	require.Len(t, executed, 1)
+	assert.Same(t, file, executed[0].File, "the child must inherit the verified descriptor itself")
+	assert.Equal(t, execArgs[0], executed[0].Name)
+	assert.Equal(t, execArgs[1:], executed[0].Args)
+	assert.Equal(t, "deploy", executed[0].User)
+	assert.Equal(t, common.ShellTimeout, executed[0].Timeout)
+}
+
+// Validation is the last guard before exec: without a descriptor there is
+// nothing verified to run, so the handler must refuse rather than fall through
+// to some path-shaped argument.
+func TestShellHandler_ExecFile_ValidateRequiresDescriptorAndArgs(t *testing.T) {
+	handler := NewShellHandler(common.NewMockCommandExecutor(t))
+
+	tests := []struct {
+		name string
+		args *common.CommandArgs
+	}{
+		{
+			name: "no descriptor",
+			args: &common.CommandArgs{ExecArgs: []string{"/bin/bash", "/proc/self/fd/3"}},
+		},
+		{
+			name: "no argv",
+			args: &common.CommandArgs{VerifiedFile: openTempFile(t)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Error(t, handler.Validate(common.ExecFile.String(), tt.args))
+		})
+	}
+}
+
+func TestShellHandler_ExecFile_ValidateAcceptsCompleteArgs(t *testing.T) {
+	handler := NewShellHandler(common.NewMockCommandExecutor(t))
+
+	err := handler.Validate(common.ExecFile.String(), &common.CommandArgs{
+		VerifiedFile: openTempFile(t),
+		ExecArgs:     []string{"/bin/bash", "/proc/self/fd/3"},
+	})
+
+	assert.NoError(t, err)
+}

--- a/pkg/executor/handlers/shell/shell.go
+++ b/pkg/executor/handlers/shell/shell.go
@@ -26,6 +26,7 @@ func NewShellHandler(cmdExecutor common.CommandExecutor) *ShellHandler {
 			[]common.CommandType{
 				common.ShellCmd,
 				common.Exec,
+				common.ExecFile,
 			},
 			cmdExecutor,
 		),
@@ -38,6 +39,8 @@ func (h *ShellHandler) Execute(ctx context.Context, cmd string, args *common.Com
 	switch cmd {
 	case common.ShellCmd.String(), common.Exec.String():
 		return h.handleShellCommand(ctx, args)
+	case common.ExecFile.String():
+		return h.handleExecFile(ctx, args)
 	default:
 		return 1, "", fmt.Errorf("unknown shell command: %s", cmd)
 	}
@@ -45,6 +48,15 @@ func (h *ShellHandler) Execute(ctx context.Context, cmd string, args *common.Com
 
 // Validate checks if the arguments are valid for the command
 func (h *ShellHandler) Validate(cmd string, args *common.CommandArgs) error {
+	if cmd == common.ExecFile.String() {
+		if args.VerifiedFile == nil {
+			return fmt.Errorf("verified file descriptor is required")
+		}
+		if len(args.ExecArgs) == 0 {
+			return fmt.Errorf("file execution arguments are required")
+		}
+		return nil
+	}
 	if args.Command == "" {
 		return fmt.Errorf("shell command is required")
 	}
@@ -97,6 +109,52 @@ func (h *ShellHandler) handleShellCommand(ctx context.Context, args *common.Comm
 
 	// Fallback: direct execution with manual operator parsing
 	return h.executeWithOperators(ctx, command, username, groupname, env, timeout, args.CommandID, args.ChunkCallback)
+}
+
+// handleExecFile runs a digest-verified entrypoint. The digest check happens in
+// the runner before dispatch, so reaching here means the descriptor in
+// args.VerifiedFile already matched the approved sha256; all that is left is
+// handing that same descriptor to the child. args.ExecArgs already names it by
+// its descriptor path, and there is no shell around it.
+func (h *ShellHandler) handleExecFile(ctx context.Context, args *common.CommandArgs) (int, string, error) {
+	username := args.Username
+	if username == "" {
+		username = "root"
+	}
+	groupname := args.Groupname
+	if groupname == "" {
+		groupname = username
+	}
+
+	timeout := args.Timeout
+	if timeout == 0 {
+		timeout = common.ShellTimeout
+	}
+
+	log.Debug().
+		Strs("args", args.ExecArgs).
+		Str("user", username).
+		Str("group", groupname).
+		Dur("timeout", timeout).
+		Msg("Executing verified file")
+
+	var pidHook func(pid int)
+	var cleanup func()
+	if args.CommandID != "" {
+		pidHook = func(pid int) {
+			cleanup = runner.RegisterCommandPID(pid, args.CommandID, username)
+		}
+	}
+
+	// Execute folds startup errors into output, so the err return is dropped
+	// here for the same reason as executeCommand.
+	exitCode, output, _ := h.Executor.ExecFileWithStreamingHook(
+		ctx, args.VerifiedFile, args.ExecArgs, username, groupname, args.Env, timeout, pidHook, args.ChunkCallback,
+	)
+	if cleanup != nil {
+		cleanup()
+	}
+	return exitCode, output, nil
 }
 
 // executeWithOperators handles shell operators (&&, ||, ;). Per-segment output

--- a/pkg/executor/handlers/shell/shell_test.go
+++ b/pkg/executor/handlers/shell/shell_test.go
@@ -27,6 +27,7 @@ func TestShellHandler_Commands(t *testing.T) {
 	expected := []string{
 		common.ShellCmd.String(),
 		common.Exec.String(),
+		common.ExecFile.String(),
 	}
 
 	if len(commands) != len(expected) {

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -131,11 +132,17 @@ func (cr *CommandRunner) Run(ctx context.Context) error {
 		// it for humans. Nothing runs until the file's digest matches.
 		fileArgs, refusal := cr.prepareFileCommand(ctx)
 		if refusal != nil {
-			log.Warn().
+			event := log.Warn().
 				Str("command_id", cr.command.ID).
 				Str("code", refusal.code).
-				Err(refusal.err).
-				Msg("Refused file command")
+				Err(refusal.err)
+			// Only the local log learns what the file hashed to; the result
+			// string the requester reads must not carry it.
+			var mismatch *hashMismatchError
+			if errors.As(refusal.err, &mismatch) {
+				event = event.Str("observed_digest", mismatch.Observed())
+			}
+			event.Msg("Refused file command")
 			exitCode = 1
 			result = refusal.String()
 			return nil

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -44,6 +44,28 @@ func NewCommandRunner(wsClient *WebsocketClient, apiSession *scheduler.Session, 
 	}
 }
 
+// newChunkCallback returns the streaming callback for this command, or nil when
+// there is no command ID to stream against.
+func (cr *CommandRunner) newChunkCallback(ctx context.Context) func(content string) {
+	if cr.command.ID == "" {
+		return nil
+	}
+
+	chunkURL := fmt.Sprintf(eventCommandChunkURL, cr.command.ID)
+	// Runner owns seq so chunks across shell operators share one series.
+	var seq int
+	return func(content string) {
+		// Advance seq before Post so it stays monotonic even if Post
+		// panics; a reused seq would collide server-side on (command, seq).
+		s := seq
+		seq++
+		scheduler.Rqueue.PostChunk(ctx, chunkURL, &protocol.CommandChunk{
+			Seq:     s,
+			Content: content,
+		}, 10)
+	}
+}
+
 func (cr *CommandRunner) Run(ctx context.Context) error {
 	var exitCode int
 	var result string
@@ -94,33 +116,33 @@ func (cr *CommandRunner) Run(ctx context.Context) error {
 			args.CommandID = cr.command.ID
 		}
 	case "system":
-		commandID := cr.command.ID
-		var chunkCallback func(content string)
-		if commandID != "" {
-			chunkURL := fmt.Sprintf(eventCommandChunkURL, commandID)
-			// Runner owns seq so chunks across shell operators share one series.
-			var seq int
-			chunkCallback = func(content string) {
-				// Advance seq before Post so it stays monotonic even if Post
-				// panics; a reused seq would collide server-side on (command, seq).
-				s := seq
-				seq++
-				scheduler.Rqueue.PostChunk(ctx, chunkURL, &protocol.CommandChunk{
-					Seq:     s,
-					Content: content,
-				}, 10)
-			}
-		}
 		command = common.ShellCmd.String()
 		args = &common.CommandArgs{
-			CommandID:     commandID,
+			CommandID:     cr.command.ID,
 			Command:       cr.command.Line,
 			Username:      cr.command.User,
 			Groupname:     cr.command.Group,
 			Env:           cr.command.Env,
 			AllowSh:       cr.command.AllowSh,
-			ChunkCallback: chunkCallback,
+			ChunkCallback: cr.newChunkCallback(ctx),
 		}
+	case "file":
+		// The structured payload in Data is the instruction; Line only renders
+		// it for humans. Nothing runs until the file's digest matches.
+		fileArgs, refusal := cr.prepareFileCommand(ctx)
+		if refusal != nil {
+			log.Warn().
+				Str("command_id", cr.command.ID).
+				Str("code", refusal.code).
+				Err(refusal.err).
+				Msg("Refused file command")
+			exitCode = 1
+			result = refusal.String()
+			return nil
+		}
+		defer func() { _ = fileArgs.VerifiedFile.Close() }()
+		command = common.ExecFile.String()
+		args = fileArgs
 	default:
 		exitCode = 1
 		result = "Invalid command shell argument."

--- a/pkg/runner/file_exec.go
+++ b/pkg/runner/file_exec.go
@@ -54,7 +54,7 @@ type hashMismatchError struct {
 }
 
 func (e *hashMismatchError) Error() string {
-	return fmt.Sprintf("%s (expected sha256:%s)", errHashMismatch, e.expected)
+	return fmt.Sprintf("%v (expected sha256:%s)", errHashMismatch, e.expected)
 }
 
 func (e *hashMismatchError) Unwrap() error { return errHashMismatch }
@@ -106,14 +106,22 @@ func openVerifiedFile(path, expectedDigest string) (*os.File, error) {
 	// is no root to confine it to. What bounds this lane is the digest, checked
 	// below over the sealed copy before anything executes: a path the approver did
 	// not clear yields a mismatch and the command is refused.
-	source, err := os.Open(path) // lgtm[go/path-injection]
+	//
+	// O_NONBLOCK because a read-only open of a FIFO blocks until a writer
+	// appears, and this runs before dispatcher.Execute — so no ShellTimeout
+	// deadline covers it. A requester can mkfifo a path in its own account and
+	// park the runner goroutine forever, leaking a goroutine and a descriptor
+	// per attempt with nothing to bound it. The flag is a no-op on regular
+	// files, which is the only kind this proceeds with anyway.
+	source, err := openEntrypoint(path) // lgtm[go/path-injection]
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = source.Close() }()
 
-	// Refuse anything but a regular file: a fifo or a device says nothing
-	// about what a later read would produce.
+	// Refuse anything but a regular file, on the descriptor rather than the
+	// path: a fifo or a device says nothing about what a later read would
+	// produce, and re-stating the path here would reintroduce a lookup.
 	info, err := source.Stat()
 	if err != nil {
 		return nil, err

--- a/pkg/runner/file_exec.go
+++ b/pkg/runner/file_exec.go
@@ -99,21 +99,7 @@ func (r *fileRefusal) String() string {
 // On any failure the copy is closed before returning: no descriptor carrying
 // unverified bytes reaches a caller.
 func openVerifiedFile(path, expectedDigest string) (*os.File, error) {
-	// codeql[go/path-injection]: Intentional - the path names a file the operator
-	// asked to run on their own host, sent by the trusted Alpacon console over the
-	// same authenticated channel that already carries arbitrary command lines
-	// (the `system` shell), so the path is not a privilege boundary here and there
-	// is no root to confine it to. What bounds this lane is the digest, checked
-	// below over the sealed copy before anything executes: a path the approver did
-	// not clear yields a mismatch and the command is refused.
-	//
-	// O_NONBLOCK because a read-only open of a FIFO blocks until a writer
-	// appears, and this runs before dispatcher.Execute — so no ShellTimeout
-	// deadline covers it. A requester can mkfifo a path in its own account and
-	// park the runner goroutine forever, leaking a goroutine and a descriptor
-	// per attempt with nothing to bound it. The flag is a no-op on regular
-	// files, which is the only kind this proceeds with anyway.
-	source, err := openEntrypoint(path) // lgtm[go/path-injection]
+	source, err := openEntrypoint(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runner/file_exec.go
+++ b/pkg/runner/file_exec.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
+)
+
+// Refusal codes for a "file" shell command that never ran. They are a closed
+// set of fixed strings so the console can tell a refusal apart from a script
+// that merely exited non-zero, and so a refusal reads the same in every
+// deployment.
+const (
+	// FileHashMismatchCode marks the digest check failing: the file behind the
+	// path is not the file the approval covers. Never a reason to fall back to
+	// running it.
+	FileHashMismatchCode = "FILE_HASH_MISMATCH"
+	// FilePayloadInvalidCode marks a malformed or incomplete instruction.
+	FilePayloadInvalidCode = "FILE_PAYLOAD_INVALID"
+	// FileOpenFailedCode marks an entrypoint that could not be opened, stated
+	// or read—including one that is not a regular file.
+	FileOpenFailedCode = "FILE_OPEN_FAILED"
+	// FileExecUnsupportedCode marks a platform with no path form that reopens
+	// the verified descriptor.
+	FileExecUnsupportedCode = "FILE_EXEC_UNSUPPORTED"
+)
+
+// errHashMismatch is the sentinel behind FileHashMismatchCode.
+var errHashMismatch = errors.New("file digest does not match the approved digest")
+
+// fileRefusal is a file command that must be reported instead of executed.
+type fileRefusal struct {
+	code string
+	err  error
+}
+
+// String renders the refusal for the command result, code first so the server
+// can match on it without parsing the diagnostic that follows.
+func (r *fileRefusal) String() string {
+	return fmt.Sprintf("%s: %s", r.code, r.err)
+}
+
+// openVerifiedFile opens path once, hashes the descriptor it got back, and
+// returns that same descriptor for execution.
+//
+// The single open is the whole guarantee. Hashing a path and then reopening it
+// to execute leaves a window in which the file can be swapped between the
+// check and the use, which is precisely what the digest exists to close, so
+// this never touches the path again after os.Open. On mismatch it returns
+// errHashMismatch with the descriptor already closed: there is no path on
+// which unverified bytes reach a caller.
+func openVerifiedFile(path, expectedDigest string) (*os.File, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Refuse anything but a regular file: hashing a fifo or a device says
+	// nothing about what a later read would produce.
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if actual := hex.EncodeToString(digest.Sum(nil)); actual != expectedDigest {
+		_ = file.Close()
+		return nil, fmt.Errorf("%w (expected sha256:%s, read sha256:%s)", errHashMismatch, expectedDigest, actual)
+	}
+
+	// Hashing consumed the offset. Rewind the same descriptor rather than
+	// reopening: on macOS the child's /dev/fd/N shares this offset, and on
+	// Linux nothing should depend on where the agent happened to leave it.
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// prepareFileCommand turns a "file" shell command into execution arguments,
+// or refuses.
+//
+// Verification runs here on every execution. A server-side approval is not a
+// substitute: the control plane never sees the file, so only the agent can
+// tell whether the bytes on disk are still the approved ones. A non-nil
+// refusal means nothing may be executed.
+//
+// On success the caller owns args.VerifiedFile and must close it.
+func (cr *CommandRunner) prepareFileCommand(ctx context.Context) (*common.CommandArgs, *fileRefusal) {
+	// Resolve the descriptor path first: on a platform that cannot name an
+	// inherited descriptor there is no point opening anything.
+	fdPath, err := common.VerifiedFilePath()
+	if err != nil {
+		return nil, &fileRefusal{code: FileExecUnsupportedCode, err: err}
+	}
+
+	payload, err := cr.command.ParseFileExecPayload()
+	if err != nil {
+		return nil, &fileRefusal{code: FilePayloadInvalidCode, err: err}
+	}
+
+	file, err := openVerifiedFile(payload.Path, payload.ExpectedDigest())
+	if err != nil {
+		code := FileOpenFailedCode
+		if errors.Is(err, errHashMismatch) {
+			code = FileHashMismatchCode
+		}
+		return nil, &fileRefusal{code: code, err: err}
+	}
+
+	// The argv is built from the structured payload alone. cr.command.Line is
+	// a human rendering of the same intent and is never parsed to decide what
+	// runs. Each payload argument becomes one argv entry, so nothing in it is
+	// split, globbed, or read as an operator.
+	execArgs := make([]string, 0, len(payload.Args)+2)
+	execArgs = append(execArgs, payload.Interpreter, fdPath)
+	execArgs = append(execArgs, payload.Args...)
+
+	return &common.CommandArgs{
+		CommandID:     cr.command.ID,
+		Username:      cr.command.User,
+		Groupname:     cr.command.Group,
+		Env:           cr.command.Env,
+		VerifiedFile:  file,
+		ExecArgs:      execArgs,
+		ChunkCallback: cr.newChunkCallback(ctx),
+	}, nil
+}

--- a/pkg/runner/file_exec.go
+++ b/pkg/runner/file_exec.go
@@ -82,7 +82,14 @@ func (r *fileRefusal) String() string {
 // On any failure the copy is closed before returning: no descriptor carrying
 // unverified bytes reaches a caller.
 func openVerifiedFile(path, expectedDigest string) (*os.File, error) {
-	source, err := os.Open(path)
+	// codeql[go/path-injection]: Intentional - the path names a file the operator
+	// asked to run on their own host, sent by the trusted Alpacon console over the
+	// same authenticated channel that already carries arbitrary command lines
+	// (the `system` shell), so the path is not a privilege boundary here and there
+	// is no root to confine it to. What bounds this lane is the digest, checked
+	// below over the sealed copy before anything executes: a path the approver did
+	// not clear yields a mismatch and the command is refused.
+	source, err := os.Open(path) // lgtm[go/path-injection]
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runner/file_exec.go
+++ b/pkg/runner/file_exec.go
@@ -26,13 +26,28 @@ const (
 	// FileOpenFailedCode marks an entrypoint that could not be opened, stated
 	// or read—including one that is not a regular file.
 	FileOpenFailedCode = "FILE_OPEN_FAILED"
-	// FileExecUnsupportedCode marks a platform with no path form that reopens
-	// the verified descriptor.
+	// FileExecUnsupportedCode marks a platform that cannot execute a file
+	// command without leaving the requester a way to change what runs.
 	FileExecUnsupportedCode = "FILE_EXEC_UNSUPPORTED"
+	// FileTooLargeCode marks an entrypoint past the size the agent will copy.
+	FileTooLargeCode = "FILE_TOO_LARGE"
 )
+
+// maxVerifiedFileSize bounds the entrypoint the agent is willing to copy.
+//
+// alpacon-server caps submitted content at 64 KiB, but the agent must not
+// trust a bound it cannot see: it reads from disk, where the file is whatever
+// the requester last made it, and it now holds those bytes in memory. 1 MiB is
+// sixteen times the server's cap, so no legitimate script comes near it, while
+// keeping a single command's copy small enough that a burst of them cannot
+// exhaust the agent.
+const maxVerifiedFileSize = 1 << 20
 
 // errHashMismatch is the sentinel behind FileHashMismatchCode.
 var errHashMismatch = errors.New("file digest does not match the approved digest")
+
+// errFileTooLarge is the sentinel behind FileTooLargeCode.
+var errFileTooLarge = errors.New("file is larger than the agent will execute")
 
 // fileRefusal is a file command that must be reported instead of executed.
 type fileRefusal struct {
@@ -46,52 +61,102 @@ func (r *fileRefusal) String() string {
 	return fmt.Sprintf("%s: %s", r.code, r.err)
 }
 
-// openVerifiedFile opens path once, hashes the descriptor it got back, and
-// returns that same descriptor for execution.
+// openVerifiedFile reads path once into a sealed copy the requester cannot
+// reach, hashes that copy, and returns it for execution.
 //
-// The single open is the whole guarantee. Hashing a path and then reopening it
-// to execute leaves a window in which the file can be swapped between the
-// check and the use, which is precisely what the digest exists to close, so
-// this never touches the path again after os.Open. On mismatch it returns
-// errHashMismatch with the descriptor already closed: there is no path on
-// which unverified bytes reach a caller.
+// Executing the on-disk inode is not enough, even through a descriptor opened
+// before the check. The principal this lane constrains is the requester, and
+// the requester owns the file it submitted: it can rewrite those very bytes in
+// place, through its own handle, in the window between the digest matching and
+// the interpreter reading. That needs no compromise of anything—only a retry
+// until the timing lands—so "the bytes approved are the bytes run" would be
+// false against exactly the party the approval binds.
+//
+// Copying into a sealed object removes the window. Once sealFile returns, the
+// copy is immutable (Linux) or nameless (macOS), so no write the requester can
+// issue reaches the bytes that run. The digest is then computed over the
+// sealed copy rather than over the source, so what is hashed is literally what
+// executes: by that point nothing can change it, and a source rewritten
+// mid-copy yields a digest that does not match and a command that is refused.
+//
+// On any failure the copy is closed before returning: no descriptor carrying
+// unverified bytes reaches a caller.
 func openVerifiedFile(path, expectedDigest string) (*os.File, error) {
-	file, err := os.Open(path)
+	source, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = source.Close() }()
 
-	// Refuse anything but a regular file: hashing a fifo or a device says
-	// nothing about what a later read would produce.
-	info, err := file.Stat()
+	// Refuse anything but a regular file: a fifo or a device says nothing
+	// about what a later read would produce.
+	info, err := source.Stat()
 	if err != nil {
-		_ = file.Close()
 		return nil, err
 	}
 	if !info.Mode().IsRegular() {
-		_ = file.Close()
 		return nil, fmt.Errorf("%s is not a regular file", path)
 	}
 
+	sealed, err := newSealedFile()
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the source exactly once, straight into the copy. Reading it a
+	// second time would invite the two reads to disagree, which is the race
+	// this function exists to remove. The limit runs one byte past the cap so
+	// a file sitting exactly on it is still accepted.
+	copied, err := io.Copy(sealed, io.LimitReader(source, maxVerifiedFileSize+1))
+	if err != nil {
+		_ = sealed.Close()
+		return nil, err
+	}
+	if copied > maxVerifiedFileSize {
+		_ = sealed.Close()
+		return nil, fmt.Errorf("%w (over %d bytes)", errFileTooLarge, maxVerifiedFileSize)
+	}
+
+	if err := sealFile(sealed); err != nil {
+		_ = sealed.Close()
+		return nil, err
+	}
+
+	digest, err := digestOfSealedFile(sealed)
+	if err != nil {
+		_ = sealed.Close()
+		return nil, err
+	}
+	if digest != expectedDigest {
+		_ = sealed.Close()
+		return nil, fmt.Errorf("%w (expected sha256:%s, read sha256:%s)", errHashMismatch, expectedDigest, digest)
+	}
+
+	// Hashing consumed the offset. Rewind so the child reads from the start:
+	// on macOS its /dev/fd/N shares this offset, and on Linux nothing should
+	// depend on where the agent happened to leave it.
+	if _, err := sealed.Seek(0, io.SeekStart); err != nil {
+		_ = sealed.Close()
+		return nil, err
+	}
+
+	return sealed, nil
+}
+
+// digestOfSealedFile hashes the sealed copy from the start. It runs after
+// sealFile so the bytes it reads are already immutable, which is what lets the
+// digest speak for the bytes that will run rather than for a snapshot of them.
+func digestOfSealedFile(sealed *os.File) (string, error) {
+	if _, err := sealed.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+
 	digest := sha256.New()
-	if _, err := io.Copy(digest, file); err != nil {
-		_ = file.Close()
-		return nil, err
-	}
-	if actual := hex.EncodeToString(digest.Sum(nil)); actual != expectedDigest {
-		_ = file.Close()
-		return nil, fmt.Errorf("%w (expected sha256:%s, read sha256:%s)", errHashMismatch, expectedDigest, actual)
+	if _, err := io.Copy(digest, sealed); err != nil {
+		return "", err
 	}
 
-	// Hashing consumed the offset. Rewind the same descriptor rather than
-	// reopening: on macOS the child's /dev/fd/N shares this offset, and on
-	// Linux nothing should depend on where the agent happened to leave it.
-	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		_ = file.Close()
-		return nil, err
-	}
-
-	return file, nil
+	return hex.EncodeToString(digest.Sum(nil)), nil
 }
 
 // prepareFileCommand turns a "file" shell command into execution arguments,
@@ -99,8 +164,8 @@ func openVerifiedFile(path, expectedDigest string) (*os.File, error) {
 //
 // Verification runs here on every execution. A server-side approval is not a
 // substitute: the control plane never sees the file, so only the agent can
-// tell whether the bytes on disk are still the approved ones. A non-nil
-// refusal means nothing may be executed.
+// tell what is actually on disk at the moment of execution. A non-nil refusal
+// means nothing may be executed.
 //
 // On success the caller owns args.VerifiedFile and must close it.
 func (cr *CommandRunner) prepareFileCommand(ctx context.Context) (*common.CommandArgs, *fileRefusal) {
@@ -119,8 +184,13 @@ func (cr *CommandRunner) prepareFileCommand(ctx context.Context) (*common.Comman
 	file, err := openVerifiedFile(payload.Path, payload.ExpectedDigest())
 	if err != nil {
 		code := FileOpenFailedCode
-		if errors.Is(err, errHashMismatch) {
+		switch {
+		case errors.Is(err, errHashMismatch):
 			code = FileHashMismatchCode
+		case errors.Is(err, errFileTooLarge):
+			code = FileTooLargeCode
+		case errors.Is(err, errSealUnavailable):
+			code = FileExecUnsupportedCode
 		}
 		return nil, &fileRefusal{code: code, err: err}
 	}

--- a/pkg/runner/file_exec.go
+++ b/pkg/runner/file_exec.go
@@ -46,6 +46,23 @@ const maxVerifiedFileSize = 1 << 20
 // errHashMismatch is the sentinel behind FileHashMismatchCode.
 var errHashMismatch = errors.New("file digest does not match the approved digest")
 
+// hashMismatchError carries the observed digest for the local log while keeping
+// it out of Error(), which is reported to the requester verbatim.
+type hashMismatchError struct {
+	expected string
+	observed string
+}
+
+func (e *hashMismatchError) Error() string {
+	return fmt.Sprintf("%s (expected sha256:%s)", errHashMismatch, e.expected)
+}
+
+func (e *hashMismatchError) Unwrap() error { return errHashMismatch }
+
+// Observed is the digest the file actually hashed to. Log-only: see the
+// construction site for why it must never reach the command result.
+func (e *hashMismatchError) Observed() string { return e.observed }
+
 // errFileTooLarge is the sentinel behind FileTooLargeCode.
 var errFileTooLarge = errors.New("file is larger than the agent will execute")
 
@@ -136,7 +153,16 @@ func openVerifiedFile(path, expectedDigest string) (*os.File, error) {
 	}
 	if digest != expectedDigest {
 		_ = sealed.Close()
-		return nil, fmt.Errorf("%w (expected sha256:%s, read sha256:%s)", errHashMismatch, expectedDigest, digest)
+		// The observed digest is deliberately absent from the error. The
+		// error text is reported back to the requester as the command result,
+		// and the requester chose this path: returning what the file hashed to
+		// would turn a refusal into "tell me the sha256 of any file on this
+		// host, read as root". The assessor judges the submitted *content*, so
+		// a benign script paired with /etc/shadow auto-approves and the refusal
+		// itself becomes the disclosure. Only the expected digest — which the
+		// requester supplied — may be echoed. The real value goes to the local
+		// log below, where the operator can see it and the requester cannot.
+		return nil, &hashMismatchError{expected: expectedDigest, observed: digest}
 	}
 
 	// Hashing consumed the offset. Rewind so the child reads from the start:

--- a/pkg/runner/file_exec_test.go
+++ b/pkg/runner/file_exec_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -79,6 +80,8 @@ func (d *fakeDispatcher) Execute(_ context.Context, command string, args *common
 func (d *fakeDispatcher) HasHandler(string) bool { return true }
 
 func TestOpenVerifiedFile_DigestMatchReturnsRewoundDescriptor(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
 	content := []byte("#!/bin/sh\necho original\n")
 	path := writeScript(t, content)
 
@@ -88,13 +91,15 @@ func TestOpenVerifiedFile_DigestMatchReturnsRewoundDescriptor(t *testing.T) {
 	t.Cleanup(func() { _ = file.Close() })
 
 	// Hashing consumed the offset; the descriptor handed to the child must
-	// start at the beginning of the file.
+	// start at the beginning of the copy.
 	read, err := io.ReadAll(file)
 	require.NoError(t, err)
 	assert.Equal(t, content, read)
 }
 
 func TestOpenVerifiedFile_DigestMismatchRefuses(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
 	path := writeScript(t, []byte("#!/bin/sh\necho original\n"))
 
 	file, err := openVerifiedFile(path, hexDigest([]byte("something else")))
@@ -121,6 +126,86 @@ func TestOpenVerifiedFile_NonRegularFileRefused(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, file)
+}
+
+func TestOpenVerifiedFile_ExactlyAtSizeCapAccepted(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	content := bytes.Repeat([]byte("a"), maxVerifiedFileSize)
+	path := writeScript(t, content)
+
+	file, err := openVerifiedFile(path, hexDigest(content))
+
+	require.NoError(t, err, "a file sitting exactly on the cap must still run")
+	t.Cleanup(func() { _ = file.Close() })
+}
+
+func TestOpenVerifiedFile_OverSizeCapRefused(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	// The agent holds the copy in memory and reads from disk, where the file
+	// is whatever the requester made it—the server's own 64 KiB cap is not
+	// something the agent can see or rely on.
+	content := bytes.Repeat([]byte("a"), maxVerifiedFileSize+1)
+	path := writeScript(t, content)
+
+	file, err := openVerifiedFile(path, hexDigest(content))
+
+	require.Error(t, err)
+	assert.Nil(t, file)
+	assert.ErrorIs(t, err, errFileTooLarge)
+	assert.NotErrorIs(t, err, errHashMismatch, "an oversize file is not a mismatch")
+}
+
+// TestOpenVerifiedFile_InPlaceRewriteKeepsOriginalBytes is the case the sealed
+// copy exists for.
+//
+// The requester owns the file it submitted, so it needs no compromise of
+// anything to rewrite those bytes in place—same inode, same path, same
+// descriptor the agent verified—in the window before the interpreter reads
+// them. An implementation that executes the on-disk inode, even through a
+// descriptor opened before hashing, runs the rewritten bytes and fails here.
+func TestOpenVerifiedFile_InPlaceRewriteKeepsOriginalBytes(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	// Equal lengths so the rewrite lands over the whole file without
+	// truncating, the way dd conv=notrunc would.
+	original := []byte("#!/bin/sh\necho original!\n")
+	rewritten := []byte("#!/bin/sh\necho rewrite!!\n")
+	require.Len(t, rewritten, len(original))
+
+	path := writeScript(t, original)
+	file, err := openVerifiedFile(path, hexDigest(original))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+
+	rewriteInPlace(t, path, rewritten)
+
+	onDisk, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, rewritten, onDisk,
+		"the in-place rewrite must have landed or this test proves nothing")
+
+	fromDescriptor, err := io.ReadAll(file)
+	require.NoError(t, err)
+	assert.Equal(t, original, fromDescriptor,
+		"the verified copy must still yield the bytes that were hashed")
+}
+
+// rewriteInPlace overwrites path's contents through a separate handle without
+// truncating, so the inode, its link and its length are all unchanged. This is
+// the write the requester can always make to its own file.
+func rewriteInPlace(t *testing.T, path string, content []byte) {
+	t.Helper()
+
+	handle, err := os.OpenFile(path, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, handle.Close()) }()
+
+	written, err := handle.WriteAt(content, 0)
+	require.NoError(t, err)
+	require.Equal(t, len(content), written)
+	require.NoError(t, handle.Sync())
 }
 
 // TestOpenVerifiedFile_SwapAfterVerifyKeepsOriginalBytes is the fd invariant.
@@ -241,6 +326,33 @@ func TestPrepareFileCommand_RefusalCodes(t *testing.T) {
 			assert.Equal(t, tt.code, refusal.code)
 		})
 	}
+}
+
+func TestPrepareFileCommand_OverSizeCapRefusesWithItsOwnCode(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	content := bytes.Repeat([]byte("a"), maxVerifiedFileSize+1)
+	path := writeScript(t, content)
+	cr := &CommandRunner{command: fileCommand(t, "cmd-1", path, "/bin/bash", nil, digestOf(content))}
+
+	args, refusal := cr.prepareFileCommand(context.Background())
+
+	assert.Nil(t, args)
+	require.NotNil(t, refusal)
+	assert.Equal(t, FileTooLargeCode, refusal.code)
+}
+
+func TestCommandRunner_Run_FileOverSizeCapNeverDispatches(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	content := bytes.Repeat([]byte("a"), maxVerifiedFileSize+1)
+	path := writeScript(t, content)
+	dispatcher := &fakeDispatcher{}
+	cr := NewCommandRunner(nil, nil, fileCommand(t, "", path, "/bin/bash", nil, digestOf(content)), protocol.CommandData{}, dispatcher)
+
+	require.NoError(t, cr.Run(context.Background()))
+
+	assert.Empty(t, dispatcher.calls, "an oversize entrypoint must never reach execution")
 }
 
 func TestPrepareFileCommand_UnsupportedPlatformDeclinesCleanly(t *testing.T) {

--- a/pkg/runner/file_exec_test.go
+++ b/pkg/runner/file_exec_test.go
@@ -6,11 +6,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/internal/protocol"
@@ -420,42 +418,4 @@ func TestCommandRunner_Run_FileMalformedPayloadNeverDispatches(t *testing.T) {
 func hexDigest(content []byte) string {
 	sum := sha256.Sum256(content)
 	return hex.EncodeToString(sum[:])
-}
-
-// A refusal is reported to the requester as the command result, and the
-// requester chose the path. Returning what the file hashed to would make the
-// refusal itself a disclosure: the assessor judges the submitted content, so a
-// benign script paired with a path like /etc/shadow auto-approves, mismatches,
-// and hands back the digest of a file the requester may not read.
-func TestOpenVerifiedFile_MismatchNeverReportsTheObservedDigest(t *testing.T) {
-	secret := []byte("root-only secret\n")
-	path := filepath.Join(t.TempDir(), "secret")
-	require.NoError(t, os.WriteFile(path, secret, 0o600))
-	observed := fmt.Sprintf("%x", sha256.Sum256(secret))
-	approved := strings.Repeat("b", 64)
-
-	_, err := openVerifiedFile(path, approved)
-
-	require.Error(t, err)
-	require.ErrorIs(t, err, errHashMismatch)
-	assert.NotContains(t, err.Error(), observed,
-		"the refusal must not disclose what the file hashed to")
-	// The expected digest came from the requester, so echoing it tells them
-	// nothing they did not already send.
-	assert.Contains(t, err.Error(), approved)
-}
-
-// The operator still needs the real value to diagnose a genuine mismatch; it
-// travels on the error type for the local log rather than in Error().
-func TestHashMismatchError_CarriesTheObservedDigestForTheLog(t *testing.T) {
-	secret := []byte("root-only secret\n")
-	path := filepath.Join(t.TempDir(), "secret")
-	require.NoError(t, os.WriteFile(path, secret, 0o600))
-	observed := fmt.Sprintf("%x", sha256.Sum256(secret))
-
-	_, err := openVerifiedFile(path, strings.Repeat("b", 64))
-
-	var mismatch *hashMismatchError
-	require.ErrorAs(t, err, &mismatch)
-	assert.Equal(t, observed, mismatch.Observed())
 }

--- a/pkg/runner/file_exec_test.go
+++ b/pkg/runner/file_exec_test.go
@@ -6,9 +6,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/internal/protocol"
@@ -418,4 +420,42 @@ func TestCommandRunner_Run_FileMalformedPayloadNeverDispatches(t *testing.T) {
 func hexDigest(content []byte) string {
 	sum := sha256.Sum256(content)
 	return hex.EncodeToString(sum[:])
+}
+
+// A refusal is reported to the requester as the command result, and the
+// requester chose the path. Returning what the file hashed to would make the
+// refusal itself a disclosure: the assessor judges the submitted content, so a
+// benign script paired with a path like /etc/shadow auto-approves, mismatches,
+// and hands back the digest of a file the requester may not read.
+func TestOpenVerifiedFile_MismatchNeverReportsTheObservedDigest(t *testing.T) {
+	secret := []byte("root-only secret\n")
+	path := filepath.Join(t.TempDir(), "secret")
+	require.NoError(t, os.WriteFile(path, secret, 0o600))
+	observed := fmt.Sprintf("%x", sha256.Sum256(secret))
+	approved := strings.Repeat("b", 64)
+
+	_, err := openVerifiedFile(path, approved)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errHashMismatch)
+	assert.NotContains(t, err.Error(), observed,
+		"the refusal must not disclose what the file hashed to")
+	// The expected digest came from the requester, so echoing it tells them
+	// nothing they did not already send.
+	assert.Contains(t, err.Error(), approved)
+}
+
+// The operator still needs the real value to diagnose a genuine mismatch; it
+// travels on the error type for the local log rather than in Error().
+func TestHashMismatchError_CarriesTheObservedDigestForTheLog(t *testing.T) {
+	secret := []byte("root-only secret\n")
+	path := filepath.Join(t.TempDir(), "secret")
+	require.NoError(t, os.WriteFile(path, secret, 0o600))
+	observed := fmt.Sprintf("%x", sha256.Sum256(secret))
+
+	_, err := openVerifiedFile(path, strings.Repeat("b", 64))
+
+	var mismatch *hashMismatchError
+	require.ErrorAs(t, err, &mismatch)
+	assert.Equal(t, observed, mismatch.Observed())
 }

--- a/pkg/runner/file_exec_test.go
+++ b/pkg/runner/file_exec_test.go
@@ -1,0 +1,309 @@
+package runner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alpacax/alpamon/v2/internal/protocol"
+	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// digestOf renders content's sha256 in the "sha256:<hex>" wire shape.
+func digestOf(content []byte) string {
+	sum := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// writeScript writes content into a temp dir and returns its path.
+func writeScript(t *testing.T, content []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "deploy.sh")
+	require.NoError(t, os.WriteFile(path, content, 0o700))
+	return path
+}
+
+// skipIfNoVerifiedFileExec skips a test on platforms with no path form that
+// reopens an inherited descriptor.
+func skipIfNoVerifiedFileExec(t *testing.T) {
+	t.Helper()
+	if _, err := common.VerifiedFilePath(); err != nil {
+		t.Skipf("verified file execution is unsupported here: %v", err)
+	}
+}
+
+// fileCommand builds a "file" shell command carrying the structured payload.
+func fileCommand(t *testing.T, id, path, interpreter string, args []string, digest string) protocol.Command {
+	t.Helper()
+	data, err := json.Marshal(protocol.FileExecPayload{
+		Path:        path,
+		Interpreter: interpreter,
+		Args:        args,
+		SHA256:      digest,
+	})
+	require.NoError(t, err)
+	return protocol.Command{
+		ID:    id,
+		Shell: "file",
+		// Deliberately at odds with the payload: nothing may be derived from it.
+		Line: "/bin/echo this line is decoration",
+		User: "root",
+		Data: string(data),
+	}
+}
+
+// dispatchCall records one dispatcher invocation.
+type dispatchCall struct {
+	command string
+	args    *common.CommandArgs
+}
+
+// fakeDispatcher stands in for the executor so tests can assert whether a
+// command reached execution at all.
+type fakeDispatcher struct {
+	calls []dispatchCall
+}
+
+func (d *fakeDispatcher) Execute(_ context.Context, command string, args *common.CommandArgs) (int, string, error) {
+	d.calls = append(d.calls, dispatchCall{command: command, args: args})
+	return 0, "ok", nil
+}
+
+func (d *fakeDispatcher) HasHandler(string) bool { return true }
+
+func TestOpenVerifiedFile_DigestMatchReturnsRewoundDescriptor(t *testing.T) {
+	content := []byte("#!/bin/sh\necho original\n")
+	path := writeScript(t, content)
+
+	file, err := openVerifiedFile(path, hexDigest(content))
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	t.Cleanup(func() { _ = file.Close() })
+
+	// Hashing consumed the offset; the descriptor handed to the child must
+	// start at the beginning of the file.
+	read, err := io.ReadAll(file)
+	require.NoError(t, err)
+	assert.Equal(t, content, read)
+}
+
+func TestOpenVerifiedFile_DigestMismatchRefuses(t *testing.T) {
+	path := writeScript(t, []byte("#!/bin/sh\necho original\n"))
+
+	file, err := openVerifiedFile(path, hexDigest([]byte("something else")))
+
+	require.Error(t, err)
+	assert.Nil(t, file, "no descriptor may escape a failed verification")
+	assert.ErrorIs(t, err, errHashMismatch)
+}
+
+func TestOpenVerifiedFile_MissingFileIsNotAMismatch(t *testing.T) {
+	content := []byte("#!/bin/sh\n")
+
+	file, err := openVerifiedFile(filepath.Join(t.TempDir(), "absent.sh"), hexDigest(content))
+
+	require.Error(t, err)
+	assert.Nil(t, file)
+	assert.NotErrorIs(t, err, errHashMismatch)
+}
+
+func TestOpenVerifiedFile_NonRegularFileRefused(t *testing.T) {
+	dir := t.TempDir()
+
+	file, err := openVerifiedFile(dir, hexDigest(nil))
+
+	require.Error(t, err)
+	assert.Nil(t, file)
+}
+
+// TestOpenVerifiedFile_SwapAfterVerifyKeepsOriginalBytes is the fd invariant.
+// A path-based implementation—hash the path, then reopen it to execute—passes
+// every other test here and fails this one.
+//
+// It is scoped to the platforms that run file commands: replacing a file that
+// is still open is POSIX behavior, and where the handler declines there is no
+// invariant to prove.
+func TestOpenVerifiedFile_SwapAfterVerifyKeepsOriginalBytes(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deploy.sh")
+	original := []byte("#!/bin/sh\necho original\n")
+	require.NoError(t, os.WriteFile(path, original, 0o700))
+
+	file, err := openVerifiedFile(path, hexDigest(original))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+
+	// Swap the file behind the path, as an attacker would between the check
+	// and the use. Rename is atomic, so there is no moment a path-based
+	// implementation could notice.
+	swapped := []byte("#!/bin/sh\necho swapped\n")
+	decoy := filepath.Join(dir, "decoy.sh")
+	require.NoError(t, os.WriteFile(decoy, swapped, 0o700))
+	require.NoError(t, os.Rename(decoy, path))
+
+	onDisk, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, swapped, onDisk, "the swap must have landed or this test proves nothing")
+
+	fromDescriptor, err := io.ReadAll(file)
+	require.NoError(t, err)
+	assert.Equal(t, original, fromDescriptor,
+		"the verified descriptor must still yield the bytes that were hashed")
+}
+
+func TestPrepareFileCommand_BuildsArgvFromPayloadOnly(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	content := []byte("#!/bin/sh\necho original\n")
+	path := writeScript(t, content)
+	// Arguments a shell would mangle: a space, an operator, a variable
+	// reference and a glob. Each must survive as exactly one argv entry.
+	scriptArgs := []string{"--fast", "a b", "; rm -rf /", "$HOME", "*"}
+	cr := &CommandRunner{command: fileCommand(t, "", path, "/bin/bash", scriptArgs, digestOf(content))}
+
+	args, refusal := cr.prepareFileCommand(context.Background())
+
+	require.Nil(t, refusal)
+	require.NotNil(t, args)
+	t.Cleanup(func() { _ = args.VerifiedFile.Close() })
+
+	fdPath, err := common.VerifiedFilePath()
+	require.NoError(t, err)
+	assert.Equal(t, append([]string{"/bin/bash", fdPath}, scriptArgs...), args.ExecArgs)
+	assert.NotContains(t, args.ExecArgs, path, "argv must name the descriptor, never the path")
+	assert.NotNil(t, args.VerifiedFile)
+}
+
+func TestPrepareFileCommand_HashMismatchRefusesWithoutDescriptor(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	path := writeScript(t, []byte("#!/bin/sh\necho original\n"))
+	cr := &CommandRunner{command: fileCommand(t, "cmd-1", path, "/bin/bash", nil, digestOf([]byte("approved")))}
+
+	args, refusal := cr.prepareFileCommand(context.Background())
+
+	assert.Nil(t, args)
+	require.NotNil(t, refusal)
+	assert.Equal(t, FileHashMismatchCode, refusal.code)
+	assert.Contains(t, refusal.String(), FileHashMismatchCode)
+}
+
+func TestPrepareFileCommand_RefusalCodes(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	content := []byte("#!/bin/sh\n")
+	path := writeScript(t, content)
+
+	tests := []struct {
+		name string
+		data string
+		code string
+	}{
+		{
+			name: "empty payload",
+			data: "",
+			code: FilePayloadInvalidCode,
+		},
+		{
+			name: "malformed payload",
+			data: `{"path":`,
+			code: FilePayloadInvalidCode,
+		},
+		{
+			name: "missing interpreter",
+			data: `{"path":"` + path + `","sha256":"` + digestOf(content) + `"}`,
+			code: FilePayloadInvalidCode,
+		},
+		{
+			name: "unreadable path",
+			data: `{"path":"/nonexistent/deploy.sh","interpreter":"/bin/bash","sha256":"` + digestOf(content) + `"}`,
+			code: FileOpenFailedCode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr := &CommandRunner{command: protocol.Command{ID: "cmd-1", Shell: "file", Data: tt.data}}
+
+			args, refusal := cr.prepareFileCommand(context.Background())
+
+			assert.Nil(t, args)
+			require.NotNil(t, refusal)
+			assert.Equal(t, tt.code, refusal.code)
+		})
+	}
+}
+
+func TestPrepareFileCommand_UnsupportedPlatformDeclinesCleanly(t *testing.T) {
+	if _, err := common.VerifiedFilePath(); err == nil {
+		t.Skip("this platform supports verified file execution")
+	}
+
+	content := []byte("#!/bin/sh\n")
+	path := writeScript(t, content)
+	cr := &CommandRunner{command: fileCommand(t, "cmd-1", path, "/bin/bash", nil, digestOf(content))}
+
+	args, refusal := cr.prepareFileCommand(context.Background())
+
+	assert.Nil(t, args)
+	require.NotNil(t, refusal)
+	assert.Equal(t, FileExecUnsupportedCode, refusal.code)
+}
+
+func TestCommandRunner_Run_FileDispatchesVerifiedDescriptor(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	content := []byte("#!/bin/sh\necho original\n")
+	path := writeScript(t, content)
+	dispatcher := &fakeDispatcher{}
+	cr := NewCommandRunner(nil, nil, fileCommand(t, "", path, "/bin/bash", []string{"--fast"}, digestOf(content)), protocol.CommandData{}, dispatcher)
+
+	require.NoError(t, cr.Run(context.Background()))
+
+	require.Len(t, dispatcher.calls, 1)
+	call := dispatcher.calls[0]
+	assert.Equal(t, common.ExecFile.String(), call.command)
+	assert.NotNil(t, call.args.VerifiedFile)
+	assert.Equal(t, "/bin/bash", call.args.ExecArgs[0])
+	assert.Equal(t, "--fast", call.args.ExecArgs[2])
+}
+
+func TestCommandRunner_Run_FileMismatchNeverDispatches(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	path := writeScript(t, []byte("#!/bin/sh\necho original\n"))
+	dispatcher := &fakeDispatcher{}
+	cr := NewCommandRunner(nil, nil, fileCommand(t, "", path, "/bin/bash", nil, digestOf([]byte("approved"))), protocol.CommandData{}, dispatcher)
+
+	require.NoError(t, cr.Run(context.Background()))
+
+	assert.Empty(t, dispatcher.calls, "a digest mismatch must never reach execution")
+}
+
+func TestCommandRunner_Run_FileMalformedPayloadNeverDispatches(t *testing.T) {
+	dispatcher := &fakeDispatcher{}
+	cr := NewCommandRunner(nil, nil, protocol.Command{
+		Shell: "file",
+		Line:  "/bin/bash /opt/deploy.sh",
+		Data:  "not json",
+	}, protocol.CommandData{}, dispatcher)
+
+	require.NoError(t, cr.Run(context.Background()))
+
+	assert.Empty(t, dispatcher.calls)
+}
+
+// hexDigest returns the bare hex sum openVerifiedFile compares against.
+func hexDigest(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/runner/file_exec_unix_test.go
+++ b/pkg/runner/file_exec_unix_test.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package runner
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runVerifiedFile executes the copy openVerifiedFile returned, the way the
+// executor does: inherited at VerifiedFileChildFD and named by its descriptor
+// path, never by the path it came from.
+func runVerifiedFile(t *testing.T, sealed *os.File) string {
+	t.Helper()
+
+	fdPath, err := common.VerifiedFilePath()
+	require.NoError(t, err)
+
+	cmd := exec.Command("/bin/sh", fdPath)
+	cmd.ExtraFiles = []*os.File{sealed}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "output was %q", string(out))
+
+	return string(out)
+}
+
+// runPath executes the script the path currently names, as a control for what
+// a path-based implementation would have run.
+func runPath(t *testing.T, path string) string {
+	t.Helper()
+
+	out, err := exec.Command("/bin/sh", path).CombinedOutput()
+	require.NoError(t, err, "output was %q", string(out))
+
+	return string(out)
+}
+
+// TestOpenVerifiedFile_InPlaceRewriteExecutesVerifiedBytes is the end-to-end
+// form of the case the sealed copy closes: the requester rewrites its own file
+// in place after the digest matched, and the child still runs what was
+// approved. The control at the end proves the rewrite really landed, so the
+// test cannot pass by the rewrite silently failing.
+func TestOpenVerifiedFile_InPlaceRewriteExecutesVerifiedBytes(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	original := []byte("printf 'ORIGINAL\\n'\n")
+	rewritten := []byte("printf 'REWRITE!\\n'\n")
+	require.Len(t, rewritten, len(original))
+
+	path := filepath.Join(t.TempDir(), "deploy.sh")
+	require.NoError(t, os.WriteFile(path, original, 0o700))
+
+	sealed, err := openVerifiedFile(path, hexDigest(original))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sealed.Close() })
+
+	rewriteInPlace(t, path, rewritten)
+
+	assert.Equal(t, "ORIGINAL\n", runVerifiedFile(t, sealed),
+		"the executed bytes must be the verified ones")
+	require.Equal(t, "REWRITE!\n", runPath(t, path),
+		"the in-place rewrite must be live or this test proves nothing")
+}
+
+// The replace-at-the-path case, end to end through the same production path.
+func TestOpenVerifiedFile_SwapExecutesVerifiedBytes(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deploy.sh")
+	original := []byte("printf 'ORIGINAL\\n'\n")
+	require.NoError(t, os.WriteFile(path, original, 0o700))
+
+	sealed, err := openVerifiedFile(path, hexDigest(original))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sealed.Close() })
+
+	decoy := filepath.Join(dir, "decoy.sh")
+	require.NoError(t, os.WriteFile(decoy, []byte("printf 'SWAPPED\\n'\n"), 0o700))
+	require.NoError(t, os.Rename(decoy, path))
+
+	assert.Equal(t, "ORIGINAL\n", runVerifiedFile(t, sealed))
+	require.Equal(t, "SWAPPED\n", runPath(t, path),
+		"the swap must be live or this test proves nothing")
+}
+
+// Deleting the original entirely leaves the approved bytes runnable: the copy
+// never depended on the path.
+func TestOpenVerifiedFile_SurvivesDeletionOfTheOriginal(t *testing.T) {
+	skipIfNoVerifiedFileExec(t)
+
+	original := []byte("printf 'ORIGINAL\\n'\n")
+	path := filepath.Join(t.TempDir(), "deploy.sh")
+	require.NoError(t, os.WriteFile(path, original, 0o700))
+
+	sealed, err := openVerifiedFile(path, hexDigest(original))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sealed.Close() })
+
+	require.NoError(t, os.Remove(path))
+
+	assert.Equal(t, "ORIGINAL\n", runVerifiedFile(t, sealed))
+}

--- a/pkg/runner/file_exec_unix_test.go
+++ b/pkg/runner/file_exec_unix_test.go
@@ -5,13 +5,17 @@ package runner
 import (
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
+	"golang.org/x/sys/unix"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -147,4 +151,58 @@ func TestHashMismatchError_CarriesTheObservedDigestForTheLog(t *testing.T) {
 	var mismatch *hashMismatchError
 	require.ErrorAs(t, err, &mismatch)
 	assert.Equal(t, observed, mismatch.Observed())
+}
+
+// A read-only open of a FIFO blocks until a writer appears, and this runs
+// before dispatcher.Execute so no ShellTimeout deadline covers it. Without the
+// non-blocking open a requester could mkfifo a path in its own account and park
+// the runner goroutine forever, one leaked goroutine and descriptor per
+// attempt. This test hangs rather than fails if that regresses, so it carries
+// its own deadline.
+func TestOpenVerifiedFile_FifoRefusedWithoutBlocking(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipe")
+	require.NoError(t, unix.Mkfifo(path, 0o600))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := openVerifiedFile(path, strings.Repeat("a", 64))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, errHashMismatch,
+			"a fifo must be refused as a non-regular file, never hashed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("openVerifiedFile blocked on a fifo; the open is not O_NONBLOCK")
+	}
+}
+
+// A symlink resolves to its target, so what gets hashed and sealed is the
+// target's bytes. Swapping the link afterwards cannot reach the sealed copy —
+// the same property the rename test proves for the path, stated for links
+// because "non-regular" in the refusal test only demonstrates a directory.
+func TestOpenVerifiedFile_SymlinkIsResolvedThenSealed(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.sh")
+	link := filepath.Join(dir, "link.sh")
+	body := []byte("printf 'ORIGINAL\\n'\n")
+	require.NoError(t, os.WriteFile(target, body, 0o700))
+	require.NoError(t, os.Symlink(target, link))
+	digest := fmt.Sprintf("%x", sha256.Sum256(body))
+
+	sealed, err := openVerifiedFile(link, digest)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sealed.Close() })
+
+	// Repoint the link at different content; the sealed copy is unaffected.
+	other := filepath.Join(dir, "other.sh")
+	require.NoError(t, os.WriteFile(other, []byte("printf 'SWAPPED\\n'\n"), 0o700))
+	require.NoError(t, os.Remove(link))
+	require.NoError(t, os.Symlink(other, link))
+
+	got, err := io.ReadAll(sealed)
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
 }

--- a/pkg/runner/file_exec_unix_test.go
+++ b/pkg/runner/file_exec_unix_test.go
@@ -3,9 +3,12 @@
 package runner
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
@@ -106,4 +109,42 @@ func TestOpenVerifiedFile_SurvivesDeletionOfTheOriginal(t *testing.T) {
 	require.NoError(t, os.Remove(path))
 
 	assert.Equal(t, "ORIGINAL\n", runVerifiedFile(t, sealed))
+}
+
+// A refusal is reported to the requester as the command result, and the
+// requester chose the path. Returning what the file hashed to would make the
+// refusal itself a disclosure: the assessor judges the submitted content, so a
+// benign script paired with a path like /etc/shadow auto-approves, mismatches,
+// and hands back the digest of a file the requester may not read.
+func TestOpenVerifiedFile_MismatchNeverReportsTheObservedDigest(t *testing.T) {
+	secret := []byte("root-only secret\n")
+	path := filepath.Join(t.TempDir(), "secret")
+	require.NoError(t, os.WriteFile(path, secret, 0o600))
+	observed := fmt.Sprintf("%x", sha256.Sum256(secret))
+	approved := strings.Repeat("b", 64)
+
+	_, err := openVerifiedFile(path, approved)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errHashMismatch)
+	assert.NotContains(t, err.Error(), observed,
+		"the refusal must not disclose what the file hashed to")
+	// The expected digest came from the requester, so echoing it tells them
+	// nothing they did not already send.
+	assert.Contains(t, err.Error(), approved)
+}
+
+// The operator still needs the real value to diagnose a genuine mismatch; it
+// travels on the error type for the local log rather than in Error().
+func TestHashMismatchError_CarriesTheObservedDigestForTheLog(t *testing.T) {
+	secret := []byte("root-only secret\n")
+	path := filepath.Join(t.TempDir(), "secret")
+	require.NoError(t, os.WriteFile(path, secret, 0o600))
+	observed := fmt.Sprintf("%x", sha256.Sum256(secret))
+
+	_, err := openVerifiedFile(path, strings.Repeat("b", 64))
+
+	var mismatch *hashMismatchError
+	require.ErrorAs(t, err, &mismatch)
+	assert.Equal(t, observed, mismatch.Observed())
 }

--- a/pkg/runner/file_open_other.go
+++ b/pkg/runner/file_open_other.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package runner
+
+import "os"
+
+// openEntrypoint is unreachable on Windows: the lane declines with
+// FILE_EXEC_UNSUPPORTED before a path is ever opened. It exists so the
+// cross-platform file compiles, and it is deliberately the plain open rather
+// than a panic — a build that somehow reached it should fail closed later on
+// the missing sealed object, not crash the agent.
+func openEntrypoint(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/pkg/runner/file_open_unix.go
+++ b/pkg/runner/file_open_unix.go
@@ -20,7 +20,13 @@ import (
 // O_CLOEXEC keeps this descriptor out of the child; the child receives the
 // sealed copy through ExtraFiles instead.
 func openEntrypoint(path string) (*os.File, error) {
-	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	// codeql[go/path-injection]: Intentional - the path names a file the operator
+	// asked to run on their own host, arriving over the authenticated channel that
+	// already carries arbitrary command lines (the `system` shell), so it crosses
+	// no privilege boundary and there is no root to confine it to. Payload
+	// validation requires a POSIX-absolute path, and what bounds this lane is the
+	// digest verified over the sealed copy before anything executes.
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0) // lgtm[go/path-injection]
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
 	}

--- a/pkg/runner/file_open_unix.go
+++ b/pkg/runner/file_open_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package runner
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openEntrypoint opens the submitted path for reading without blocking.
+//
+// O_NONBLOCK is the whole point. A read-only open of a FIFO blocks until a
+// writer appears, and this runs before dispatcher.Execute, so no ShellTimeout
+// deadline covers it: a requester could mkfifo a path in its own account and
+// park the runner goroutine forever, leaking a goroutine and a descriptor per
+// attempt with nothing to bound it. The flag is a no-op on regular files,
+// which is the only kind the caller proceeds with.
+//
+// O_CLOEXEC keeps this descriptor out of the child; the child receives the
+// sealed copy through ExtraFiles instead.
+func openEntrypoint(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}

--- a/pkg/runner/sealed_file.go
+++ b/pkg/runner/sealed_file.go
@@ -1,0 +1,9 @@
+package runner
+
+import "errors"
+
+// errSealUnavailable marks a host that cannot give the agent an execution
+// object beyond the requester's reach. Executing the on-disk inode instead is
+// not an acceptable fallback—that is the very window the sealed copy closes—so
+// a file command refuses here.
+var errSealUnavailable = errors.New("no tamper-proof execution object is available")

--- a/pkg/runner/sealed_file_darwin.go
+++ b/pkg/runner/sealed_file_darwin.go
@@ -1,0 +1,68 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// newSealedFile returns an empty file that no name in the filesystem refers to.
+//
+// macOS has no memfd, so the copy starts as a real file and is unlinked at
+// once. It is created inside a private directory (os.MkdirTemp makes it 0700,
+// owned by the agent) at mode 0600, so for the instant a name does exist no
+// other account can reach it; after the unlink there is no name to reach.
+func newSealedFile() (*os.File, error) {
+	dir, err := os.MkdirTemp("", "alpamon-verified-")
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errSealUnavailable, err)
+	}
+	// Removed once the file inside is unlinked, leaving the object alive on
+	// the descriptor alone.
+	defer func() { _ = os.Remove(dir) }()
+
+	file, err := os.CreateTemp(dir, "alpamon-verified-file")
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errSealUnavailable, err)
+	}
+	if err := os.Remove(file.Name()); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("%w: failed to unlink the verified copy: %v", errSealUnavailable, err)
+	}
+
+	return file, nil
+}
+
+// sealFile confirms the copy is nameless, which is what stands in for sealing
+// here.
+//
+// There is no F_SEAL_WRITE on macOS, so immutability cannot be enforced on the
+// object itself; it comes from reachability instead. A link count of zero is
+// the kernel's own statement that no directory entry points at this inode, so
+// the requester—who knows only the original path—has nothing left to write to.
+// The count is checked rather than assumed, for the same reason the seals are
+// read back on Linux.
+//
+// The residue this leaves is narrower than the window it closes: the child
+// this agent execs holds the descriptor and could write through it, because
+// /dev/fd/N on macOS duplicates the descriptor (access mode included) instead
+// of opening the object afresh, so a read-only handover is not available. That
+// child is the approved script itself, so reaching the residue means the
+// approver read and approved code that rewrites its own remaining bytes. The
+// window being closed needed no such approval.
+func sealFile(file *os.File) error {
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("%w: %v", errSealUnavailable, err)
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("%w: cannot read the verified copy's link count", errSealUnavailable)
+	}
+	if stat.Nlink != 0 {
+		return fmt.Errorf("%w: the verified copy still has %d link(s)", errSealUnavailable, stat.Nlink)
+	}
+
+	return nil
+}

--- a/pkg/runner/sealed_file_darwin_test.go
+++ b/pkg/runner/sealed_file_darwin_test.go
@@ -1,0 +1,49 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// macOS has no seal API, so the copy's protection is that nothing can name it.
+// This is the property sealFile checks, and the one the requester cannot get
+// around: it knows only the original path.
+func TestSealedFile_IsNameless(t *testing.T) {
+	sealed, err := newSealedFile()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sealed.Close() })
+
+	_, err = sealed.WriteString("printf 'original\\n'\n")
+	require.NoError(t, err)
+	require.NoError(t, sealFile(sealed))
+
+	info, err := sealed.Stat()
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	assert.Zero(t, stat.Nlink, "the copy must have no directory entry left")
+
+	_, err = os.Stat(sealed.Name())
+	assert.Error(t, err, "the copy must not be reachable by any path")
+}
+
+// sealFile refuses rather than reporting success when the object still has a
+// name: a linked file is one the requester could reach, which is the window
+// the copy exists to close.
+func TestSealedFile_RefusesAStillLinkedObject(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "linked.sh")
+	require.NoError(t, os.WriteFile(path, []byte("printf 'x\\n'\n"), 0o600))
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+
+	err = sealFile(file)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSealUnavailable)
+}

--- a/pkg/runner/sealed_file_linux.go
+++ b/pkg/runner/sealed_file_linux.go
@@ -1,0 +1,52 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// verifiedFileSeals makes the copy permanently immutable: no writes, and no
+// change of length in either direction. F_SEAL_SEAL closes the door behind
+// them so nothing—including this process—can lift the others later.
+const verifiedFileSeals = unix.F_SEAL_WRITE | unix.F_SEAL_SHRINK | unix.F_SEAL_GROW | unix.F_SEAL_SEAL
+
+// newSealedFile returns an empty anonymous memory file.
+//
+// It exists only as a descriptor: it has no name anywhere in the filesystem,
+// so the requester has nothing to open, rename or rewrite. MFD_CLOEXEC keeps
+// it out of unrelated children—os/exec clears close-on-exec on the descriptor
+// it dups into the child that is meant to have it.
+func newSealedFile() (*os.File, error) {
+	fd, err := unix.MemfdCreate("alpamon-verified-file", unix.MFD_CLOEXEC|unix.MFD_ALLOW_SEALING)
+	if err != nil {
+		return nil, fmt.Errorf("%w: memfd_create: %v", errSealUnavailable, err)
+	}
+	return os.NewFile(uintptr(fd), "memfd:alpamon-verified-file"), nil
+}
+
+// sealFile makes file's contents immutable for every descriptor that refers to
+// it, this process's own included.
+//
+// The seals are read back rather than assumed: a memfd created without
+// MFD_ALLOW_SEALING, or on a kernel that took the request without honoring it,
+// would leave the copy writable and put the swap window straight back. An
+// unverified seal is the same hole wearing a different name, so a readback
+// that does not show every seal refuses the command.
+func sealFile(file *os.File) error {
+	if _, err := unix.FcntlInt(file.Fd(), unix.F_ADD_SEALS, verifiedFileSeals); err != nil {
+		return fmt.Errorf("%w: failed to seal the verified copy: %v", errSealUnavailable, err)
+	}
+
+	applied, err := unix.FcntlInt(file.Fd(), unix.F_GET_SEALS, 0)
+	if err != nil {
+		return fmt.Errorf("%w: failed to read back the seals: %v", errSealUnavailable, err)
+	}
+	if applied&verifiedFileSeals != verifiedFileSeals {
+		return fmt.Errorf("%w: seals not applied (want 0x%x, got 0x%x)",
+			errSealUnavailable, verifiedFileSeals, applied)
+	}
+
+	return nil
+}

--- a/pkg/runner/sealed_file_linux_test.go
+++ b/pkg/runner/sealed_file_linux_test.go
@@ -1,0 +1,67 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestSealedFile_RejectsWritesOnceSealed(t *testing.T) {
+	sealed, err := newSealedFile()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sealed.Close() })
+
+	_, err = sealed.WriteString("printf 'original\\n'\n")
+	require.NoError(t, err, "the copy must be writable until it is sealed")
+
+	require.NoError(t, sealFile(sealed))
+
+	// The seal binds every descriptor for this object, this one included, so
+	// there is no handle left anywhere that can change what runs.
+	_, err = sealed.WriteAt([]byte("x"), 0)
+	assert.Error(t, err, "a sealed copy must reject writes")
+}
+
+func TestSealedFile_AppliesEverySeal(t *testing.T) {
+	sealed, err := newSealedFile()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sealed.Close() })
+
+	require.NoError(t, sealFile(sealed))
+
+	applied, err := unix.FcntlInt(sealed.Fd(), unix.F_GET_SEALS, 0)
+	require.NoError(t, err)
+	assert.Equal(t, verifiedFileSeals, applied&verifiedFileSeals,
+		"write, shrink, grow and seal must all be set")
+}
+
+// A memfd has no name, so there is nothing for the requester to open, rename
+// or rewrite—the property the seal complements rather than replaces.
+func TestSealedFile_HasNoNameInTheFilesystem(t *testing.T) {
+	sealed, err := newSealedFile()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sealed.Close() })
+
+	_, err = os.Stat(sealed.Name())
+	assert.Error(t, err, "the copy must not be reachable by any path")
+}
+
+// sealFile refuses rather than reporting success when the object cannot
+// actually be sealed: a regular file accepts no seals, and treating that as
+// sealed would put the rewrite window straight back.
+func TestSealedFile_RefusesToSealAnUnsealableObject(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "regular.sh")
+	require.NoError(t, os.WriteFile(path, []byte("printf 'x\\n'\n"), 0o600))
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+
+	err = sealFile(file)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSealUnavailable)
+}

--- a/pkg/runner/sealed_file_linux_test.go
+++ b/pkg/runner/sealed_file_linux_test.go
@@ -46,8 +46,12 @@ func TestSealedFile_HasNoNameInTheFilesystem(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sealed.Close() })
 
-	_, err = os.Stat(sealed.Name())
-	assert.Error(t, err, "the copy must not be reachable by any path")
+	// Asserted on the descriptor, not on Name(): a memfd's Name() is a label
+	// rather than a path, so stat-ing it would test whether a file of that name
+	// happens to sit in the working directory.
+	var st unix.Stat_t
+	require.NoError(t, unix.Fstat(int(sealed.Fd()), &st))
+	assert.Zero(t, st.Nlink, "the copy must have no directory entry to open")
 }
 
 // sealFile refuses rather than reporting success when the object cannot

--- a/pkg/runner/sealed_file_other.go
+++ b/pkg/runner/sealed_file_other.go
@@ -1,0 +1,23 @@
+//go:build !linux && !darwin
+
+package runner
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// newSealedFile declines on platforms with no way to hold the verified bytes
+// beyond the requester's reach.
+//
+// common.VerifiedFilePath already turns these hosts away before a file is ever
+// opened, so this is the second of two closed doors rather than the only one.
+func newSealedFile() (*os.File, error) {
+	return nil, fmt.Errorf("%w on %s", errSealUnavailable, runtime.GOOS)
+}
+
+// sealFile is unreachable here: newSealedFile never returns a file to seal.
+func sealFile(*os.File) error {
+	return fmt.Errorf("%w on %s", errSealUnavailable, runtime.GOOS)
+}

--- a/pkg/runner/signing.go
+++ b/pkg/runner/signing.go
@@ -36,10 +36,28 @@ func newRejection(reason string, err error) *rejectionError {
 	return &rejectionError{reason: reason, err: err}
 }
 
+// enforcesSignature reports whether a command that fails verification must be
+// refused rather than warned about and run.
+//
+// The fleet mode decides for every lane but one. A "file" command always
+// enforces, because there the command line is a rendering and the structured
+// payload decides what runs (ADR 0053): the signature is the only thing between
+// a rewritten instruction and a digest that then verifies against the file the
+// rewriter named. Verifying the entrypoint against an instruction nothing
+// vouches for proves the requester's own claim back to them.
+//
+// The reason the general lane runs unenforced does not reach here. That reason
+// is skew—older agents that cannot verify—and the server admits this lane only
+// for an agent version that can, so there is no such agent to break.
+func (wc *WebsocketClient) enforcesSignature(cmd *protocol.Command) bool {
+	return wc.signingMode == "enforce" || cmd.Shell == "file"
+}
+
 // verifyCommandSignature checks the Ed25519 signature on a command.
 // Internal commands bypass verification. In monitor mode, unsigned or
-// invalid signatures log a warning but allow execution. In enforce mode,
-// they return an error which prevents ACK and execution.
+// invalid signatures log a warning but allow execution. In enforce mode—and on
+// the file lane whatever the mode is, see enforcesSignature—they return an
+// error which prevents ACK and execution.
 func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 	// Internal commands bypass verification (no signature expected)
 	if cmd.Shell == "internal" {
@@ -48,9 +66,9 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 
 	// No signature: unsigned command
 	if cmd.Signature == "" {
-		if wc.signingMode == "enforce" {
+		if wc.enforcesSignature(cmd) {
 			return newRejection(rejectReasonUnsigned,
-				errors.New("missing signature in enforce mode"))
+				errors.New("missing signature on a command that requires one"))
 		}
 		log.Warn().Str("command_id", cmd.ID).Msg("Command has no signature (unsigned).")
 		return nil
@@ -67,7 +85,7 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 	}
 
 	if err != nil {
-		if wc.signingMode == "enforce" {
+		if wc.enforcesSignature(cmd) {
 			return newRejection(rejectReasonKeyUnavailable,
 				fmt.Errorf("public key unavailable: %w", err))
 		}
@@ -97,7 +115,7 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 		}
 	}
 
-	if wc.signingMode == "enforce" {
+	if wc.enforcesSignature(cmd) {
 		reason := rejectReasonInvalidSignature
 		if errors.Is(err, signing.ErrSignatureMismatch) {
 			reason = rejectReasonSignatureMismatch

--- a/pkg/runner/signing_test.go
+++ b/pkg/runner/signing_test.go
@@ -58,6 +58,58 @@ func TestVerifyCommandSignature_InternalBypass(t *testing.T) {
 	assert.NoError(t, err, "internal commands should bypass verification")
 }
 
+// Only "internal" bypasses signature verification. File commands carry a
+// signature like system commands do, and the file-hash check is independent of
+// it: neither one stands in for the other.
+func TestVerifyCommandSignature_FileShellIsNotBypassed(t *testing.T) {
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, "", nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:    "cmd-1",
+		Shell: "file",
+		Line:  "/bin/bash /opt/deploy.sh --fast",
+		Data:  `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","args":["--fast"],"sha256":"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+	}
+
+	err := wc.verifyCommandSignature(cmd)
+	assert.Error(t, err, "file commands must not bypass signature verification")
+	assert.Equal(t, rejectReasonUnsigned, err.Error())
+}
+
+// A signed file command passes verification on the same terms as a system one:
+// the canonical payload covers shell and line, and the structured payload in
+// Data is verified separately by the digest check.
+func TestVerifyCommandSignature_FileShellValidSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	srv := newTestKeyServer(t, pub, "kid-1")
+	defer srv.Close()
+
+	wc := &WebsocketClient{
+		signingMode: "enforce",
+		serverID:    testServerID,
+		keyManager:  signing.NewKeyManager(srv.URL, 3600, "", nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:         "cmd-1",
+		Shell:      "file",
+		Line:       "/bin/bash /opt/deploy.sh --fast",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		KeyID:      "kid-1",
+		Data:       `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","args":["--fast"],"sha256":"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+	}
+	signCommand(t, cmd, testServerID, priv)
+
+	assert.NoError(t, wc.verifyCommandSignature(cmd))
+}
+
 func TestVerifyCommandSignature_UnsignedMonitorMode(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "monitor",

--- a/pkg/runner/signing_test.go
+++ b/pkg/runner/signing_test.go
@@ -79,9 +79,11 @@ func TestVerifyCommandSignature_FileShellIsNotBypassed(t *testing.T) {
 	assert.Equal(t, rejectReasonUnsigned, err.Error())
 }
 
-// A signed file command passes verification on the same terms as a system one:
-// the canonical payload covers shell and line, and the structured payload in
-// Data is verified separately by the digest check.
+// A signed file command passes verification on the same terms as a system one.
+// The canonical payload covers Data on this lane precisely because it is NOT
+// verified separately: the digest inside it is its own expected value, so a
+// signature omitting it would leave a rewritten payload verifying against
+// itself. See BuildCanonicalPayload.
 func TestVerifyCommandSignature_FileShellValidSignature(t *testing.T) {
 	pub, priv, err := ed25519.GenerateKey(nil)
 	require.NoError(t, err)

--- a/pkg/runner/signing_test.go
+++ b/pkg/runner/signing_test.go
@@ -128,6 +128,125 @@ func TestVerifyCommandSignature_UnsignedMonitorMode(t *testing.T) {
 	assert.NoError(t, err, "monitor mode should allow unsigned commands")
 }
 
+// The file lane enforces whatever the fleet mode says, so an unsigned file
+// command is refused in monitor mode where an unsigned system command runs.
+// The pair above and below is the point: monitor still means monitor
+// everywhere else.
+func TestVerifyCommandSignature_UnsignedFileCommandIsRefusedInMonitorMode(t *testing.T) {
+	wc := &WebsocketClient{
+		signingMode: "monitor",
+		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, "", nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:    "cmd-1",
+		Shell: "file",
+		Line:  "/bin/bash /opt/deploy.sh",
+		Data:  `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","args":[],"sha256":"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+	}
+
+	err := wc.verifyCommandSignature(cmd)
+	require.Error(t, err, "the file lane must refuse an unsigned command in monitor mode")
+	assert.Equal(t, rejectReasonUnsigned, err.Error())
+}
+
+// Monitor mode runs a system command whose signature does not verify. That is
+// what monitor means, and the file-lane test below has to differ from it or the
+// lane rule is a blanket flip to enforce rather than a lane rule.
+func TestVerifyCommandSignature_MisSignedSystemCommandStillRunsInMonitorMode(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	_, otherPriv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	srv := newTestKeyServer(t, pub, "kid-1")
+	defer srv.Close()
+
+	wc := &WebsocketClient{
+		signingMode: "monitor",
+		serverID:    testServerID,
+		keyManager:  signing.NewKeyManager(srv.URL, 3600, "", nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:         "cmd-1",
+		Shell:      "system",
+		Line:       "echo hello",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		KeyID:      "kid-1",
+	}
+	signCommand(t, cmd, testServerID, otherPriv)
+
+	assert.NoError(t, wc.verifyCommandSignature(cmd))
+}
+
+// The attack the file lane closes: an attacker in the command transport rewrites
+// Data to name a file it controls and the digest of that file. The digest then
+// verifies against itself, so the signature is the only thing that can notice —
+// and under monitor mode it would only log. Here it refuses.
+func TestVerifyCommandSignature_MisSignedFileCommandIsRefusedInMonitorMode(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	srv := newTestKeyServer(t, pub, "kid-1")
+	defer srv.Close()
+
+	wc := &WebsocketClient{
+		signingMode: "monitor",
+		serverID:    testServerID,
+		keyManager:  signing.NewKeyManager(srv.URL, 3600, "", nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:         "cmd-1",
+		Shell:      "file",
+		Line:       "/bin/bash /opt/deploy.sh",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		KeyID:      "kid-1",
+		Data:       `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","args":[],"sha256":"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+	}
+	signCommand(t, cmd, testServerID, priv)
+	require.NoError(t, wc.verifyCommandSignature(cmd), "the signature must verify before it is broken")
+
+	cmd.Data = `{"path":"/tmp/attacker.sh","interpreter":"/bin/bash","args":[],"sha256":"sha256:0000000000000000000000000000000000000000000000000000000000000000"}`
+
+	err = wc.verifyCommandSignature(cmd)
+	require.Error(t, err, "a rewritten instruction must not execute in monitor mode")
+	assert.Equal(t, rejectReasonSignatureMismatch, err.Error())
+}
+
+// The third enforcement site. A file command whose key cannot be fetched is
+// unverifiable, and unverifiable is refused on this lane rather than warned
+// about — otherwise an attacker who can reach the key endpoint downgrades the
+// lane by making it unreachable.
+func TestVerifyCommandSignature_KeyUnavailableRefusesFileCommandInMonitorMode(t *testing.T) {
+	wc := &WebsocketClient{
+		signingMode: "monitor",
+		serverID:    testServerID,
+		keyManager:  signing.NewKeyManager("http://127.0.0.1:9999", 3600, "", nil),
+	}
+
+	cmd := &protocol.Command{
+		ID:         "cmd-1",
+		Shell:      "file",
+		Line:       "/bin/bash /opt/deploy.sh",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+		KeyID:      "kid-1",
+		Signature:  base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)),
+		Data:       `{"path":"/opt/deploy.sh","interpreter":"/bin/bash","args":[],"sha256":"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+	}
+
+	err := wc.verifyCommandSignature(cmd)
+	require.Error(t, err, "an unverifiable file command must not run")
+	assert.Equal(t, rejectReasonKeyUnavailable, err.Error())
+}
+
 func TestVerifyCommandSignature_UnsignedEnforceMode(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "enforce",

--- a/pkg/signing/verifier.go
+++ b/pkg/signing/verifier.go
@@ -22,12 +22,19 @@ var ErrSignatureMismatch = errors.New("signature verification failed")
 // json.dumps(sort_keys=True, separators=(',', ':')).
 type signingPayload struct {
 	CommandID string `json:"command_id"`
-	GroupName string `json:"groupname"`
-	Line      string `json:"line"`
-	ServerID  string `json:"server_id"`
-	Shell     string `json:"shell"`
-	Timestamp string `json:"timestamp"`
-	Username  string `json:"username"`
+	// Present only on the file lane, where `line` is a human rendering and this
+	// is the only authoritative field: a signature omitting it binds nothing,
+	// so rewriting Data on a legitimately signed command would leave the
+	// signature valid and the digest verifying against itself. A pointer so it
+	// is absent — not empty — on every other shell, keeping existing signatures
+	// byte-identical. Sorts after command_id, matching Python's sort_keys.
+	Data      *string `json:"data,omitempty"`
+	GroupName string  `json:"groupname"`
+	Line      string  `json:"line"`
+	ServerID  string  `json:"server_id"`
+	Shell     string  `json:"shell"`
+	Timestamp string  `json:"timestamp"`
+	Username  string  `json:"username"`
 }
 
 // BuildCanonicalPayload constructs the signing payload that must match
@@ -48,6 +55,10 @@ func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
 		Shell:     cmd.Shell,
 		Timestamp: cmd.AnalyzedAt,
 		Username:  cmd.User,
+	}
+	if cmd.Shell == "file" {
+		data := cmd.Data
+		p.Data = &data
 	}
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alpacax/alpamon/v2/internal/protocol"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildCanonicalPayload(t *testing.T) {
@@ -196,4 +197,70 @@ func TestBuildCanonicalPayload_OtherShellsOmitData(t *testing.T) {
 
 	assert.NotContains(t, got, `"data"`)
 	assert.NotContains(t, got, "carried but never signed here")
+}
+
+// The shape assertions above say Data is in the payload; this says what that
+// buys. Without it the whole `shell == "file"` branch can be deleted and only
+// a shape test fails, which proves nothing about the property the branch
+// exists for: that rewriting the structured instruction under a valid
+// signature is caught.
+//
+// The attack it stands for: on this lane `line` is a human rendering and Data
+// decides what runs, so an attacker inside the command transport takes a
+// legitimately signed file command and swaps in a new path plus the digest of
+// a file it already controls. The digest then verifies against itself, and the
+// signature is the only thing that can notice.
+func TestVerifyCommand_FileLaneRejectsRewrittenData(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	cmd := &protocol.Command{
+		ID:         "11111111-1111-1111-1111-111111111111",
+		Shell:      "file",
+		Line:       "/bin/bash /opt/deploy.sh",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-08-27T00:00:00+00:00",
+		Data:       `{"path":"/opt/deploy.sh","sha256":"sha256:aaa"}`,
+	}
+	const serverID = "22222222-2222-2222-2222-222222222222"
+	cmd.Signature = base64.StdEncoding.EncodeToString(
+		ed25519.Sign(priv, BuildCanonicalPayload(cmd, serverID)),
+	)
+	require.NoError(t, VerifyCommand(cmd, serverID, pub))
+
+	// Same signature, same line, different instruction.
+	cmd.Data = `{"path":"/tmp/attacker.sh","sha256":"sha256:bbb"}`
+
+	assert.ErrorIs(t, VerifyCommand(cmd, serverID, pub), ErrSignatureMismatch)
+}
+
+// The counterpart: on every other shell Data is not signed, so rewriting it
+// leaves the signature valid. Stated so the scope of the branch is explicit
+// rather than incidental — `line` is the instruction there, and it is covered.
+func TestVerifyCommand_OtherShellsDoNotCoverData(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	cmd := &protocol.Command{
+		ID:         "11111111-1111-1111-1111-111111111111",
+		Shell:      "system",
+		Line:       "uptime",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-08-27T00:00:00+00:00",
+		Data:       "before",
+	}
+	const serverID = "22222222-2222-2222-2222-222222222222"
+	cmd.Signature = base64.StdEncoding.EncodeToString(
+		ed25519.Sign(priv, BuildCanonicalPayload(cmd, serverID)),
+	)
+	require.NoError(t, VerifyCommand(cmd, serverID, pub))
+
+	cmd.Data = "after"
+
+	assert.NoError(t, VerifyCommand(cmd, serverID, pub))
+	// But the instruction on that lane is the line, and it IS bound.
+	cmd.Line = "rm -rf /"
+	assert.ErrorIs(t, VerifyCommand(cmd, serverID, pub), ErrSignatureMismatch)
 }

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -3,6 +3,7 @@ package signing
 import (
 	"crypto/ed25519"
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/internal/protocol"
@@ -152,4 +153,47 @@ func TestVerifyCommand_Errors(t *testing.T) {
 			assert.ErrorContains(t, VerifyCommand(tt.cmd, testServerID, tt.key), tt.want)
 		})
 	}
+}
+
+// On the file lane `line` is a human rendering and the structured payload is
+// the only authoritative field, so a signature that omits Data binds nothing:
+// rewriting it on a legitimately signed command would leave the signature
+// valid while the digest verifies against itself.
+func TestBuildCanonicalPayload_FileLaneCoversData(t *testing.T) {
+	cmd := &protocol.Command{
+		ID:         "11111111-1111-1111-1111-111111111111",
+		Shell:      "file",
+		Line:       "/bin/bash /opt/deploy.sh",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-08-26T00:00:00+00:00",
+		Data:       `{"path":"/opt/deploy.sh"}`,
+	}
+
+	got := string(BuildCanonicalPayload(cmd, "22222222-2222-2222-2222-222222222222"))
+
+	assert.Contains(t, got, `"data":"{\"path\":\"/opt/deploy.sh\"}"`)
+	// Sorted position matters: the signer emits sort_keys=True, so `data` sits
+	// between command_id and groupname or the two canonical forms diverge.
+	assert.Less(t, strings.Index(got, `"data"`), strings.Index(got, `"groupname"`))
+	assert.Greater(t, strings.Index(got, `"data"`), strings.Index(got, `"command_id"`))
+}
+
+// Scoped to the file lane so no existing signature changes shape — a system
+// command carrying data must serialize exactly as it did before.
+func TestBuildCanonicalPayload_OtherShellsOmitData(t *testing.T) {
+	cmd := &protocol.Command{
+		ID:         "11111111-1111-1111-1111-111111111111",
+		Shell:      "system",
+		Line:       "uptime",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-08-26T00:00:00+00:00",
+		Data:       "carried but never signed here",
+	}
+
+	got := string(BuildCanonicalPayload(cmd, "22222222-2222-2222-2222-222222222222"))
+
+	assert.NotContains(t, got, `"data"`)
+	assert.NotContains(t, got, "carried but never signed here")
 }


### PR DESCRIPTION
Agent half of ADR 0053, v1. Closes #430.

Server side: alpacax/alpacon-server#3158. Assessor side: alpacax/alpacon-ai-server#406. Decision record: alpacax/alpacon-handbook#163.

## What this does

Adds a third shell type, `file`, beside `internal` and `system`. The server sends one entrypoint as structure in the existing `data` field:

```json
{"path": "/opt/deploy.sh", "interpreter": "/bin/bash", "args": ["--fast"], "sha256": "sha256:<64 hex>"}
```

`line` stays a human rendering for display and signing and is never parsed to decide what runs.

## The guarantee, and how it is kept

The control plane never sees the file, so the whole promise of the lane — *the bytes an approver cleared are the bytes that run* — rests here.

**Verifying and executing are the same object.** The source path is opened exactly once and streamed straight into a copy the requester cannot reach; the digest is taken over that copy **after** it is sealed, and the sealed copy is what executes. Hashing the disk descriptor and separately copying from it would move the race one layer down rather than closing it, so the ordering is load-bearing and is stated in the code.

- **Linux:** `memfd_create` with `MFD_ALLOW_SEALING`, then `F_SEAL_WRITE|F_SEAL_SHRINK|F_SEAL_GROW|F_SEAL_SEAL`. The seals are read back with `F_GET_SEALS` and the command is refused unless every one applied — a silently unsealed memfd would be the hole again. Sealing binds the child's descriptor too, so the copy is immutable even to the script itself.
- **macOS:** no memfd, so the copy is a 0600 file in a 0700 directory, unlinked immediately. Protection is namelessness: after verification no path the requester can reach names the object being executed.
- **Elsewhere:** declines with `FILE_EXEC_UNSUPPORTED` before anything is opened.

## Why the sealed copy, and not just the descriptor

The first pass held the original descriptor. That defeats a *replacement* — a rename over the path leaves the descriptor on the old inode — but not an *in-place rewrite* of the same inode, which the descriptor follows.

That gap looked narrow until the threat model was read the right way round. The principal this lane constrains is the requester, and the requester is the agent that wrote the script in the first place, so it owns the file. No compromise is needed: submit benign bytes, let a human approve them, rewrite the file in the window before exec, retry on failure. Against exactly the party the feature exists to bind, the guarantee would have been false.

## Tests

Both races are covered, and both have a control that fails loudly if the attack did not actually land, so neither test can pass vacuously:

- **replacement** — rename a different script over the path after verification; the run still produces the verified bytes, while a control executing the path directly proves the swap landed.
- **in-place rewrite** — a separate `O_WRONLY` handle does `WriteAt(…, 0)` without truncating, so the inode, its link and its length are unchanged; a `require` asserts the new bytes are on disk before the run is checked.

Also covered: the seals really apply and a write to the sealed copy fails; digest mismatch refuses and executes nothing; a malformed payload is a clean error rather than a panic; arguments pass through without shell interpretation; the size cap accepts exactly-at and refuses cap+1; deletion of the original does not affect the run; and signing still treats `file` like `system`.

## Deliberate choices

- **Argument expansion is suppressed on this path.** The executor normally expands a whole-arg `$VAR`; for a verified entrypoint that would be interpretation of an approved instruction.
- **A 1 MiB cap of its own.** The server caps submitted content at 64 KiB, but the agent reads from disk — where the file is whatever the requester last made it — and now holds it in memory, so a bound it cannot see is not one it can trust. Anything above the server's cap can never match a digest anyway; the headroom is so a later server-side increase does not need a fleet upgrade first.
- **Five refusal codes, not one:** `FILE_HASH_MISMATCH`, `FILE_PAYLOAD_INVALID`, `FILE_OPEN_FAILED`, `FILE_EXEC_UNSUPPORTED`, `FILE_TOO_LARGE`, each as `CODE: diagnostic`. The server has to tell a refusal from a script that merely exited non-zero.
- **One existing test changed:** `TestShellHandler_Commands` asserts the handler's exact command list, so `execfile` had to be added to it. No assertion weakened.

## Behavior change to note in release notes

The sealed copy is owned by the agent, so the kernel's permission recheck against the original inode no longer applies: a root-only-readable script becomes executable as a demoted account, which it is not today. On this lane the approval — not the file mode — is the authorization, and the approver saw the content and named the account, so this is the intended reading. It is still a change.

## Known limits at merge

**The demoted (non-root) path is unverified.** Every exec test runs with no
username, so `demotePrivileges` never executes. The documented behavior change
— a root-only-readable script becomes executable as a demoted account — rests
on the demoted child reopening `/proc/self/fd/N`, and the reasoning for why
that works has not been run. If it is wrong the lane is inert for every
non-root account, failing closed. Tracked in #439.

**This lane enforces signing, whatever the fleet mode is.** `DefaultSigningMode`
stays `monitor`, and `enforcesSignature` makes shell `file` refuse anyway, at all
three sites that branched on the mode: no signature, no usable key, and a
signature that does not verify. The skew argument that keeps the general lane on
monitor does not reach here — the server admits a file command only to an agent
version that verifies, so there is no older agent to break.

**What that does and does not buy, precisely.** It closes the misconfigured and
partially-deployed server cases, and it closes them closed. It is *not* a defense
against an active attacker in the command transport while the general lane stays
on monitor: `enforcesSignature` keys on `cmd.Shell`, which is a field that same
attacker controls, so relabelling a `file` command as `system` drops it back to
warn-and-run and `cmd.Line` executes with no digest check. Making that case safe
needs the general lane on enforce, which is a fleet decision, not this PR.

**Local development.** `pkg/runner/client.go` downgrades `enforce` to `monitor`
for local work; the file lane ignores that, so a local file-lane command now
fails hard with `key_unavailable` unless a reachable key endpoint is configured.
That matches the server, which refuses the lane outright when the assessor is off.

Each new test has a system-lane twin. Monitor still has to mean monitor
everywhere else, and without the twin a blanket flip to enforce would satisfy
the file-lane assertion just as well.

## Boundary

Only the first entrypoint is verified. Environment, libraries, interpreter version, and anything the script fetches at runtime are the executor's responsibility — the same boundary package signing draws, stated to approvers rather than hidden.

## Out of scope

Read-for-approval (the server asking the agent to read a file so a reviewer can see it before approving) is v1.1; v1 has the requester submit the content. Binary entrypoints are not supported.

## Verification

`go build` and `go vet` on darwin/linux/windows, `gofmt` clean, full `go test ./... -p 1` green on macOS and in a Linux container, `golangci-lint v2.9.0` under `GOOS=linux` reporting 0 issues. `go.mod`/`go.sum` unchanged.



