### PR TITLE
fix: stop one bad entry from failing a WebFTP folder download

### DIFF
--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -164,7 +164,7 @@ func (h *FileHandler) handleUpload(ctx context.Context, args *common.CommandArgs
 		return 1, err.Error()
 	}
 
-	name, cleanupPath, err := h.makeArchive(ctx, paths, bulk, recursive, sysProcAttr)
+	name, cleanupPath, skipped, err := h.makeArchive(ctx, paths, bulk, recursive, sysProcAttr)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create archive")
 		return 1, err.Error()
@@ -189,7 +189,7 @@ func (h *FileHandler) handleUpload(ctx context.Context, args *common.CommandArgs
 	}
 
 	if statusCode == http.StatusOK {
-		return 0, fmt.Sprintf("Successfully uploaded %d file(s).", len(paths))
+		return 0, uploadSummary(len(paths), skipped)
 	}
 
 	return 1, "You do not have permission to read on the directory. or directory does not exist"
@@ -438,25 +438,57 @@ func (h *FileHandler) parsePaths(homeDirectory string, pathList []string) ([]str
 	return paths, isBulk, isRecursive, nil
 }
 
+// skippedSummaryNamed caps how many skipped paths the upload summary spells out
+// before the rest collapse into a count, so one unreadable directory cannot fill
+// the console with a wall of paths.
+const skippedSummaryNamed = 3
+
+// uploadSummary reports the archive that was uploaded along with whatever it
+// could not hold, so a partial archive never looks like a complete one.
+func uploadSummary(count int, skipped []utils.SkippedEntry) string {
+	if len(skipped) == 0 {
+		return fmt.Sprintf("Successfully uploaded %d file(s).", count)
+	}
+
+	named := skipped
+	if len(named) > skippedSummaryNamed {
+		named = named[:skippedSummaryNamed]
+	}
+	reasons := make([]string, 0, len(named)+1)
+	for _, entry := range named {
+		reasons = append(reasons, fmt.Sprintf("%s: %v", entry.Path, entry.Reason))
+	}
+	if rest := len(skipped) - len(named); rest > 0 {
+		reasons = append(reasons, fmt.Sprintf("and %d more", rest))
+	}
+
+	// count is what the user asked for, and a skipped path is still in it, so
+	// naming a success count here would contradict the list that follows.
+	return fmt.Sprintf("Uploaded the archive, skipping %d path(s): %s",
+		len(skipped), strings.Join(reasons, "; "))
+}
+
 // makeArchive creates a zip archive from the specified paths using Go's archive/zip.
-// It returns the archive file path, a cleanup path (non-empty only for temp archives), and any error.
+// It returns the archive file path, a cleanup path (non-empty only for temp archives),
+// the paths left out of the archive, and any error.
 // cleanupPath is always derived from os.TempDir() and never from user input,
 // ensuring os.Remove(cleanupPath) is safe from path-injection.
-func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, recursive bool, sysProcAttr *syscall.SysProcAttr) (string, string, error) {
+func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, recursive bool, sysProcAttr *syscall.SysProcAttr) (string, string, []utils.SkippedEntry, error) {
 	path := paths[0]
 
 	if !bulk && !recursive {
-		return path, "", nil
+		return path, "", nil, nil
 	}
 
 	archiveName := filepath.Join(os.TempDir(), uuid.New().String()+".zip")
 
-	if err := utils.CreateZip(archiveName, paths, recursive || bulk); err != nil {
+	skipped, err := utils.CreateZip(archiveName, paths, recursive || bulk)
+	if err != nil {
 		_ = os.Remove(archiveName)
-		return "", "", err
+		return "", "", nil, err
 	}
 
-	return archiveName, archiveName, nil
+	return archiveName, archiveName, skipped, nil
 }
 
 // fileUpload uploads the file to the server. Owns src.Close():

--- a/pkg/executor/handlers/file/file_test.go
+++ b/pkg/executor/handlers/file/file_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFileHandler_Validate(t *testing.T) {
@@ -513,6 +514,58 @@ func TestFileHandler_Execute_Rm(t *testing.T) {
 			if output == "" {
 				t.Error("Execute() expected a rejection message")
 			}
+		})
+	}
+}
+
+func TestUploadSummary(t *testing.T) {
+	skip := func(path, reason string) utils.SkippedEntry {
+		return utils.SkippedEntry{Path: path, Reason: errors.New(reason)}
+	}
+
+	tests := []struct {
+		name    string
+		count   int
+		skipped []utils.SkippedEntry
+		want    string
+	}{
+		{
+			name:  "nothing skipped reads as before",
+			count: 3,
+			want:  "Successfully uploaded 3 file(s).",
+		},
+		{
+			name:    "a skipped path is named with its cause",
+			count:   2,
+			skipped: []utils.SkippedEntry{skip("/home/u/secret.txt", "permission denied")},
+			want:    "Uploaded the archive, skipping 1 path(s): /home/u/secret.txt: permission denied",
+		},
+		{
+			// count is every path the user asked for, skipped ones included, so
+			// a summary that still named it would contradict the list.
+			name:    "a requested path that was skipped is not counted as uploaded",
+			count:   1,
+			skipped: []utils.SkippedEntry{skip("/home/u/locked", "permission denied")},
+			want:    "Uploaded the archive, skipping 1 path(s): /home/u/locked: permission denied",
+		},
+		{
+			name:  "the tail collapses into a count",
+			count: 1,
+			skipped: []utils.SkippedEntry{
+				skip("/a", "permission denied"),
+				skip("/b", "permission denied"),
+				skip("/c", "permission denied"),
+				skip("/d", "no such file or directory"),
+				skip("/e", "input/output error"),
+			},
+			want: "Uploaded the archive, skipping 5 path(s): " +
+				"/a: permission denied; /b: permission denied; /c: permission denied; and 2 more",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, uploadSummary(tt.count, tt.skipped))
 		})
 	}
 }

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -85,7 +85,9 @@ func newZipEntry(w *zip.Writer, archiveName string, fi os.FileInfo, method uint1
 		Name:   filepath.ToSlash(archiveName),
 		Method: method,
 	}
-	hdr.SetMode(fi.Mode())
+	// Permissions and the link flag only: setuid, setgid and sticky mean
+	// nothing in a download and Unzip would hand them to os.OpenFile.
+	hdr.SetMode(fi.Mode().Perm() | fi.Mode()&os.ModeSymlink)
 
 	zw, err := w.CreateHeader(hdr)
 	if err != nil {

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -11,9 +11,10 @@ import (
 
 // CreateZip creates a zip archive at destPath containing the specified paths.
 // If recursive is true and a path is a directory, its contents are included recursively.
-// Explicitly listed paths are followed if they are symlinks; symlinks met while
-// walking are stored as link entries (target path, not content), so cycles cannot
-// recurse and out-of-tree targets are not pulled in.
+// A symlink listed explicitly is followed, so its whole target tree is archived
+// even when that tree lives outside the listed path. A symlink met while walking
+// is stored as a link entry (target path, not content), so it cannot recurse into
+// a cycle and its target is not pulled in.
 func CreateZip(destPath string, paths []string, recursive bool) error {
 	f, err := os.Create(destPath)
 	if err != nil {

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -16,15 +16,25 @@ import (
 // is stored as a link entry (target path, not content), so it cannot recurse into
 // a cycle and its target is not pulled in. Sockets, FIFOs and device nodes met
 // while walking are skipped; listed explicitly, they are an error.
-func CreateZip(destPath string, paths []string, recursive bool) error {
+func CreateZip(destPath string, paths []string, recursive bool) (err error) {
 	f, err := os.Create(destPath)
 	if err != nil {
 		return fmt.Errorf("failed to create zip file: %w", err)
 	}
-	defer func() { _ = f.Close() }()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to close zip file: %w", cerr)
+		}
+	}()
 
 	w := zip.NewWriter(f)
-	defer func() { _ = w.Close() }()
+	// Close writes the central directory, so discarding its error would
+	// report a truncated archive as a successful one.
+	defer func() {
+		if cerr := w.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to finalize zip file: %w", cerr)
+		}
+	}()
 
 	for _, path := range paths {
 		info, err := os.Stat(path)

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -2,12 +2,29 @@ package utils
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+var errNotRegular = errors.New("not a regular file")
+
+// SkippedEntry is a path left out of the archive, with the reason it was left
+// out. Everything else was archived.
+type SkippedEntry struct {
+	Path   string
+	Reason error
+}
+
+// unreadable separates a source that cannot be opened, which costs one entry,
+// from a failure once the entry is already being written, which costs the whole
+// archive. It carries the cause unchanged so the reported reason stays readable.
+type unreadable struct{ error }
+
+func (u unreadable) Unwrap() error { return u.error }
 
 // CreateZip creates a zip archive at destPath containing the specified paths.
 // If recursive is true and a path is a directory, its contents are included recursively.
@@ -16,10 +33,35 @@ import (
 // is stored as a link entry (target path, not content), so it cannot recurse into
 // a cycle and its target is not pulled in. Sockets, FIFOs and device nodes are
 // never archived, wherever they are found.
-func CreateZip(destPath string, paths []string, recursive bool) (err error) {
+//
+// A listed path that cannot be opened, or that is not a regular file, is left
+// out and reported in skipped, so one bad path does not cost the user the rest
+// of the archive. A failure to write the archive itself returns an error, and so
+// does a read that fails once an entry is already being written.
+func CreateZip(destPath string, paths []string, recursive bool) (skipped []SkippedEntry, err error) {
+	note := func(path string, reason error) {
+		// A PathError repeats the path the entry already carries, so keep
+		// the cause on its own and let the caller pair the two.
+		var perr *os.PathError
+		if errors.As(reason, &perr) {
+			reason = perr.Err
+		}
+		skipped = append(skipped, SkippedEntry{Path: path, Reason: reason})
+	}
+	// skip records a source that could not be opened and reports whether err
+	// was one, so both branches agree on what costs a single entry.
+	skip := func(path string, err error) bool {
+		var u unreadable
+		if !errors.As(err, &u) {
+			return false
+		}
+		note(path, u.error)
+		return true
+	}
+
 	f, err := os.Create(destPath)
 	if err != nil {
-		return fmt.Errorf("failed to create zip file: %w", err)
+		return nil, fmt.Errorf("failed to create zip file: %w", err)
 	}
 	defer func() {
 		if cerr := f.Close(); cerr != nil && err == nil {
@@ -39,7 +81,8 @@ func CreateZip(destPath string, paths []string, recursive bool) (err error) {
 	for _, path := range paths {
 		info, err := os.Stat(path)
 		if err != nil {
-			return fmt.Errorf("failed to stat %s: %w", path, err)
+			note(path, err)
+			continue
 		}
 
 		if info.IsDir() && recursive {
@@ -47,7 +90,8 @@ func CreateZip(destPath string, paths []string, recursive bool) (err error) {
 			// symlinked directory, so resolve the explicitly requested path.
 			root, err := filepath.EvalSymlinks(path)
 			if err != nil {
-				return fmt.Errorf("failed to resolve %s: %w", path, err)
+				note(path, err)
+				continue
 			}
 			base := filepath.Base(path)
 			if base == string(filepath.Separator) {
@@ -56,7 +100,10 @@ func CreateZip(destPath string, paths []string, recursive bool) (err error) {
 			}
 			err = filepath.Walk(root, func(fpath string, fi os.FileInfo, err error) error {
 				if err != nil {
-					return err
+					// Walk hands over the directory it could not read and
+					// carries on with its siblings once this returns nil.
+					note(fpath, err)
+					return nil
 				}
 				if fi.IsDir() {
 					return nil
@@ -66,31 +113,41 @@ func CreateZip(destPath string, paths []string, recursive bool) (err error) {
 					return err
 				}
 				name := filepath.Join(base, relPath)
-				if fi.Mode()&os.ModeSymlink != 0 {
-					return addSymlinkToZip(w, fpath, name, fi)
-				}
-				if !fi.Mode().IsRegular() {
+				switch {
+				case fi.Mode()&os.ModeSymlink != 0:
+					err = addSymlinkToZip(w, fpath, name, fi)
+				case !fi.Mode().IsRegular():
 					// Sockets, FIFOs and device nodes carry nothing to archive,
 					// and opening a FIFO blocks until a writer shows up.
 					return nil
+				default:
+					err = addFileToZip(w, fpath, name, fi)
 				}
-				return addFileToZip(w, fpath, name, fi)
+				if skip(fpath, err) {
+					return nil
+				}
+				return err
 			})
 			if err != nil {
-				return err
+				return skipped, err
 			}
 		} else {
 			if !info.Mode().IsRegular() {
 				// Failing here would cost the user every path listed alongside it.
+				note(path, errNotRegular)
 				continue
 			}
-			if err := addFileToZip(w, path, filepath.Base(path), info); err != nil {
-				return err
+			err := addFileToZip(w, path, filepath.Base(path), info)
+			if skip(path, err) {
+				continue
+			}
+			if err != nil {
+				return skipped, err
 			}
 		}
 	}
 
-	return nil
+	return skipped, nil
 }
 
 // newZipEntry opens an entry carrying the source mode bits, which w.Create
@@ -117,7 +174,7 @@ func newZipEntry(w *zip.Writer, archiveName string, fi os.FileInfo, method uint1
 func addSymlinkToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo) error {
 	target, err := os.Readlink(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to read symlink %s: %w", filePath, err)
+		return unreadable{err}
 	}
 
 	zw, err := newZipEntry(w, archiveName, fi, zip.Store)
@@ -135,7 +192,7 @@ func addSymlinkToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo
 func addFileToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo) error {
 	f, err := os.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to open %s: %w", filePath, err)
+		return unreadable{err}
 	}
 	defer func() { _ = f.Close() }()
 
@@ -145,6 +202,9 @@ func addFileToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo) e
 	}
 
 	if _, err := io.Copy(zw, f); err != nil {
+		// A read failing here has already written a partial entry that
+		// archive/zip cannot take back, so it ends the archive rather than
+		// leaving a silently truncated file in it.
 		return fmt.Errorf("failed to write zip entry: %w", err)
 	}
 

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -14,8 +14,8 @@ import (
 // A symlink listed explicitly is followed, so its whole target tree is archived
 // even when that tree lives outside the listed path. A symlink met while walking
 // is stored as a link entry (target path, not content), so it cannot recurse into
-// a cycle and its target is not pulled in. Sockets, FIFOs and device nodes met
-// while walking are skipped; listed explicitly, they are an error.
+// a cycle and its target is not pulled in. Sockets, FIFOs and device nodes are
+// never archived, wherever they are found.
 func CreateZip(destPath string, paths []string, recursive bool) (err error) {
 	f, err := os.Create(destPath)
 	if err != nil {
@@ -81,7 +81,8 @@ func CreateZip(destPath string, paths []string, recursive bool) (err error) {
 			}
 		} else {
 			if !info.Mode().IsRegular() {
-				return fmt.Errorf("cannot archive %s: unsupported file type %s", path, info.Mode().Type())
+				// Failing here would cost the user every path listed alongside it.
+				continue
 			}
 			if err := addFileToZip(w, path, filepath.Base(path), info); err != nil {
 				return err

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -40,6 +40,10 @@ func CreateZip(destPath string, paths []string, recursive bool) error {
 				return fmt.Errorf("failed to resolve %s: %w", path, err)
 			}
 			base := filepath.Base(path)
+			if base == string(filepath.Separator) {
+				// Base of "/" is "/", which would make every entry name absolute.
+				base = ""
+			}
 			err = filepath.Walk(root, func(fpath string, fi os.FileInfo, err error) error {
 				if err != nil {
 					return err
@@ -82,8 +86,9 @@ func CreateZip(destPath string, paths []string, recursive bool) error {
 // would replace with 0666. Zip archive names use forward slashes (ZIP spec).
 func newZipEntry(w *zip.Writer, archiveName string, fi os.FileInfo, method uint16) (io.Writer, error) {
 	hdr := &zip.FileHeader{
-		Name:   filepath.ToSlash(archiveName),
-		Method: method,
+		Name:     filepath.ToSlash(archiveName),
+		Method:   method,
+		Modified: fi.ModTime(),
 	}
 	// Permissions and the link flag only: setuid, setgid and sticky mean
 	// nothing in a download and Unzip would hand them to os.OpenFile.

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -11,6 +11,9 @@ import (
 
 // CreateZip creates a zip archive at destPath containing the specified paths.
 // If recursive is true and a path is a directory, its contents are included recursively.
+// Explicitly listed paths are followed if they are symlinks; symlinks met while
+// walking are stored as link entries (target path, not content), so cycles cannot
+// recurse and out-of-tree targets are not pulled in.
 func CreateZip(destPath string, paths []string, recursive bool) error {
 	f, err := os.Create(destPath)
 	if err != nil {
@@ -28,19 +31,29 @@ func CreateZip(destPath string, paths []string, recursive bool) error {
 		}
 
 		if info.IsDir() && recursive {
-			baseDir := filepath.Dir(path)
-			err = filepath.Walk(path, func(fpath string, fi os.FileInfo, err error) error {
+			// filepath.Walk lstats its root and would not descend into a
+			// symlinked directory, so resolve the explicitly requested path.
+			root, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return fmt.Errorf("failed to resolve %s: %w", path, err)
+			}
+			base := filepath.Base(path)
+			err = filepath.Walk(root, func(fpath string, fi os.FileInfo, err error) error {
 				if err != nil {
 					return err
 				}
 				if fi.IsDir() {
 					return nil
 				}
-				relPath, err := filepath.Rel(baseDir, fpath)
+				relPath, err := filepath.Rel(root, fpath)
 				if err != nil {
 					return err
 				}
-				return addFileToZip(w, fpath, relPath)
+				name := filepath.Join(base, relPath)
+				if fi.Mode()&os.ModeSymlink != 0 {
+					return addSymlinkToZip(w, fpath, name, fi)
+				}
+				return addFileToZip(w, fpath, name)
 			})
 			if err != nil {
 				return err
@@ -50,6 +63,32 @@ func CreateZip(destPath string, paths []string, recursive bool) error {
 				return err
 			}
 		}
+	}
+
+	return nil
+}
+
+// addSymlinkToZip writes the link target as the entry body with ModeSymlink
+// in the mode bits—the zip --symlinks layout.
+func addSymlinkToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo) error {
+	target, err := os.Readlink(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read symlink %s: %w", filePath, err)
+	}
+
+	hdr := &zip.FileHeader{
+		Name:   filepath.ToSlash(archiveName),
+		Method: zip.Store,
+	}
+	hdr.SetMode(fi.Mode())
+
+	zw, err := w.CreateHeader(hdr)
+	if err != nil {
+		return fmt.Errorf("failed to create zip entry: %w", err)
+	}
+
+	if _, err := zw.Write([]byte(target)); err != nil {
+		return fmt.Errorf("failed to write zip entry: %w", err)
 	}
 
 	return nil

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -53,19 +53,35 @@ func CreateZip(destPath string, paths []string, recursive bool) error {
 				if fi.Mode()&os.ModeSymlink != 0 {
 					return addSymlinkToZip(w, fpath, name, fi)
 				}
-				return addFileToZip(w, fpath, name)
+				return addFileToZip(w, fpath, name, fi)
 			})
 			if err != nil {
 				return err
 			}
 		} else {
-			if err := addFileToZip(w, path, filepath.Base(path)); err != nil {
+			if err := addFileToZip(w, path, filepath.Base(path), info); err != nil {
 				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+// newZipEntry opens an entry carrying the source mode bits, which w.Create
+// would replace with 0666. Zip archive names use forward slashes (ZIP spec).
+func newZipEntry(w *zip.Writer, archiveName string, fi os.FileInfo, method uint16) (io.Writer, error) {
+	hdr := &zip.FileHeader{
+		Name:   filepath.ToSlash(archiveName),
+		Method: method,
+	}
+	hdr.SetMode(fi.Mode())
+
+	zw, err := w.CreateHeader(hdr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create zip entry: %w", err)
+	}
+	return zw, nil
 }
 
 // addSymlinkToZip writes the link target as the entry body with ModeSymlink
@@ -76,15 +92,9 @@ func addSymlinkToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo
 		return fmt.Errorf("failed to read symlink %s: %w", filePath, err)
 	}
 
-	hdr := &zip.FileHeader{
-		Name:   filepath.ToSlash(archiveName),
-		Method: zip.Store,
-	}
-	hdr.SetMode(fi.Mode())
-
-	zw, err := w.CreateHeader(hdr)
+	zw, err := newZipEntry(w, archiveName, fi, zip.Store)
 	if err != nil {
-		return fmt.Errorf("failed to create zip entry: %w", err)
+		return err
 	}
 
 	if _, err := zw.Write([]byte(target)); err != nil {
@@ -94,19 +104,16 @@ func addSymlinkToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo
 	return nil
 }
 
-func addFileToZip(w *zip.Writer, filePath, archiveName string) error {
+func addFileToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo) error {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to open %s: %w", filePath, err)
 	}
 	defer func() { _ = f.Close() }()
 
-	// Use forward slashes in zip archive names (ZIP spec)
-	archiveName = filepath.ToSlash(archiveName)
-
-	zw, err := w.Create(archiveName)
+	zw, err := newZipEntry(w, archiveName, fi, zip.Deflate)
 	if err != nil {
-		return fmt.Errorf("failed to create zip entry: %w", err)
+		return err
 	}
 
 	if _, err := io.Copy(zw, f); err != nil {

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -14,7 +14,8 @@ import (
 // A symlink listed explicitly is followed, so its whole target tree is archived
 // even when that tree lives outside the listed path. A symlink met while walking
 // is stored as a link entry (target path, not content), so it cannot recurse into
-// a cycle and its target is not pulled in.
+// a cycle and its target is not pulled in. Sockets, FIFOs and device nodes met
+// while walking are skipped; listed explicitly, they are an error.
 func CreateZip(destPath string, paths []string, recursive bool) error {
 	f, err := os.Create(destPath)
 	if err != nil {
@@ -54,12 +55,20 @@ func CreateZip(destPath string, paths []string, recursive bool) error {
 				if fi.Mode()&os.ModeSymlink != 0 {
 					return addSymlinkToZip(w, fpath, name, fi)
 				}
+				if !fi.Mode().IsRegular() {
+					// Sockets, FIFOs and device nodes carry nothing to archive,
+					// and opening a FIFO blocks until a writer shows up.
+					return nil
+				}
 				return addFileToZip(w, fpath, name, fi)
 			})
 			if err != nil {
 				return err
 			}
 		} else {
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("cannot archive %s: unsupported file type %s", path, info.Mode().Type())
+			}
 			if err := addFileToZip(w, path, filepath.Base(path), info); err != nil {
 				return err
 			}

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -37,7 +37,9 @@ func (u unreadable) Unwrap() error { return u.error }
 // A listed path that cannot be opened, or that is not a regular file, is left
 // out and reported in skipped, so one bad path does not cost the user the rest
 // of the archive. A failure to write the archive itself returns an error, and so
-// does a read that fails once an entry is already being written.
+// does a read that fails once an entry is already being written. An archive that
+// holds nothing while something was skipped is an error too: an empty archive is
+// a failed request, not a partial one.
 func CreateZip(destPath string, paths []string, recursive bool) (skipped []SkippedEntry, err error) {
 	note := func(path string, reason error) {
 		// A PathError repeats the path the entry already carries, so keep
@@ -58,6 +60,10 @@ func CreateZip(destPath string, paths []string, recursive bool) (skipped []Skipp
 		note(path, u.error)
 		return true
 	}
+
+	// A caller keys off success, so an archive that ended up holding nothing
+	// must not be handed over as one.
+	archived := false
 
 	f, err := os.Create(destPath)
 	if err != nil {
@@ -126,7 +132,11 @@ func CreateZip(destPath string, paths []string, recursive bool) (skipped []Skipp
 				if skip(fpath, err) {
 					return nil
 				}
-				return err
+				if err != nil {
+					return err
+				}
+				archived = true
+				return nil
 			})
 			if err != nil {
 				return skipped, err
@@ -144,7 +154,15 @@ func CreateZip(destPath string, paths []string, recursive bool) (skipped []Skipp
 			if err != nil {
 				return skipped, err
 			}
+			archived = true
 		}
+	}
+
+	if !archived && len(skipped) > 0 {
+		// Every path was skipped, so this is the all-or-nothing failure in the
+		// other direction: an empty archive that reports a finished download.
+		return skipped, fmt.Errorf("nothing could be archived, skipped %d path(s): %w",
+			len(skipped), skipped[0].Reason)
 	}
 
 	return skipped, nil

--- a/pkg/utils/archive_linux_test.go
+++ b/pkg/utils/archive_linux_test.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateZip_CloseFailureIsReported(t *testing.T) {
+	if _, err := os.Stat("/dev/full"); err != nil {
+		t.Skip("/dev/full is not available")
+	}
+
+	src := filepath.Join(t.TempDir(), "file.txt")
+	require.NoError(t, os.WriteFile(src, []byte("hi"), 0644))
+
+	// /dev/full accepts the open and fails every write with ENOSPC. The
+	// zip.Writer buffers, so a small entry only fails once Close flushes it
+	// along with the central directory.
+	err := CreateZip("/dev/full", []string{src}, false)
+	assert.ErrorContains(t, err, "no space left on device")
+}

--- a/pkg/utils/archive_linux_test.go
+++ b/pkg/utils/archive_linux_test.go
@@ -22,6 +22,6 @@ func TestCreateZip_CloseFailureIsReported(t *testing.T) {
 	// /dev/full accepts the open and fails every write with ENOSPC. The
 	// zip.Writer buffers, so a small entry only fails once Close flushes it
 	// along with the central directory.
-	err := CreateZip("/dev/full", []string{src}, false)
+	_, err := CreateZip("/dev/full", []string{src}, false)
 	assert.ErrorContains(t, err, "no space left on device")
 }

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"archive/zip"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,6 +60,79 @@ func TestCreateZip_RecursiveDirectory(t *testing.T) {
 	defer func() { _ = r.Close() }()
 
 	assert.Len(t, r.File, 2)
+}
+
+func readZipEntry(t *testing.T, f *zip.File) string {
+	t.Helper()
+	rc, err := f.Open()
+	require.NoError(t, err)
+	body, err := io.ReadAll(rc)
+	require.NoError(t, rc.Close())
+	require.NoError(t, err)
+	return string(body)
+}
+
+func TestCreateZip_SymlinksStoredAsEntries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "demo", "real")
+	require.NoError(t, os.MkdirAll(realDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(realDir, "file.txt"), []byte("hi"), 0644))
+	require.NoError(t, os.Symlink("real", filepath.Join(dir, "demo", "link")))
+	require.NoError(t, os.Symlink("real/file.txt", filepath.Join(dir, "demo", "filelink")))
+	require.NoError(t, os.Symlink(".", filepath.Join(dir, "demo", "loop")))
+
+	dest := filepath.Join(dir, "out.zip")
+	require.NoError(t, CreateZip(dest, []string{filepath.Join(dir, "demo")}, true))
+
+	r, err := zip.OpenReader(dest)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	entries := make(map[string]*zip.File, len(r.File))
+	for _, f := range r.File {
+		entries[f.Name] = f
+	}
+
+	// One real file plus the three links: following any link would add
+	// duplicates or recurse into loop.
+	require.Len(t, entries, 4)
+	require.Contains(t, entries, "demo/real/file.txt")
+	for name, target := range map[string]string{
+		"demo/link":     "real",
+		"demo/filelink": "real/file.txt",
+		"demo/loop":     ".",
+	} {
+		entry, ok := entries[name]
+		require.True(t, ok, "link entry %s missing from archive", name)
+		assert.NotZero(t, entry.Mode()&os.ModeSymlink, name)
+		assert.Equal(t, target, readZipEntry(t, entry), name)
+	}
+}
+
+func TestCreateZip_SymlinkedRootIsFollowed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	require.NoError(t, os.MkdirAll(realDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(realDir, "file.txt"), []byte("hi"), 0644))
+	require.NoError(t, os.Symlink("real", filepath.Join(dir, "link")))
+
+	dest := filepath.Join(dir, "out.zip")
+	require.NoError(t, CreateZip(dest, []string{filepath.Join(dir, "link")}, true))
+
+	r, err := zip.OpenReader(dest)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	require.Len(t, r.File, 1)
+	assert.Equal(t, "link/file.txt", r.File[0].Name)
 }
 
 func TestCreateZip_BulkMultiplePaths(t *testing.T) {

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -84,6 +84,7 @@ func TestCreateZip_SymlinksStoredAsEntries(t *testing.T) {
 	require.NoError(t, os.Symlink("real", filepath.Join(dir, "demo", "link")))
 	require.NoError(t, os.Symlink("real/file.txt", filepath.Join(dir, "demo", "filelink")))
 	require.NoError(t, os.Symlink(".", filepath.Join(dir, "demo", "loop")))
+	require.NoError(t, os.Symlink("nowhere", filepath.Join(dir, "demo", "broken")))
 
 	dest := filepath.Join(dir, "out.zip")
 	require.NoError(t, CreateZip(dest, []string{filepath.Join(dir, "demo")}, true))
@@ -97,16 +98,18 @@ func TestCreateZip_SymlinksStoredAsEntries(t *testing.T) {
 		entries[f.Name] = f
 	}
 
-	// One real file plus the three links: following any link would add
-	// duplicates or recurse into loop. Assert on r.File as well, because the
-	// map collapses a name written twice into one key.
-	require.Len(t, r.File, 4)
-	require.Len(t, entries, 4, "archive holds duplicate entry names")
+	// One real file plus the four links: following any link would add
+	// duplicates, recurse into loop, or fail outright on broken. Assert on
+	// r.File as well, because the map collapses a name written twice into
+	// one key.
+	require.Len(t, r.File, 5)
+	require.Len(t, entries, 5, "archive holds duplicate entry names")
 	require.Contains(t, entries, "demo/real/file.txt")
 	for name, target := range map[string]string{
 		"demo/link":     "real",
 		"demo/filelink": "real/file.txt",
 		"demo/loop":     ".",
+		"demo/broken":   "nowhere",
 	} {
 		entry, ok := entries[name]
 		require.True(t, ok, "link entry %s missing from archive", name)
@@ -174,6 +177,29 @@ func TestCreateZip_SymlinkedRootIsFollowed(t *testing.T) {
 
 	require.Len(t, r.File, 1)
 	assert.Equal(t, "link/file.txt", r.File[0].Name)
+}
+
+func TestCreateZip_SymlinkedFileIsFollowed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.txt"), []byte("hi"), 0644))
+	link := filepath.Join(dir, "link.txt")
+	require.NoError(t, os.Symlink("real.txt", link))
+
+	dest := filepath.Join(dir, "out.zip")
+	require.NoError(t, CreateZip(dest, []string{link}, false))
+
+	r, err := zip.OpenReader(dest)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	require.Len(t, r.File, 1)
+	assert.Equal(t, "link.txt", r.File[0].Name)
+	assert.Zero(t, r.File[0].Mode()&os.ModeSymlink)
+	assert.Equal(t, "hi", readZipEntry(t, r.File[0]))
 }
 
 func TestCreateZip_BulkMultiplePaths(t *testing.T) {

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -30,13 +30,23 @@ func writeZip(t *testing.T, path string, entries map[string]string) {
 	require.NoError(t, f.Close())
 }
 
+// requireZip builds the archive and requires that nothing was left out of it,
+// so a test that does not care about skipping still fails if an entry silently
+// goes missing.
+func requireZip(t *testing.T, dest string, paths []string, recursive bool) {
+	t.Helper()
+	skipped, err := CreateZip(dest, paths, recursive)
+	require.NoError(t, err)
+	require.Empty(t, skipped)
+}
+
 func TestCreateZip_SingleFile(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "hello.txt")
 	require.NoError(t, os.WriteFile(src, []byte("hello world"), 0644))
 
 	dest := filepath.Join(dir, "out.zip")
-	require.NoError(t, CreateZip(dest, []string{src}, false))
+	requireZip(t, dest, []string{src}, false)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -54,7 +64,7 @@ func TestCreateZip_RecursiveDirectory(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(subdir, "b.txt"), []byte("b"), 0644))
 
 	dest := filepath.Join(dir, "out.zip")
-	require.NoError(t, CreateZip(dest, []string{filepath.Join(dir, "mydir")}, true))
+	requireZip(t, dest, []string{filepath.Join(dir, "mydir")}, true)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -88,7 +98,7 @@ func TestCreateZip_SymlinksStoredAsEntries(t *testing.T) {
 	require.NoError(t, os.Symlink("nowhere", filepath.Join(dir, "demo", "broken")))
 
 	dest := filepath.Join(dir, "out.zip")
-	require.NoError(t, CreateZip(dest, []string{filepath.Join(dir, "demo")}, true))
+	requireZip(t, dest, []string{filepath.Join(dir, "demo")}, true)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -135,7 +145,7 @@ func TestCreateZip_FileModeIsPreserved(t *testing.T) {
 	require.NoError(t, os.Chmod(plain, 0644))
 
 	dest := filepath.Join(dir, "out.zip")
-	require.NoError(t, CreateZip(dest, []string{scripts, plain}, true))
+	requireZip(t, dest, []string{scripts, plain}, true)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -169,7 +179,7 @@ func TestCreateZip_ModTimeIsPreserved(t *testing.T) {
 	require.NoError(t, os.Chtimes(src, mtime, mtime))
 
 	dest := filepath.Join(dir, "out.zip")
-	require.NoError(t, CreateZip(dest, []string{src}, false))
+	requireZip(t, dest, []string{src}, false)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -192,7 +202,7 @@ func TestCreateZip_SymlinkedRootIsFollowed(t *testing.T) {
 	require.NoError(t, os.Symlink("real", filepath.Join(dir, "link")))
 
 	dest := filepath.Join(dir, "out.zip")
-	require.NoError(t, CreateZip(dest, []string{filepath.Join(dir, "link")}, true))
+	requireZip(t, dest, []string{filepath.Join(dir, "link")}, true)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -213,7 +223,7 @@ func TestCreateZip_SymlinkedFileIsFollowed(t *testing.T) {
 	require.NoError(t, os.Symlink("real.txt", link))
 
 	dest := filepath.Join(dir, "out.zip")
-	require.NoError(t, CreateZip(dest, []string{link}, false))
+	requireZip(t, dest, []string{link}, false)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -233,7 +243,7 @@ func TestCreateZip_BulkMultiplePaths(t *testing.T) {
 	require.NoError(t, os.WriteFile(f2, []byte("2"), 0644))
 
 	dest := filepath.Join(dir, "out.zip")
-	require.NoError(t, CreateZip(dest, []string{f1, f2}, true))
+	requireZip(t, dest, []string{f1, f2}, true)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -288,7 +298,7 @@ func TestCreateZipAndUnzip_RoundTrip(t *testing.T) {
 
 	// Zip
 	zipPath := filepath.Join(dir, "archive.zip")
-	require.NoError(t, CreateZip(zipPath, []string{srcDir}, true))
+	requireZip(t, zipPath, []string{srcDir}, true)
 
 	// Unzip
 	outDir := filepath.Join(dir, "out")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -128,7 +128,7 @@ func TestCreateZip_FileModeIsPreserved(t *testing.T) {
 	require.NoError(t, os.MkdirAll(scripts, 0755))
 	script := filepath.Join(scripts, "run.sh")
 	require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\n"), 0644))
-	require.NoError(t, os.Chmod(script, 0755))
+	require.NoError(t, os.Chmod(script, os.ModeSetuid|0755))
 	plain := filepath.Join(dir, "plain.txt")
 	require.NoError(t, os.WriteFile(plain, []byte("x"), 0644))
 	require.NoError(t, os.Chmod(plain, 0644))
@@ -142,10 +142,13 @@ func TestCreateZip_FileModeIsPreserved(t *testing.T) {
 
 	modes := make(map[string]os.FileMode, len(r.File))
 	for _, f := range r.File {
-		modes[f.Name] = f.Mode().Perm()
+		modes[f.Name] = f.Mode()
 	}
-	assert.Equal(t, os.FileMode(0755), modes["scripts/run.sh"])
-	assert.Equal(t, os.FileMode(0644), modes["plain.txt"])
+	assert.Equal(t, os.FileMode(0755), modes["scripts/run.sh"].Perm())
+	assert.Equal(t, os.FileMode(0644), modes["plain.txt"].Perm())
+	// A download has no use for setuid, and Unzip hands the entry mode to
+	// os.OpenFile, so the extracted file would carry it.
+	assert.Zero(t, modes["scripts/run.sh"]&os.ModeSetuid)
 
 	outDir := filepath.Join(dir, "out")
 	require.NoError(t, os.MkdirAll(outDir, 0755))

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -98,8 +98,10 @@ func TestCreateZip_SymlinksStoredAsEntries(t *testing.T) {
 	}
 
 	// One real file plus the three links: following any link would add
-	// duplicates or recurse into loop.
-	require.Len(t, entries, 4)
+	// duplicates or recurse into loop. Assert on r.File as well, because the
+	// map collapses a name written twice into one key.
+	require.Len(t, r.File, 4)
+	require.Len(t, entries, 4, "archive holds duplicate entry names")
 	require.Contains(t, entries, "demo/real/file.txt")
 	for name, target := range map[string]string{
 		"demo/link":     "real",

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -158,6 +159,25 @@ func TestCreateZip_FileModeIsPreserved(t *testing.T) {
 	fi, err := os.Stat(filepath.Join(outDir, "scripts", "run.sh"))
 	require.NoError(t, err)
 	assert.NotZero(t, fi.Mode().Perm()&0100, "extracted script lost its execute bit")
+}
+
+func TestCreateZip_ModTimeIsPreserved(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "old.txt")
+	require.NoError(t, os.WriteFile(src, []byte("x"), 0644))
+	mtime := time.Date(2021, 3, 4, 5, 6, 8, 0, time.UTC)
+	require.NoError(t, os.Chtimes(src, mtime, mtime))
+
+	dest := filepath.Join(dir, "out.zip")
+	require.NoError(t, CreateZip(dest, []string{src}, false))
+
+	r, err := zip.OpenReader(dest)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	require.Len(t, r.File, 1)
+	// Zip's DOS timestamp has two-second granularity.
+	assert.WithinDuration(t, mtime, r.File[0].Modified, 2*time.Second)
 }
 
 func TestCreateZip_SymlinkedRootIsFollowed(t *testing.T) {

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -115,6 +115,45 @@ func TestCreateZip_SymlinksStoredAsEntries(t *testing.T) {
 	}
 }
 
+func TestCreateZip_FileModeIsPreserved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	scripts := filepath.Join(dir, "scripts")
+	require.NoError(t, os.MkdirAll(scripts, 0755))
+	script := filepath.Join(scripts, "run.sh")
+	require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\n"), 0644))
+	require.NoError(t, os.Chmod(script, 0755))
+	plain := filepath.Join(dir, "plain.txt")
+	require.NoError(t, os.WriteFile(plain, []byte("x"), 0644))
+	require.NoError(t, os.Chmod(plain, 0644))
+
+	dest := filepath.Join(dir, "out.zip")
+	require.NoError(t, CreateZip(dest, []string{scripts, plain}, true))
+
+	r, err := zip.OpenReader(dest)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	modes := make(map[string]os.FileMode, len(r.File))
+	for _, f := range r.File {
+		modes[f.Name] = f.Mode().Perm()
+	}
+	assert.Equal(t, os.FileMode(0755), modes["scripts/run.sh"])
+	assert.Equal(t, os.FileMode(0644), modes["plain.txt"])
+
+	outDir := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(outDir, 0755))
+	require.NoError(t, Unzip(dest, outDir))
+
+	// Only the owner-execute bit: umask can clear the group and other bits.
+	fi, err := os.Stat(filepath.Join(outDir, "scripts", "run.sh"))
+	require.NoError(t, err)
+	assert.NotZero(t, fi.Mode().Perm()&0100, "extracted script lost its execute bit")
+}
+
 func TestCreateZip_SymlinkedRootIsFollowed(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_unix_test.go
+++ b/pkg/utils/archive_unix_test.go
@@ -1,0 +1,55 @@
+//go:build !windows
+
+package utils
+
+import (
+	"archive/zip"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateZip_IrregularEntriesAreSkipped(t *testing.T) {
+	// Short base directory: a unix socket path must fit in sun_path (104
+	// bytes on darwin), which t.TempDir() plus this test's name overruns.
+	dir, err := os.MkdirTemp("", "z")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	demo := filepath.Join(dir, "demo")
+	require.NoError(t, os.MkdirAll(demo, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(demo, "file.txt"), []byte("hi"), 0644))
+	require.NoError(t, syscall.Mkfifo(filepath.Join(demo, "fifo"), 0600))
+	sock, err := net.Listen("unix", filepath.Join(demo, "sock"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sock.Close() })
+
+	dest := filepath.Join(dir, "out.zip")
+	// The socket used to fail the whole archive and the FIFO used to block
+	// os.Open forever, with no context to cancel it.
+	require.NoError(t, CreateZip(dest, []string{demo}, true))
+
+	r, err := zip.OpenReader(dest)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	require.Len(t, r.File, 1)
+	assert.Equal(t, "demo/file.txt", r.File[0].Name)
+}
+
+func TestCreateZip_IrregularPathIsRejected(t *testing.T) {
+	dir, err := os.MkdirTemp("", "z")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	fifo := filepath.Join(dir, "fifo")
+	require.NoError(t, syscall.Mkfifo(fifo, 0600))
+
+	dest := filepath.Join(dir, "out.zip")
+	assert.ErrorContains(t, CreateZip(dest, []string{fifo}, false), "unsupported file type")
+}

--- a/pkg/utils/archive_unix_test.go
+++ b/pkg/utils/archive_unix_test.go
@@ -115,3 +115,25 @@ func TestCreateZip_UnreadableEntriesAreSkipped(t *testing.T) {
 		filepath.Join(resolved, "secret.txt"),
 	}, reported)
 }
+
+func TestCreateZip_NothingArchivedIsAnError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads a 0000 directory whatever its mode says")
+	}
+
+	dir := t.TempDir()
+	demo := filepath.Join(dir, "demo")
+	require.NoError(t, os.MkdirAll(demo, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(demo, "hidden.txt"), []byte("h"), 0644))
+	require.NoError(t, os.Chmod(demo, 0000))
+	// TempDir cannot delete what it cannot enter, and cleanups run last in first.
+	t.Cleanup(func() { _ = os.Chmod(demo, 0755) })
+
+	dest := filepath.Join(dir, "out.zip")
+	// Skipping every path leaves an archive holding nothing, and the caller
+	// keys off the exit code, so success here would read as a finished download.
+	skipped, err := CreateZip(dest, []string{demo}, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrPermission)
+	require.Len(t, skipped, 1)
+}

--- a/pkg/utils/archive_unix_test.go
+++ b/pkg/utils/archive_unix_test.go
@@ -32,7 +32,7 @@ func TestCreateZip_IrregularEntriesAreSkipped(t *testing.T) {
 	dest := filepath.Join(dir, "out.zip")
 	// The socket used to fail the whole archive and the FIFO used to block
 	// os.Open forever, with no context to cancel it.
-	require.NoError(t, CreateZip(dest, []string{demo}, true))
+	requireZip(t, dest, []string{demo}, true)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -43,9 +43,7 @@ func TestCreateZip_IrregularEntriesAreSkipped(t *testing.T) {
 }
 
 func TestCreateZip_ListedIrregularPathIsSkipped(t *testing.T) {
-	dir, err := os.MkdirTemp("", "z")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "file.txt")
 	require.NoError(t, os.WriteFile(file, []byte("hi"), 0644))
@@ -56,7 +54,8 @@ func TestCreateZip_ListedIrregularPathIsSkipped(t *testing.T) {
 	// The shape a multi-select produces, and the only one that reaches this
 	// branch: several paths listed at once, one of them irregular. A lone
 	// FIFO is streamed without an archive and never gets here.
-	require.NoError(t, CreateZip(dest, []string{file, fifo}, true))
+	skipped, err := CreateZip(dest, []string{file, fifo}, true)
+	require.NoError(t, err)
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)
@@ -64,4 +63,55 @@ func TestCreateZip_ListedIrregularPathIsSkipped(t *testing.T) {
 
 	require.Len(t, r.File, 1)
 	assert.Equal(t, "file.txt", r.File[0].Name)
+
+	// The user picked this path by hand, so dropping it without a word would
+	// leave them reading an archive that is quietly short one entry.
+	require.Len(t, skipped, 1)
+	assert.Equal(t, fifo, skipped[0].Path)
+	assert.ErrorIs(t, skipped[0].Reason, errNotRegular)
+}
+
+func TestCreateZip_UnreadableEntriesAreSkipped(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads a 0000 file whatever its mode says")
+	}
+
+	dir := t.TempDir()
+	demo := filepath.Join(dir, "demo")
+	locked := filepath.Join(demo, "locked")
+	secret := filepath.Join(demo, "secret.txt")
+	require.NoError(t, os.MkdirAll(locked, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(demo, "readable.txt"), []byte("hi"), 0644))
+	require.NoError(t, os.WriteFile(secret, []byte("s"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(locked, "hidden.txt"), []byte("h"), 0644))
+	require.NoError(t, os.Chmod(secret, 0000))
+	require.NoError(t, os.Chmod(locked, 0000))
+	// TempDir cannot delete what it cannot enter, and cleanups run last in first.
+	t.Cleanup(func() { _ = os.Chmod(locked, 0755) })
+
+	dest := filepath.Join(dir, "out.zip")
+	skipped, err := CreateZip(dest, []string{demo}, true)
+	require.NoError(t, err)
+
+	r, err := zip.OpenReader(dest)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	require.Len(t, r.File, 1)
+	assert.Equal(t, "demo/readable.txt", r.File[0].Name)
+
+	var reported []string
+	for _, entry := range skipped {
+		reported = append(reported, entry.Path)
+		assert.ErrorIs(t, entry.Reason, os.ErrPermission)
+	}
+	// Walk runs on the resolved root, and on darwin /var is a link to
+	// /private/var, so the reported paths carry the resolved prefix.
+	resolved, err := filepath.EvalSymlinks(demo)
+	require.NoError(t, err)
+	// The unreadable directory is reported once, not once per file inside it.
+	assert.ElementsMatch(t, []string{
+		filepath.Join(resolved, "locked"),
+		filepath.Join(resolved, "secret.txt"),
+	}, reported)
 }

--- a/pkg/utils/archive_unix_test.go
+++ b/pkg/utils/archive_unix_test.go
@@ -42,14 +42,26 @@ func TestCreateZip_IrregularEntriesAreSkipped(t *testing.T) {
 	assert.Equal(t, "demo/file.txt", r.File[0].Name)
 }
 
-func TestCreateZip_IrregularPathIsRejected(t *testing.T) {
+func TestCreateZip_ListedIrregularPathIsSkipped(t *testing.T) {
 	dir, err := os.MkdirTemp("", "z")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 
+	file := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(file, []byte("hi"), 0644))
 	fifo := filepath.Join(dir, "fifo")
 	require.NoError(t, syscall.Mkfifo(fifo, 0600))
 
 	dest := filepath.Join(dir, "out.zip")
-	assert.ErrorContains(t, CreateZip(dest, []string{fifo}, false), "unsupported file type")
+	// The shape a multi-select produces, and the only one that reaches this
+	// branch: several paths listed at once, one of them irregular. A lone
+	// FIFO is streamed without an archive and never gets here.
+	require.NoError(t, CreateZip(dest, []string{file, fifo}, true))
+
+	r, err := zip.OpenReader(dest)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	require.Len(t, r.File, 1)
+	assert.Equal(t, "file.txt", r.File[0].Name)
 }


### PR DESCRIPTION
## Background

Downloading a folder through WebFTP fails with exit 1 whenever the folder contains a symlink to a directory (#432). `CreateZip` in `pkg/utils/archive.go` treated every non-directory walk entry as a regular file: `filepath.Walk` reports entries through `Lstat`, so `IsDir()` is false for a link to a directory, but `os.Open` follows the link, and `io.Copy` on the opened directory failed with `EISDIR`, aborting the whole archive. One link anywhere in the tree made the entire download fail.

The same all-or-nothing shape turned out to have three more ways in, all of them found in review: a socket named explicitly, a file the user cannot read, and a `Close` error thrown away. They are fixed here too, since fixing only the symlink path would leave the folder download failing whole for reasons the user can neither see nor avoid.

## Changes

Symlinks met while walking a directory are now stored as zip link entries: the target path as the entry body with `ModeSymlink` set in the external attributes, the layout `zip --symlinks` produces. Standard tools (`unzip`, `bsdtar`, macOS Archive Utility) restore them as real links. Storing a walked link rather than following it also means a self-referencing link cannot recurse and that link's target is not pulled into the archive.

An explicitly listed path is still followed when it is a symlink. `filepath.Walk` lstats its root and would otherwise not descend into a symlinked directory, so the root is resolved with `filepath.EvalSymlinks` first. A directory named this way is archived in full, including whatever part of its target tree lives outside the listed path.

Sockets, FIFOs and device nodes are never archived, wherever they are found. They used to reach `os.Open` like any regular file, which is wrong for all of them: a socket fails the open and aborts the whole archive, the same all-or-nothing failure this PR set out to fix, and opening a FIFO read-only waits for a writer that a download will never provide. None of the three has content an archive can carry. Sockets in particular are ordinary things to find in a home directory: gpg-agent, ssh-agent, `docker.sock`. One met while walking is dropped silently, since the user never picked it out; one named explicitly is reported in the skipped list described below, because a path chosen by hand should not disappear without a word.

Entry headers now carry the source file's mode. `zip.Writer.Create` leaves the header's mode bits unset, so every regular file was written as 0666 while symlinks kept their real mode through `CreateHeader` plus `SetMode`. `Unzip` passes `f.Mode()` straight to `os.OpenFile`, so an executable script inside a downloaded folder came back without its execute bit. Both entry kinds now go through one helper that sets the name, the compression method, the mode and the modification time; regular files stay on Deflate and link entries on Store.

The mode written to the entry is the permission bits plus the link flag, not the whole mode. Handing `SetMode` the source's full mode turned a 04755 file into an entry carrying setuid, and `UnzipReader` would pass that to `os.OpenFile`, which recreates a setuid file on extraction. Two smaller header fixes ride along: `Modified` is set from the source, where every entry used to carry the 1980 DOS epoch, and archiving `/` no longer produces absolute entry names, since `filepath.Base("/")` is `/`.

`zip.Writer.Close` writes the central directory, and both deferred closes used to throw their error away. A write that fails there — a full disk, an NFS mount that went away — leaves an archive with no readable index while `CreateZip` still returned nil, so the user was told the download succeeded and then handed a zip nothing will open, with nothing in the log either. Both closes now report, and an error from `Close` never overwrites one that was already on its way out.

One file the user cannot read no longer ends the download. A home directory holding a single 0600 file belonging to someone else produced no archive at all, and the console showed that file's error in place of the folder that was asked for. `CreateZip` now returns the paths it left out alongside the error, splitting a source that cannot be opened, which costs one entry, from a failure once an entry is already being written, which costs the archive. `archive/zip` cannot take back an entry it has begun writing, so a read that breaks mid-copy has to end the archive rather than leave a silently truncated file inside it. An unreadable subdirectory is reported once rather than once per file it hides, since `filepath.Walk` hands over the directory it could not read and carries on with its siblings.

This follows what the standard tools do. `cp`, `rsync`, `tar` and `zip` were each run against a chmod 000 file under a non-root user: all four copy or archive everything else, name the path they could not read, and exit non-zero — 1, 23, 2 and 18 respectively. None of them splits its behaviour by errno, so neither does this.

`handleUpload` names up to three skipped paths with their causes and collapses the rest into a count, so one unreadable directory cannot fill the console with a wall of paths. When something was skipped the summary drops the file count entirely: that count is every path the user asked for, skipped ones included, and printing it beside the skip list would contradict it. The exit code stays 0 for a partial archive, because `handleUpload` has only 0 and 1 and returning 1 would put back the all-or-nothing appearance this PR removes.

An archive that ended up holding nothing while something was skipped is the other boundary, and it is a failure. `CreateZip` returns an error there, `makeArchive` deletes the empty file, and the command exits 1. Without that floor the reachable case was an ordinary folder download: `parsePaths` only stats the directory, so it succeeds and `recursive` is true, `filepath.Walk` then fails on the root with EACCES, the callback notes it and returns nil, and the user received a 22-byte zip holding nothing but its central directory, with exit 0. The summary named the skipped path, but the web client can only key off the exit code, so it read a completed download. Skipping everything is not a partial success.

## Behavior change

A symlink to a file met while walking used to be dereferenced into a full copy: the download succeeded and the user received a real file carrying the link's name. It is now stored as a link entry instead. Nobody reported this as broken, so it is a policy change rather than a bug fix, and it is what #432 refers to as "silently dereferenced as full copies". Extractors on macOS and Linux recreate the link; Windows Explorer writes a small text file holding the target path. A symlink named explicitly on the command is still followed, so that path is unaffected.

A folder download that used to fail whole on one unreadable or irregular entry now succeeds with a partial archive, and the console message names what is missing and why. The command still exits 0 in that case, so a caller reading only the exit code sees success where it used to see failure. A download where every path was skipped still exits 1, since an archive holding nothing is a failed request rather than a partial one.

`CreateZip` returns two values now. The only caller in this repo is `makeArchive`; a caller that ignores the skipped list is telling the user an archive is complete when it may not be.

Known limitation, not addressed here: `UnzipReader` has no link branch, so re-uploading a downloaded archive with `allow_unzip` turns each link entry back into a plain text file holding the target path. Adding link creation there needs the zip-slip check extended to link targets, which the current entry-name check does not cover.

## Testing

`TestCreateZip_SymlinksStoredAsEntries` builds a directory link, a file link, a self-referencing loop (`loop -> .`), and a broken link (`broken -> nowhere`), then asserts the archive holds exactly one real file plus the four links, each with `ModeSymlink` set and the target path as its body. The broken link pins the change from the old failure, where `os.Open` killed the whole archive with "failed to open". `TestCreateZip_SymlinkedRootIsFollowed` and `TestCreateZip_SymlinkedFileIsFollowed` cover the explicitly listed directory and file, the latter asserting the entry is a plain file carrying the target's content. `TestCreateZip_FileModeIsPreserved` archives a 04755 script and a 0644 file, checks both modes on the entries, checks setuid is gone, and checks the owner-execute bit survives extraction. `TestCreateZip_ModTimeIsPreserved` pins the entry timestamp to the source's.

`TestCreateZip_IrregularEntriesAreSkipped` puts a FIFO and a bound unix socket next to a real file and requires the archive to hold the file alone. `TestCreateZip_ListedIrregularPathIsSkipped` covers a FIFO named alongside a regular file, the only shape a multi-select can produce, and asserts the FIFO comes back in the skipped list rather than failing the archive or vanishing. Both live in a `!windows` file, since `syscall.Mkfifo` does not exist there.

`TestCreateZip_UnreadableEntriesAreSkipped` builds a directory holding a readable file, a 0000 file and a 0000 subdirectory, then asserts the archive holds the readable file alone while both unreadable paths come back carrying `os.ErrPermission` — the subdirectory once, not once per file inside it. It skips under root, which reads a 0000 file whatever its mode says. `TestCreateZip_CloseFailureIsReported` writes to `/dev/full`, which accepts the open and fails every write with ENOSPC; `zip.Writer` buffers, so a small entry survives `io.Copy` and only fails once `Close` flushes it with the central directory. No such device exists on darwin, so that test is build-tagged linux and was run in a container. `TestCreateZip_NothingArchivedIsAnError` builds the folder-download shape the guard exists for, a 0000 directory named on its own, and requires an error carrying `os.ErrPermission` alongside the one skipped path; it sits beside the partial case so both sides of the boundary are pinned. `TestUploadSummary` covers the console message itself: nothing skipped, one path named with its cause, a requested path that was skipped, and a tail that collapses into a count.

Every test that does not care about skipping now goes through a `requireZip` helper that also requires the skipped list to be empty, so an entry cannot silently go missing from a test that was not looking for it.

Every one of these was seen failing first: against the unfixed code, or against a deliberate mutation of the fixed code (`os.Stat` swapped for `os.Lstat`, a branch switched off, `CreateHeader` reverted to `Create`, the skip bookkeeping reverted to `return err`, `uploadSummary` made to ignore its skipped argument, the empty-archive guard inverted to `archived && len(skipped) > 0`). Without the irregular-file branch the socket fails with "operation not supported on socket" and the FIFO test never returns. Full suite: `go test ./... -p 1` exit 0 on darwin, and `pkg/utils` plus `pkg/executor/handlers/file` re-run in a `golang:1.25` container for the linux-only test.

Verified end to end on the dev workspace: an agent built from this branch, registered in a container holding the link layout under `/tmp/demo` plus a FIFO, a bound unix socket, a 04755 script and a file stamped 2021-03-04. The WebFTP folder download completed (`upload` command exit 0 in 487ms, previously exit 1 with EISDIR), the server recorded `demo.zip` with `success: true`, and `zipinfo` on the S3 object shows six entries: the four `lrwxrwxrwx` links, the file at `100644` dated 2021 Mar 4, and the script at `100755` with setuid dropped. Neither the FIFO nor the socket appears. After extraction `cat demo/link/file.txt` prints the file's content through the restored link.

Closes #432

