### PR TITLE
fix: restore symlinks when unzipping an uploaded archive

### DIFF
--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -283,7 +283,7 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 
 	if args.AllowUnzip {
 		if rc := utils.OpenIfZip(args.Path, filepath.Ext(args.Path)); rc != nil {
-			err := utils.UnzipReader(rc, filepath.Dir(args.Path))
+			err := utils.UnzipReader(&rc.Reader, filepath.Dir(args.Path))
 			_ = rc.Close()
 			if err != nil {
 				log.Error().Err(err).Msg("Failed to unzip file.")

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -264,7 +264,7 @@ func UnzipReader(r *zip.ReadCloser, destDir string) error {
 	for _, f := range r.File {
 		fpath := filepath.Join(root, f.Name)
 		if !isInside(root, fpath) {
-			return fmt.Errorf("illegal file path in zip: %s", f.Name)
+			return fmt.Errorf("illegal file path in zip: %q", f.Name)
 		}
 
 		if f.FileInfo().IsDir() {
@@ -308,7 +308,7 @@ func isInside(root, path string) bool {
 func mkdirAllInside(root, dir, name string) error {
 	rel, err := filepath.Rel(root, dir)
 	if err != nil {
-		return fmt.Errorf("illegal file path in zip: %s", name)
+		return fmt.Errorf("illegal file path in zip: %q", name)
 	}
 	if rel == "." {
 		return nil
@@ -331,7 +331,7 @@ func mkdirAllInside(root, dir, name string) error {
 			return err
 		}
 		if fi.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("illegal link target in zip: %s is written through a symlink", name)
+			return fmt.Errorf("illegal link target in zip: %q is written through a symlink", name)
 		}
 	}
 
@@ -355,12 +355,12 @@ func extractSymlink(f *zip.File, root, fpath string) error {
 		return err
 	}
 	if len(body) > maxSymlinkTarget {
-		return fmt.Errorf("illegal link target in zip: %s exceeds %d bytes", f.Name, maxSymlinkTarget)
+		return fmt.Errorf("illegal link target in zip: %q exceeds %d bytes", f.Name, maxSymlinkTarget)
 	}
 
 	target := string(body)
 	if !isValidLinkTarget(root, fpath, target) {
-		return fmt.Errorf("illegal link target in zip: %s -> %s", f.Name, target)
+		return fmt.Errorf("illegal link target in zip: %q -> %q", f.Name, target)
 	}
 
 	// os.Symlink refuses an existing path where a regular entry would have

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -10,6 +10,20 @@ import (
 	"strings"
 )
 
+const (
+	// maxSymlinkTarget is past any platform's path limit, so a longer body is a
+	// malformed entry, not a target worth reading into memory.
+	maxSymlinkTarget = 4096
+
+	// maxLinkResolution bounds the chain isValidLinkTarget will walk, the way
+	// ELOOP bounds the kernel's own resolution.
+	maxLinkResolution = 64
+
+	// symlinkAttempts bounds createSymlink's retry, so a path that another
+	// extraction keeps refilling ends the entry instead of spinning on it.
+	symlinkAttempts = 3
+)
+
 var errNotRegular = errors.New("not a regular file")
 
 // SkippedEntry is a path left out of the archive, with the reason it was left
@@ -25,6 +39,12 @@ type SkippedEntry struct {
 type unreadable struct{ error }
 
 func (u unreadable) Unwrap() error { return u.error }
+
+// extractedLink is a link entry held back until the regular ones are out.
+type extractedLink struct {
+	file *zip.File
+	path string
+}
 
 // CreateZip creates a zip archive at destPath containing the specified paths.
 // If recursive is true and a path is a directory, its contents are included
@@ -225,14 +245,6 @@ func addSymlinkToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo
 	return nil
 }
 
-func isEmptyDir(path string) (bool, error) {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return false, err
-	}
-	return len(entries) == 0, nil
-}
-
 // addDirToZip writes a directory entry. The trailing slash is what every other
 // zip reader keys off; the mode bit alone is not enough.
 func addDirToZip(w *zip.Writer, archiveName string, fi os.FileInfo) error {
@@ -260,6 +272,14 @@ func addFileToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo) e
 	}
 
 	return nil
+}
+
+func isEmptyDir(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
 }
 
 // Unzip extracts a zip archive to the specified destination directory.
@@ -337,12 +357,6 @@ func UnzipReader(r *zip.ReadCloser, destDir string) error {
 	return recheckLinks(root, links)
 }
 
-// extractedLink is a link entry held back until the regular ones are out.
-type extractedLink struct {
-	file *zip.File
-	path string
-}
-
 // recheckLinks walks every link the extraction wrote once the archive is fully
 // on disk. A target is checked against what exists when the link is written, so
 // a link the archive lists later can still turn an earlier one into an escape.
@@ -408,10 +422,6 @@ func mkdirAllInside(root, dir, name string) error {
 	return nil
 }
 
-// maxSymlinkTarget is past any platform's path limit, so a longer body is a
-// malformed entry, not a target worth reading into memory.
-const maxSymlinkTarget = 4096
-
 // extractSymlink is the mirror of addSymlinkToZip.
 func extractSymlink(f *zip.File, root, fpath string) error {
 	rc, err := f.Open()
@@ -434,8 +444,6 @@ func extractSymlink(f *zip.File, root, fpath string) error {
 
 	return createSymlink(target, fpath)
 }
-
-const symlinkAttempts = 3
 
 // createSymlink puts a link to target at fpath, over whatever is already there.
 // A regular entry gets that from O_TRUNC in one call, and this is the same
@@ -462,10 +470,6 @@ func createSymlink(target, fpath string) error {
 		}
 	}
 }
-
-// maxLinkResolution bounds the chain isValidLinkTarget will walk, the way ELOOP
-// bounds the kernel's own resolution.
-const maxLinkResolution = 64
 
 // isValidLinkTarget reports whether a link at fpath may carry target. It walks
 // the target component by component, following every link already on disk,

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -2,11 +2,13 @@ package utils
 
 import (
 	"archive/zip"
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -46,8 +48,10 @@ type unreadable struct{ error }
 
 func (u unreadable) Unwrap() error { return u.error }
 
-// extractedLink is a link entry held back until the regular ones are out.
-type extractedLink struct {
+// deferredEntry is an entry whose work waits until the regular entries are out:
+// a link, so what it points at exists first, or a directory's mode, so a
+// read-only one cannot block the entries below it.
+type deferredEntry struct {
 	file *zip.File
 	path string
 }
@@ -318,6 +322,9 @@ func Unzip(src, destDir string) error {
 // Nothing may leave destDir: an escaping entry name, a link target that lands
 // outside once every link on the way to it is followed, and an entry written
 // through a link are each refused.
+//
+// A directory entry's mode lands last, deepest first, so a read-only directory
+// cannot block the entries below it.
 func UnzipReader(r *zip.Reader, destDir string) error {
 	// destDir used to appear on its own with the first entry, back when every
 	// entry called os.MkdirAll on its own parent.
@@ -332,7 +339,8 @@ func UnzipReader(r *zip.Reader, destDir string) error {
 		return fmt.Errorf("failed to resolve destination directory: %w", err)
 	}
 
-	var links []extractedLink
+	var links []deferredEntry
+	var dirs []deferredEntry
 	for _, f := range r.File {
 		fpath := filepath.Join(root, f.Name)
 		if !isInside(root, fpath) {
@@ -343,6 +351,7 @@ func UnzipReader(r *zip.Reader, destDir string) error {
 			if err := mkdirAllInside(root, fpath, f.Name); err != nil {
 				return err
 			}
+			dirs = append(dirs, deferredEntry{file: f, path: fpath})
 			continue
 		}
 
@@ -354,7 +363,7 @@ func UnzipReader(r *zip.Reader, destDir string) error {
 		// by what the target is at creation time, and entry order does not
 		// promise the target has been extracted yet.
 		if f.Mode()&os.ModeSymlink != 0 {
-			links = append(links, extractedLink{file: f, path: fpath})
+			links = append(links, deferredEntry{file: f, path: fpath})
 			continue
 		}
 
@@ -382,6 +391,41 @@ func UnzipReader(r *zip.Reader, destDir string) error {
 		return rejected
 	}
 
+	return applyDirModes(dirs)
+}
+
+// applyDirModes lands each directory entry's mode once everything below it is
+// out, because a directory entry from zip -r comes before its children and a
+// read-only mode landing first would block them. Deepest first for the same
+// reason: a parent without search permission blocks the chmod below it. A
+// child's path is longer than its parent's, so longest first is deepest first.
+func applyDirModes(dirs []deferredEntry) error {
+	slices.SortStableFunc(dirs, func(a, b deferredEntry) int {
+		return cmp.Compare(len(b.path), len(a.path))
+	})
+
+	for _, dir := range dirs {
+		// A link entry that took the directory's name has nothing for this
+		// mode to land on, and os.Chmod would follow it to whatever it points
+		// at.
+		fi, err := os.Lstat(dir.path)
+		if err != nil {
+			return fmt.Errorf("failed to set mode of %q: %w", dir.file.Name, err)
+		}
+		if !fi.IsDir() {
+			return fmt.Errorf("illegal entry in zip: %q is no longer a directory", dir.file.Name)
+		}
+		// Perm only, for the reason extractFile gives. Zero is an archive that
+		// carried no mode at all, not a directory nobody may enter.
+		mode := dir.file.Mode().Perm()
+		if mode == 0 {
+			continue
+		}
+		if err := chmodDir(dir.path, mode); err != nil {
+			return fmt.Errorf("failed to set mode of %q: %w", dir.file.Name, err)
+		}
+	}
+
 	return nil
 }
 
@@ -392,7 +436,7 @@ func UnzipReader(r *zip.Reader, destDir string) error {
 // as it was. rejected is the first offender removed and left the first one
 // still on disk. The caller reports left ahead of everything else, since it
 // means destDir still holds an escape.
-func recheckLinks(root string, links []extractedLink) (rejected, left error) {
+func recheckLinks(root string, links []deferredEntry) (rejected, left error) {
 	for _, link := range links {
 		target, err := os.Readlink(link.path)
 		if err != nil {

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -15,8 +15,9 @@ const (
 	// malformed entry, not a target worth reading into memory.
 	maxSymlinkTarget = 4096
 
-	// maxLinkResolution bounds the chain isValidLinkTarget will walk, the way
-	// ELOOP bounds the kernel's own resolution.
+	// maxLinkResolution bounds the links isValidLinkTarget will follow, the
+	// way ELOOP bounds the kernel's own resolution. Components are not
+	// counted: a deep tree with no link in it is not a chain.
 	maxLinkResolution = 64
 
 	// symlinkAttempts bounds createSymlink's retry, so a path that another
@@ -495,11 +496,8 @@ func isValidLinkTarget(root, fpath, target string) bool {
 
 	current := filepath.Dir(fpath)
 	parts := strings.Split(target, "/")
-	for steps := 0; len(parts) > 0; steps++ {
-		if steps > maxLinkResolution {
-			return false
-		}
-
+	hops := 0
+	for len(parts) > 0 {
 		part := parts[0]
 		parts = parts[1:]
 
@@ -511,6 +509,10 @@ func isValidLinkTarget(root, fpath, target string) bool {
 		default:
 			next := filepath.Join(current, part)
 			if fi, err := os.Lstat(next); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+				hops++
+				if hops > maxLinkResolution {
+					return false
+				}
 				link, err := os.Readlink(next)
 				// An absolute link is refused rather than followed: only a link
 				// the extraction did not write can be one, and reasoning about

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -363,35 +363,59 @@ func UnzipReader(r *zip.Reader, destDir string) error {
 		}
 	}
 
+	var failed error
 	for _, link := range links {
 		if err := extractSymlink(link.file, root, link.path); err != nil {
-			return err
+			failed = err
+			break
 		}
 	}
+	// Links already on disk were validated against an archive that was not
+	// fully written yet, so sweep them even when a later entry ended the run.
+	rejected, left := recheckLinks(root, links)
+	switch {
+	case left != nil:
+		return left
+	case failed != nil:
+		return failed
+	case rejected != nil:
+		return rejected
+	}
 
-	return recheckLinks(root, links)
+	return nil
 }
 
 // recheckLinks walks every link the extraction wrote once the archive is fully
 // on disk. A target is checked against what exists when the link is written, so
 // a link the archive lists later can still turn an earlier one into an escape.
-func recheckLinks(root string, links []extractedLink) error {
+// Every link is swept, since the ones after an offender are just as unchecked
+// as it was. rejected is the first offender removed and left the first one
+// still on disk. The caller reports left ahead of everything else, since it
+// means destDir still holds an escape.
+func recheckLinks(root string, links []extractedLink) (rejected, left error) {
 	for _, link := range links {
 		target, err := os.Readlink(link.path)
 		if err != nil {
-			// Dropped on a host that makes no links, so there is none to check.
+			// Never written: dropped on a host that makes no links, or listed
+			// after the entry that ended the extraction. Nothing to check.
 			continue
 		}
 		if isValidLinkTarget(root, link.path, filepath.ToSlash(target)) {
 			continue
 		}
-		if err := os.Remove(link.path); err != nil {
-			return err
+		// Another extraction into the same destination may have swept it first.
+		if err := os.Remove(link.path); err != nil && !os.IsNotExist(err) {
+			if left == nil {
+				left = fmt.Errorf("failed to remove link %q: %w", link.file.Name, err)
+			}
+			continue
 		}
-		return fmt.Errorf("illegal link target in zip: %q -> %q", link.file.Name, target)
+		if rejected == nil {
+			rejected = fmt.Errorf("illegal link target in zip: %q -> %q", link.file.Name, target)
+		}
 	}
 
-	return nil
+	return rejected, left
 }
 
 func isInside(root, path string) bool {

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -399,20 +399,35 @@ func extractSymlink(f *zip.File, root, fpath string) error {
 		return fmt.Errorf("illegal link target in zip: %q -> %q", f.Name, target)
 	}
 
-	// os.Symlink will not overwrite where a regular entry truncates, so clear
-	// the way and keep the two kinds symmetric.
-	if err := os.Remove(fpath); err != nil && !os.IsNotExist(err) {
-		return err
-	}
+	return createSymlink(target, fpath)
+}
 
-	if err := os.Symlink(target, fpath); err != nil {
-		if symlinkUnsupported(err) {
+const symlinkAttempts = 3
+
+// createSymlink puts a link to target at fpath, over whatever is already there.
+// A regular entry gets that from O_TRUNC in one call, and this is the same
+// thing in two: commands run on a worker pool, so a second extraction can fill
+// the path back in between them, and losing that race is not a failure.
+func createSymlink(target, fpath string) error {
+	for attempt := 0; ; attempt++ {
+		if err := os.Remove(fpath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+
+		err := os.Symlink(target, fpath)
+		if err == nil || symlinkUnsupported(err) {
 			return nil
 		}
-		return err
-	}
+		if !os.IsExist(err) || attempt == symlinkAttempts-1 {
+			return err
+		}
 
-	return nil
+		// Whoever won carries the same entry when the target matches, so
+		// there is nothing left to write.
+		if got, rerr := os.Readlink(fpath); rerr == nil && got == target {
+			return nil
+		}
+	}
 }
 
 // maxLinkResolution bounds the chain isValidLinkTarget will walk, the way ELOOP
@@ -475,7 +490,7 @@ func extractFile(f *zip.File, fpath string) error {
 	// os.OpenFile would write through a link sitting at the path, the one
 	// component mkdirAllInside does not cover.
 	if fi, err := os.Lstat(fpath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
-		if err := os.Remove(fpath); err != nil {
+		if err := os.Remove(fpath); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 	}

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -244,18 +244,14 @@ func Unzip(src, destDir string) error {
 // Used when the caller has pre-validated the same handle to close TOCTOU windows.
 //
 // A link entry—the target path as the body with ModeSymlink set, the layout
-// CreateZip writes—comes back as a real symlink, except on a host that makes
-// no links, where the entry is dropped rather than failing the whole
-// extraction or landing as a file holding the target path.
+// CreateZip writes—comes back as a real symlink, dropped on a Windows host that
+// makes none rather than failing the whole extraction.
 //
-// Nothing may leave destDir: an escaping entry name is rejected, so is a link
-// target that resolves outside, and no entry is written through a link, since
-// one an earlier entry created—or one already sitting in destDir—turns a name
-// that passes into a route out.
+// Nothing may leave destDir: an escaping entry name, a link target resolving
+// outside, and an entry written through a link are each refused.
 func UnzipReader(r *zip.ReadCloser, destDir string) error {
-	// Comparing against destDir unresolved reads an extraction that merely
-	// goes through a link as an escape, which is every extraction under /tmp
-	// on darwin.
+	// Unresolved, every extraction under /tmp on darwin reads as an escape,
+	// since /tmp is itself a link.
 	root, err := filepath.EvalSymlinks(destDir)
 	if err != nil {
 		return fmt.Errorf("failed to resolve destination directory: %w", err)
@@ -293,7 +289,6 @@ func UnzipReader(r *zip.ReadCloser, destDir string) error {
 	return nil
 }
 
-// isInside reports whether path stays within root.
 func isInside(root, path string) bool {
 	rel, err := filepath.Rel(root, filepath.Clean(path))
 	if err != nil || filepath.IsAbs(rel) {
@@ -302,9 +297,8 @@ func isInside(root, path string) bool {
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
-// mkdirAllInside walks dir one component at a time because os.MkdirAll follows
-// a symlink, which would let a link extracted earlier, or one already sitting
-// in destDir, put the entries below it outside root.
+// mkdirAllInside walks dir one component at a time because os.MkdirAll follows a
+// symlink, which would put the entries below one outside root.
 func mkdirAllInside(root, dir, name string) error {
 	rel, err := filepath.Rel(root, dir)
 	if err != nil {
@@ -319,9 +313,9 @@ func mkdirAllInside(root, dir, name string) error {
 		current = filepath.Join(current, part)
 		fi, err := os.Lstat(current)
 		if os.IsNotExist(err) {
-			// Commands run on a worker pool, so a second extraction may
-			// create the directory first. Losing that race is not a failure,
-			// but the check below still has to see what landed.
+			// Commands run on a worker pool, so another extraction may win
+			// the create. Not a failure, but the check below still needs
+			// to see what landed.
 			if err := os.Mkdir(current, 0755); err != nil && !os.IsExist(err) {
 				return err
 			}
@@ -338,12 +332,11 @@ func mkdirAllInside(root, dir, name string) error {
 	return nil
 }
 
-// maxSymlinkTarget is longer than any platform's path limit, so a body past it
-// is a malformed entry rather than a target worth reading into memory.
+// maxSymlinkTarget is past any platform's path limit, so a longer body is a
+// malformed entry, not a target worth reading into memory.
 const maxSymlinkTarget = 4096
 
-// extractSymlink restores a link entry, refusing a target that leaves root.
-// The mirror of addSymlinkToZip.
+// extractSymlink is the mirror of addSymlinkToZip.
 func extractSymlink(f *zip.File, root, fpath string) error {
 	rc, err := f.Open()
 	if err != nil {
@@ -363,8 +356,8 @@ func extractSymlink(f *zip.File, root, fpath string) error {
 		return fmt.Errorf("illegal link target in zip: %q -> %q", f.Name, target)
 	}
 
-	// os.Symlink refuses an existing path where a regular entry would have
-	// truncated it, so clear the way first and keep the two kinds symmetric.
+	// os.Symlink will not overwrite where a regular entry truncates, so clear
+	// the way and keep the two kinds symmetric.
 	if err := os.Remove(fpath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -379,9 +372,9 @@ func extractSymlink(f *zip.File, root, fpath string) error {
 	return nil
 }
 
-// isValidLinkTarget rejects an empty or absolute target, and a relative one
-// that resolves outside root. Zip entries carry slash-separated paths whatever
-// wrote them, so a leading slash is absolute on every platform.
+// isValidLinkTarget counts a leading slash as absolute itself: zip entries carry
+// slash-separated paths whatever wrote them, so filepath.IsAbs alone would let a
+// Unix-absolute target through on Windows.
 func isValidLinkTarget(root, fpath, target string) bool {
 	if target == "" || strings.HasPrefix(target, "/") || filepath.IsAbs(target) {
 		return false
@@ -389,19 +382,19 @@ func isValidLinkTarget(root, fpath, target string) bool {
 	return isInside(root, filepath.Join(filepath.Dir(fpath), filepath.FromSlash(target)))
 }
 
-// extractFile writes a regular entry. The mirror of addFileToZip.
+// extractFile is the mirror of addFileToZip.
 func extractFile(f *zip.File, fpath string) error {
-	// os.OpenFile would write through a link sitting at the path: the last
-	// component, the one mkdirAllInside does not cover.
+	// os.OpenFile would write through a link sitting at the path, the one
+	// component mkdirAllInside does not cover.
 	if fi, err := os.Lstat(fpath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		if err := os.Remove(fpath); err != nil {
 			return err
 		}
 	}
 
-	// Perm only: extraction runs in the alpamon process, which is root on a
-	// normal install, so setuid, setgid and sticky off an entry would land on
-	// a root-owned file. newZipEntry drops the same bits on the way in.
+	// Perm only: extraction runs as root on a normal install, so setuid, setgid
+	// or sticky off an entry would land on a root-owned file. newZipEntry drops
+	// the same bits on the way in.
 	outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
 	if err != nil {
 		return err

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -251,6 +251,12 @@ func Unzip(src, destDir string) error {
 // outside once every link on the way to it is followed, and an entry written
 // through a link are each refused.
 func UnzipReader(r *zip.ReadCloser, destDir string) error {
+	// destDir used to appear on its own with the first entry, back when every
+	// entry called os.MkdirAll on its own parent.
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
 	// Unresolved, every extraction under /tmp on darwin reads as an escape,
 	// since /tmp is itself a link.
 	root, err := filepath.EvalSymlinks(destDir)

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -484,6 +484,13 @@ func hasControlBytes(s string) bool {
 	return strings.ContainsFunc(s, func(r rune) bool { return r < 0x20 || r == 0x7f })
 }
 
+// createFile opens path for writing, made or truncated, and where the host
+// has O_NOFOLLOW it fails instead of following a link that another extraction
+// into the same destination may have put there since extractFile looked.
+func createFile(path string, mode os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|noFollow, mode)
+}
+
 func isInside(root, path string) bool {
 	rel, err := filepath.Rel(root, filepath.Clean(path))
 	if err != nil || filepath.IsAbs(rel) {
@@ -660,8 +667,9 @@ func isAbsTarget(target string) bool {
 
 // extractFile is the mirror of addFileToZip.
 func extractFile(f *zip.File, fpath string) error {
-	// os.OpenFile would write through a link sitting at the path, the one
-	// component mkdirAllInside does not cover.
+	// A link sitting at the path is the one component mkdirAllInside does not
+	// cover. createFile refuses to write through one, so it is cleared first
+	// rather than followed.
 	if fi, err := os.Lstat(fpath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		if err := os.Remove(fpath); err != nil && !os.IsNotExist(err) {
 			return err
@@ -671,7 +679,7 @@ func extractFile(f *zip.File, fpath string) error {
 	// Perm only: extraction runs as root on a normal install, so setuid, setgid
 	// or sticky off an entry would land on a root-owned file. newZipEntry drops
 	// the same bits on the way in.
-	outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
+	outFile, err := createFile(fpath, f.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -344,6 +344,12 @@ func UnzipReader(r *zip.Reader, destDir string) error {
 	var links []deferredEntry
 	var dirs []deferredEntry
 	for _, f := range r.File {
+		// The rejection below quotes the name, but an OS error raised further
+		// in embeds the raw path where %q cannot reach it, and it travels to
+		// the console as the command result.
+		if hasControlBytes(f.Name) {
+			return fmt.Errorf("illegal file path in zip: %q", f.Name)
+		}
 		fpath := filepath.Join(root, f.Name)
 		if !isInside(root, fpath) {
 			return fmt.Errorf("illegal file path in zip: %q", f.Name)
@@ -473,6 +479,11 @@ func recheckLinks(root string, links []deferredEntry) (rejected, left error) {
 	return rejected, left
 }
 
+// hasControlBytes reports whether s carries a byte a terminal would act on.
+func hasControlBytes(s string) bool {
+	return strings.ContainsFunc(s, func(r rune) bool { return r < 0x20 || r == 0x7f })
+}
+
 func isInside(root, path string) bool {
 	rel, err := filepath.Rel(root, filepath.Clean(path))
 	if err != nil || filepath.IsAbs(rel) {
@@ -539,6 +550,11 @@ func extractSymlink(f *zip.File, root, fpath string) error {
 	}
 
 	target := string(body)
+	// The same route the entry-name check closes: a failure past this point
+	// wraps the OS error, which embeds the raw target where %q cannot reach.
+	if hasControlBytes(target) {
+		return fmt.Errorf("illegal link target in zip: %q -> %q", f.Name, target)
+	}
 	if !isValidLinkTarget(root, fpath, target) {
 		return fmt.Errorf("illegal link target in zip: %q -> %q", f.Name, target)
 	}

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -256,7 +256,10 @@ func addSymlinkToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo
 		return err
 	}
 
-	if _, err := zw.Write([]byte(target)); err != nil {
+	// The separator the reading host expects, the same normalization entry
+	// names get: a backslash target written on Windows must not come back on
+	// Unix as a single opaque component.
+	if _, err := zw.Write([]byte(filepath.ToSlash(target))); err != nil {
 		return fmt.Errorf("failed to write zip entry: %w", err)
 	}
 
@@ -486,7 +489,7 @@ func recheckLinks(root string, links []deferredEntry) (rejected, left error) {
 			// after the entry that ended the extraction. Nothing to check.
 			continue
 		}
-		if isValidLinkTarget(root, link.path, filepath.ToSlash(target)) {
+		if isValidLinkTarget(root, link.path, target) {
 			continue
 		}
 		// Another extraction into the same destination may have swept it first.
@@ -642,7 +645,7 @@ func isValidLinkTarget(root, fpath, target string) bool {
 	}
 
 	current := filepath.Dir(fpath)
-	parts := strings.Split(target, "/")
+	parts := strings.Split(filepath.ToSlash(target), "/")
 	hops, visited := 0, 0
 	for len(parts) > 0 {
 		visited++

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -242,45 +242,177 @@ func Unzip(src, destDir string) error {
 
 // UnzipReader extracts an already-opened zip into destDir. Caller owns r.
 // Used when the caller has pre-validated the same handle to close TOCTOU windows.
+//
+// A link entry—the target path as the body with ModeSymlink set, the layout
+// CreateZip writes—comes back as a real symlink, except on a host that makes
+// no links, where the entry is dropped rather than failing the whole
+// extraction or landing as a file holding the target path.
+//
+// Nothing may leave destDir: an escaping entry name is rejected, so is a link
+// target that resolves outside, and no entry is written through a link, since
+// one an earlier entry created—or one already sitting in destDir—turns a name
+// that passes into a route out.
 func UnzipReader(r *zip.ReadCloser, destDir string) error {
-	for _, f := range r.File {
-		fpath := filepath.Join(destDir, f.Name)
+	// Comparing against destDir unresolved reads an extraction that merely
+	// goes through a link as an escape, which is every extraction under /tmp
+	// on darwin.
+	root, err := filepath.EvalSymlinks(destDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve destination directory: %w", err)
+	}
 
-		// Zip-slip protection using filepath.Rel (handles root dirs and all platforms)
-		rel, err := filepath.Rel(destDir, filepath.Clean(fpath))
-		if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+	for _, f := range r.File {
+		fpath := filepath.Join(root, f.Name)
+		if !isInside(root, fpath) {
 			return fmt.Errorf("illegal file path in zip: %s", f.Name)
 		}
 
 		if f.FileInfo().IsDir() {
-			if err := os.MkdirAll(fpath, 0755); err != nil {
+			if err := mkdirAllInside(root, fpath, f.Name); err != nil {
 				return err
 			}
 			continue
 		}
 
-		if err := os.MkdirAll(filepath.Dir(fpath), 0755); err != nil {
+		if err := mkdirAllInside(root, filepath.Dir(fpath), f.Name); err != nil {
 			return err
 		}
 
-		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return err
+		if f.Mode()&os.ModeSymlink != 0 {
+			if err := extractSymlink(f, root, fpath); err != nil {
+				return err
+			}
+			continue
 		}
 
-		rc, err := f.Open()
-		if err != nil {
-			_ = outFile.Close()
-			return err
-		}
-
-		_, err = io.Copy(outFile, rc)
-		_ = rc.Close()
-		_ = outFile.Close()
-		if err != nil {
+		if err := extractFile(f, fpath); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// isInside reports whether path stays within root.
+func isInside(root, path string) bool {
+	rel, err := filepath.Rel(root, filepath.Clean(path))
+	if err != nil || filepath.IsAbs(rel) {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+// mkdirAllInside walks dir one component at a time because os.MkdirAll follows
+// a symlink, which would let a link extracted earlier, or one already sitting
+// in destDir, put the entries below it outside root.
+func mkdirAllInside(root, dir, name string) error {
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return fmt.Errorf("illegal file path in zip: %s", name)
+	}
+	if rel == "." {
+		return nil
+	}
+
+	current := root
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		current = filepath.Join(current, part)
+		fi, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			// Commands run on a worker pool, so a second extraction may
+			// create the directory first. Losing that race is not a failure,
+			// but the check below still has to see what landed.
+			if err := os.Mkdir(current, 0755); err != nil && !os.IsExist(err) {
+				return err
+			}
+			fi, err = os.Lstat(current)
+		}
+		if err != nil {
+			return err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("illegal link target in zip: %s is written through a symlink", name)
+		}
+	}
+
+	return nil
+}
+
+// maxSymlinkTarget is longer than any platform's path limit, so a body past it
+// is a malformed entry rather than a target worth reading into memory.
+const maxSymlinkTarget = 4096
+
+// extractSymlink restores a link entry, refusing a target that leaves root.
+// The mirror of addSymlinkToZip.
+func extractSymlink(f *zip.File, root, fpath string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	body, err := io.ReadAll(io.LimitReader(rc, maxSymlinkTarget+1))
+	_ = rc.Close()
+	if err != nil {
+		return err
+	}
+	if len(body) > maxSymlinkTarget {
+		return fmt.Errorf("illegal link target in zip: %s exceeds %d bytes", f.Name, maxSymlinkTarget)
+	}
+
+	target := string(body)
+	if !isValidLinkTarget(root, fpath, target) {
+		return fmt.Errorf("illegal link target in zip: %s -> %s", f.Name, target)
+	}
+
+	// os.Symlink refuses an existing path where a regular entry would have
+	// truncated it, so clear the way first and keep the two kinds symmetric.
+	if err := os.Remove(fpath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if err := os.Symlink(target, fpath); err != nil {
+		if symlinkUnsupported(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+// isValidLinkTarget rejects an empty or absolute target, and a relative one
+// that resolves outside root. Zip entries carry slash-separated paths whatever
+// wrote them, so a leading slash is absolute on every platform.
+func isValidLinkTarget(root, fpath, target string) bool {
+	if target == "" || strings.HasPrefix(target, "/") || filepath.IsAbs(target) {
+		return false
+	}
+	return isInside(root, filepath.Join(filepath.Dir(fpath), filepath.FromSlash(target)))
+}
+
+// extractFile writes a regular entry. The mirror of addFileToZip.
+func extractFile(f *zip.File, fpath string) error {
+	// os.OpenFile would write through a link sitting at the path: the last
+	// component, the one mkdirAllInside does not cover.
+	if fi, err := os.Lstat(fpath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		if err := os.Remove(fpath); err != nil {
+			return err
+		}
+	}
+
+	outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+	if err != nil {
+		return err
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		_ = outFile.Close()
+		return err
+	}
+
+	_, err = io.Copy(outFile, rc)
+	_ = rc.Close()
+	_ = outFile.Close()
+
+	return err
 }

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -518,6 +518,13 @@ func mkdirAllInside(root, dir, name string) error {
 
 // extractSymlink is the mirror of addSymlinkToZip.
 func extractSymlink(f *zip.File, root, fpath string) error {
+	// The first pass checked this parent before any link entry was written,
+	// and a link entry ahead of this one may have swapped a directory on it
+	// for a link since—one to ".." would carry this entry outside root.
+	if err := mkdirAllInside(root, filepath.Dir(fpath), f.Name); err != nil {
+		return err
+	}
+
 	rc, err := f.Open()
 	if err != nil {
 		return fmt.Errorf("failed to restore link %q: %w", f.Name, err)
@@ -572,7 +579,7 @@ func createSymlink(target, fpath string) error {
 // the target component by component, following every link already on disk,
 // because filepath.Join folds "a/link/.." down to "a" while the kernel follows
 // the link first and lands somewhere else entirely. It starts from
-// filepath.Dir(fpath), which mkdirAllInside has already shown to be link-free.
+// filepath.Dir(fpath), which the caller has just shown to be link-free.
 func isValidLinkTarget(root, fpath, target string) bool {
 	if target == "" || isAbsTarget(target) {
 		return false

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -353,7 +353,7 @@ func UnzipReader(r *zip.ReadCloser, destDir string) error {
 		}
 
 		if err := extractFile(f, fpath); err != nil {
-			return err
+			return fmt.Errorf("failed to extract %q: %w", f.Name, err)
 		}
 	}
 
@@ -416,12 +416,12 @@ func mkdirAllInside(root, dir, name string) error {
 			// the create. Not a failure, but the check below still needs
 			// to see what landed.
 			if err := os.Mkdir(current, 0755); err != nil && !os.IsExist(err) {
-				return err
+				return fmt.Errorf("failed to create directory for %q: %w", name, err)
 			}
 			fi, err = os.Lstat(current)
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create directory for %q: %w", name, err)
 		}
 		if fi.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("illegal link target in zip: %q is written through a symlink", name)
@@ -435,12 +435,12 @@ func mkdirAllInside(root, dir, name string) error {
 func extractSymlink(f *zip.File, root, fpath string) error {
 	rc, err := f.Open()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to restore link %q: %w", f.Name, err)
 	}
 	body, err := io.ReadAll(io.LimitReader(rc, maxSymlinkTarget+1))
 	_ = rc.Close()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to restore link %q: %w", f.Name, err)
 	}
 	if len(body) > maxSymlinkTarget {
 		return fmt.Errorf("illegal link target in zip: %q exceeds %d bytes", f.Name, maxSymlinkTarget)
@@ -451,7 +451,10 @@ func extractSymlink(f *zip.File, root, fpath string) error {
 		return fmt.Errorf("illegal link target in zip: %q -> %q", f.Name, target)
 	}
 
-	return createSymlink(target, fpath)
+	if err := createSymlink(target, fpath); err != nil {
+		return fmt.Errorf("failed to restore link %q: %w", f.Name, err)
+	}
+	return nil
 }
 
 // createSymlink puts a link to target at fpath, over whatever is already there.

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -247,8 +247,9 @@ func Unzip(src, destDir string) error {
 // CreateZip writes—comes back as a real symlink, dropped on a Windows host that
 // makes none rather than failing the whole extraction.
 //
-// Nothing may leave destDir: an escaping entry name, a link target resolving
-// outside, and an entry written through a link are each refused.
+// Nothing may leave destDir: an escaping entry name, a link target that lands
+// outside once every link on the way to it is followed, and an entry written
+// through a link are each refused.
 func UnzipReader(r *zip.ReadCloser, destDir string) error {
 	// Unresolved, every extraction under /tmp on darwin reads as an escape,
 	// since /tmp is itself a link.
@@ -257,6 +258,7 @@ func UnzipReader(r *zip.ReadCloser, destDir string) error {
 		return fmt.Errorf("failed to resolve destination directory: %w", err)
 	}
 
+	var links []extractedLink
 	for _, f := range r.File {
 		fpath := filepath.Join(root, f.Name)
 		if !isInside(root, fpath) {
@@ -274,16 +276,51 @@ func UnzipReader(r *zip.ReadCloser, destDir string) error {
 			return err
 		}
 
+		// Links go last: on Windows os.Symlink picks a file or a directory link
+		// by what the target is at creation time, and entry order does not
+		// promise the target has been extracted yet.
 		if f.Mode()&os.ModeSymlink != 0 {
-			if err := extractSymlink(f, root, fpath); err != nil {
-				return err
-			}
+			links = append(links, extractedLink{file: f, path: fpath})
 			continue
 		}
 
 		if err := extractFile(f, fpath); err != nil {
 			return err
 		}
+	}
+
+	for _, link := range links {
+		if err := extractSymlink(link.file, root, link.path); err != nil {
+			return err
+		}
+	}
+
+	return recheckLinks(root, links)
+}
+
+// extractedLink is a link entry held back until the regular ones are out.
+type extractedLink struct {
+	file *zip.File
+	path string
+}
+
+// recheckLinks walks every link the extraction wrote once the archive is fully
+// on disk. A target is checked against what exists when the link is written, so
+// a link the archive lists later can still turn an earlier one into an escape.
+func recheckLinks(root string, links []extractedLink) error {
+	for _, link := range links {
+		target, err := os.Readlink(link.path)
+		if err != nil {
+			// Dropped on a host that makes no links, so there is none to check.
+			continue
+		}
+		if isValidLinkTarget(root, link.path, filepath.ToSlash(target)) {
+			continue
+		}
+		if err := os.Remove(link.path); err != nil {
+			return err
+		}
+		return fmt.Errorf("illegal link target in zip: %q -> %q", link.file.Name, target)
 	}
 
 	return nil
@@ -372,14 +409,59 @@ func extractSymlink(f *zip.File, root, fpath string) error {
 	return nil
 }
 
-// isValidLinkTarget counts a leading slash as absolute itself: zip entries carry
-// slash-separated paths whatever wrote them, so filepath.IsAbs alone would let a
-// Unix-absolute target through on Windows.
+// maxLinkResolution bounds the chain isValidLinkTarget will walk, the way ELOOP
+// bounds the kernel's own resolution.
+const maxLinkResolution = 64
+
+// isValidLinkTarget reports whether a link at fpath may carry target. It walks
+// the target component by component, following every link already on disk,
+// because filepath.Join folds "a/link/.." down to "a" while the kernel follows
+// the link first and lands somewhere else entirely. It starts from
+// filepath.Dir(fpath), which mkdirAllInside has already shown to be link-free.
 func isValidLinkTarget(root, fpath, target string) bool {
+	// Zip entries carry slash-separated paths whatever wrote them, so a leading
+	// slash is absolute even where filepath.IsAbs alone would miss it.
 	if target == "" || strings.HasPrefix(target, "/") || filepath.IsAbs(target) {
 		return false
 	}
-	return isInside(root, filepath.Join(filepath.Dir(fpath), filepath.FromSlash(target)))
+
+	current := filepath.Dir(fpath)
+	parts := strings.Split(target, "/")
+	for steps := 0; len(parts) > 0; steps++ {
+		if steps > maxLinkResolution {
+			return false
+		}
+
+		part := parts[0]
+		parts = parts[1:]
+
+		switch part {
+		case "", ".":
+			continue
+		case "..":
+			current = filepath.Dir(current)
+		default:
+			next := filepath.Join(current, part)
+			if fi, err := os.Lstat(next); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+				link, err := os.Readlink(next)
+				// An absolute link is refused rather than followed: only a link
+				// the extraction did not write can be one, and reasoning about
+				// where it lands is not worth the archive.
+				if err != nil || strings.HasPrefix(filepath.ToSlash(link), "/") || filepath.IsAbs(link) {
+					return false
+				}
+				parts = append(strings.Split(filepath.ToSlash(link), "/"), parts...)
+				continue
+			}
+			current = next
+		}
+
+		if !isInside(root, current) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // extractFile is the mirror of addFileToZip.

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -20,6 +20,11 @@ const (
 	// counted: a deep tree with no link in it is not a chain.
 	maxLinkResolution = 64
 
+	// maxLinkWalk bounds the components isValidLinkTarget will visit in all,
+	// since every link it follows splices a whole target in and the hop bound
+	// alone leaves a small archive able to hold a worker for tens of seconds.
+	maxLinkWalk = 8192
+
 	// symlinkAttempts bounds createSymlink's retry, so a path that another
 	// extraction keeps refilling ends the entry instead of spinning on it.
 	symlinkAttempts = 3
@@ -496,8 +501,13 @@ func isValidLinkTarget(root, fpath, target string) bool {
 
 	current := filepath.Dir(fpath)
 	parts := strings.Split(target, "/")
-	hops := 0
+	hops, visited := 0, 0
 	for len(parts) > 0 {
+		visited++
+		if visited > maxLinkWalk {
+			return false
+		}
+
 		part := parts[0]
 		parts = parts[1:]
 

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -616,7 +616,7 @@ func createSymlink(target, fpath string) error {
 		if err == nil || symlinkUnsupported(err) {
 			return nil
 		}
-		if !os.IsExist(err) || attempt == symlinkAttempts-1 {
+		if !os.IsExist(err) {
 			return err
 		}
 
@@ -624,6 +624,9 @@ func createSymlink(target, fpath string) error {
 		// there is nothing left to write.
 		if got, rerr := os.Readlink(fpath); rerr == nil && got == target {
 			return nil
+		}
+		if attempt == symlinkAttempts-1 {
+			return err
 		}
 	}
 }
@@ -669,11 +672,15 @@ func isValidLinkTarget(root, fpath, target string) bool {
 				// An absolute link is refused rather than followed: only a link
 				// the extraction did not write can be one, and reasoning about
 				// where it lands is not worth the archive.
-				if err != nil || isAbsTarget(link) {
+				if err == nil && !isAbsTarget(link) {
+					parts = append(strings.Split(filepath.ToSlash(link), "/"), parts...)
+					continue
+				}
+				// Swept between the two calls by a concurrent extraction:
+				// gone, it is no longer a link on the way.
+				if !os.IsNotExist(err) {
 					return false
 				}
-				parts = append(strings.Split(filepath.ToSlash(link), "/"), parts...)
-				continue
 			}
 			current = next
 		}

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -399,7 +399,10 @@ func extractFile(f *zip.File, fpath string) error {
 		}
 	}
 
-	outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+	// Perm only: extraction runs in the alpamon process, which is root on a
+	// normal install, so setuid, setgid and sticky off an entry would land on
+	// a root-owned file. newZipEntry drops the same bits on the way in.
+	outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -28,6 +28,13 @@ const (
 	// alone leaves a small archive able to hold a worker for tens of seconds.
 	maxLinkWalk = 8192
 
+	// zipCreatorUnix and zipCreatorMacOSX are the creator halves of a zip
+	// header's CreatorVersion under which archive/zip reads a Unix mode out of
+	// ExternalAttrs; SetMode writes the first. Every other creator gets a mode
+	// derived from FAT attributes instead.
+	zipCreatorUnix   = 3
+	zipCreatorMacOSX = 19
+
 	// symlinkAttempts bounds createSymlink's retry, so a path that another
 	// extraction keeps refilling ends the entry instead of spinning on it.
 	symlinkAttempts = 3
@@ -432,6 +439,12 @@ func applyDirModes(dirs []deferredEntry) error {
 		}
 		if !fi.IsDir() {
 			return fmt.Errorf("illegal entry in zip: %q is no longer a directory", dir.file.Name)
+		}
+		// A header only carries a mode a Unix host chose; archive/zip derives
+		// 0666 from any other creator's attributes, which would leave the
+		// directory impossible to enter.
+		if creator := dir.file.CreatorVersion >> 8; creator != zipCreatorUnix && creator != zipCreatorMacOSX {
+			continue
 		}
 		// Perm only, for the reason extractFile gives. Zero is an archive that
 		// carried no mode at all, not a directory nobody may enter.

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -17,9 +17,10 @@ const (
 	// malformed entry, not a target worth reading into memory.
 	maxSymlinkTarget = 4096
 
-	// maxLinkResolution bounds the links isValidLinkTarget will follow, the
-	// way ELOOP bounds the kernel's own resolution. Components are not
-	// counted: a deep tree with no link in it is not a chain.
+	// maxLinkResolution is past every kernel's own resolution bound (Linux
+	// follows at most 40 links, darwin 32), so a walk still following links
+	// here is resolving something no program will ever be handed. Components
+	// are not counted: a deep tree with no link in it is not a chain.
 	maxLinkResolution = 64
 
 	// maxLinkWalk bounds the components isValidLinkTarget will visit in all,
@@ -635,7 +636,10 @@ func isValidLinkTarget(root, fpath, target string) bool {
 			if fi, err := os.Lstat(next); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 				hops++
 				if hops > maxLinkResolution {
-					return false
+					// Past the kernel's own bound nothing resolves this
+					// link—ELOOP for whoever tries—so a cycle or a chain this
+					// deep carries nobody anywhere, outside included.
+					return true
 				}
 				link, err := os.Readlink(next)
 				// An absolute link is refused rather than followed: only a link

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -299,7 +299,7 @@ func Unzip(src, destDir string) error {
 		return fmt.Errorf("failed to open zip: %w", err)
 	}
 	defer func() { _ = r.Close() }()
-	return UnzipReader(r, destDir)
+	return UnzipReader(&r.Reader, destDir)
 }
 
 // UnzipReader extracts an already-opened zip into destDir. Caller owns r.
@@ -312,7 +312,7 @@ func Unzip(src, destDir string) error {
 // Nothing may leave destDir: an escaping entry name, a link target that lands
 // outside once every link on the way to it is followed, and an entry written
 // through a link are each refused.
-func UnzipReader(r *zip.ReadCloser, destDir string) error {
+func UnzipReader(r *zip.Reader, destDir string) error {
 	// destDir used to appear on its own with the first entry, back when every
 	// entry called os.MkdirAll on its own parent.
 	if err := os.MkdirAll(destDir, 0755); err != nil {

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -27,7 +27,9 @@ type unreadable struct{ error }
 func (u unreadable) Unwrap() error { return u.error }
 
 // CreateZip creates a zip archive at destPath containing the specified paths.
-// If recursive is true and a path is a directory, its contents are included recursively.
+// If recursive is true and a path is a directory, its contents are included
+// recursively. A directory holding nothing gets an entry of its own, since it
+// has no contents to carry it across.
 // A symlink listed explicitly is followed, so its whole target tree is archived
 // even when that tree lives outside the listed path. A symlink met while walking
 // is stored as a link entry (target path, not content), so it cannot recurse into
@@ -111,14 +113,30 @@ func CreateZip(destPath string, paths []string, recursive bool) (skipped []Skipp
 					note(fpath, err)
 					return nil
 				}
-				if fi.IsDir() {
-					return nil
-				}
 				relPath, err := filepath.Rel(root, fpath)
 				if err != nil {
 					return err
 				}
 				name := filepath.Join(base, relPath)
+				if fi.IsDir() {
+					if name == "." {
+						// Base of "/" left nothing to name the walk root with.
+						return nil
+					}
+					// Every other directory arrives with the entries below it,
+					// so only one holding nothing needs an entry of its own. It
+					// is still not content, and must not make an archive that
+					// holds only directories look like a finished one.
+					empty, err := isEmptyDir(fpath)
+					if err != nil {
+						note(fpath, err)
+						return nil
+					}
+					if !empty {
+						return nil
+					}
+					return addDirToZip(w, name, fi)
+				}
 				switch {
 				case fi.Mode()&os.ModeSymlink != 0:
 					err = addSymlinkToZip(w, fpath, name, fi)
@@ -176,9 +194,9 @@ func newZipEntry(w *zip.Writer, archiveName string, fi os.FileInfo, method uint1
 		Method:   method,
 		Modified: fi.ModTime(),
 	}
-	// Permissions and the link flag only: setuid, setgid and sticky mean
+	// Permissions and the type flags only: setuid, setgid and sticky mean
 	// nothing in a download and Unzip would hand them to os.OpenFile.
-	hdr.SetMode(fi.Mode().Perm() | fi.Mode()&os.ModeSymlink)
+	hdr.SetMode(fi.Mode().Perm() | fi.Mode()&(os.ModeSymlink|os.ModeDir))
 
 	zw, err := w.CreateHeader(hdr)
 	if err != nil {
@@ -205,6 +223,21 @@ func addSymlinkToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo
 	}
 
 	return nil
+}
+
+func isEmptyDir(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
+}
+
+// addDirToZip writes a directory entry. The trailing slash is what every other
+// zip reader keys off; the mode bit alone is not enough.
+func addDirToZip(w *zip.Writer, archiveName string, fi os.FileInfo) error {
+	_, err := newZipEntry(w, archiveName+"/", fi, zip.Store)
+	return err
 }
 
 func addFileToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo) error {

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -275,11 +275,20 @@ func addFileToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo) e
 }
 
 func isEmptyDir(path string) (bool, error) {
-	entries, err := os.ReadDir(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return false, err
 	}
-	return len(entries) == 0, nil
+	defer func() { _ = f.Close() }()
+
+	// One entry answers the question; os.ReadDir would read and sort them all.
+	if _, err := f.Readdirnames(1); err != nil {
+		if errors.Is(err, io.EOF) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
 }
 
 // Unzip extracts a zip archive to the specified destination directory.

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -292,6 +292,9 @@ func addFileToZip(w *zip.Writer, filePath, archiveName string, fi os.FileInfo) e
 	return nil
 }
 
+// isEmptyDir reports whether the archive will see the directory as empty.
+// FIFOs, sockets and device nodes are dropped by the walk, so they must not
+// hold a directory back from the entry that keeps it in the download.
 func isEmptyDir(path string) (bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -299,14 +302,22 @@ func isEmptyDir(path string) (bool, error) {
 	}
 	defer func() { _ = f.Close() }()
 
-	// One entry answers the question; os.ReadDir would read and sort them all.
-	if _, err := f.Readdirnames(1); err != nil {
-		if errors.Is(err, io.EOF) {
-			return true, nil
+	for {
+		// One archivable entry answers the question; os.ReadDir would read
+		// and sort them all.
+		entries, err := f.ReadDir(64)
+		for _, e := range entries {
+			if t := e.Type(); t.IsRegular() || t.IsDir() || t&os.ModeSymlink != 0 {
+				return false, nil
+			}
 		}
-		return false, err
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return true, nil
+			}
+			return false, err
+		}
 	}
-	return false, nil
 }
 
 // Unzip extracts a zip archive to the specified destination directory.

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -486,9 +486,7 @@ func createSymlink(target, fpath string) error {
 // the link first and lands somewhere else entirely. It starts from
 // filepath.Dir(fpath), which mkdirAllInside has already shown to be link-free.
 func isValidLinkTarget(root, fpath, target string) bool {
-	// Zip entries carry slash-separated paths whatever wrote them, so a leading
-	// slash is absolute even where filepath.IsAbs alone would miss it.
-	if target == "" || strings.HasPrefix(target, "/") || filepath.IsAbs(target) {
+	if target == "" || isAbsTarget(target) {
 		return false
 	}
 
@@ -514,7 +512,7 @@ func isValidLinkTarget(root, fpath, target string) bool {
 				// An absolute link is refused rather than followed: only a link
 				// the extraction did not write can be one, and reasoning about
 				// where it lands is not worth the archive.
-				if err != nil || strings.HasPrefix(filepath.ToSlash(link), "/") || filepath.IsAbs(link) {
+				if err != nil || isAbsTarget(link) {
 					return false
 				}
 				parts = append(strings.Split(filepath.ToSlash(link), "/"), parts...)
@@ -529,6 +527,13 @@ func isValidLinkTarget(root, fpath, target string) bool {
 	}
 
 	return true
+}
+
+// isAbsTarget reports whether a link target is absolute. Zip entries carry
+// slash-separated paths whatever wrote them, so a leading slash counts even
+// where filepath.IsAbs alone would miss it.
+func isAbsTarget(target string) bool {
+	return strings.HasPrefix(filepath.ToSlash(target), "/") || filepath.IsAbs(target)
 }
 
 // extractFile is the mirror of addFileToZip.

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -321,7 +321,9 @@ func Unzip(src, destDir string) error {
 //
 // Nothing may leave destDir: an escaping entry name, a link target that lands
 // outside once every link on the way to it is followed, and an entry written
-// through a link are each refused.
+// through a link are each refused. An entry naming destDir itself adds nothing
+// and changes nothing, since the destination is the caller's and not the
+// archive's.
 //
 // A directory entry's mode lands last, deepest first, so a read-only directory
 // cannot block the entries below it.
@@ -344,6 +346,15 @@ func UnzipReader(r *zip.Reader, destDir string) error {
 	for _, f := range r.File {
 		fpath := filepath.Join(root, f.Name)
 		if !isInside(root, fpath) {
+			return fmt.Errorf("illegal file path in zip: %q", f.Name)
+		}
+		if fpath == root {
+			// "./" and "sub/../" both land here. A directory entry has nothing
+			// to make and its mode would land on the caller's directory, and
+			// anything else would replace that directory.
+			if f.FileInfo().IsDir() {
+				continue
+			}
 			return fmt.Errorf("illegal file path in zip: %q", f.Name)
 		}
 

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -522,6 +522,11 @@ func mkdirAllInside(root, dir, name string) error {
 		if fi.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("illegal link target in zip: %q is written through a symlink", name)
 		}
+		// A file entry that took this component's name would only surface
+		// later as the raw ENOTDIR off whatever tries to write below it.
+		if !fi.IsDir() {
+			return fmt.Errorf("illegal entry in zip: %q is written through a non-directory", name)
+		}
 	}
 
 	return nil

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -554,8 +554,10 @@ func mkdirAllInside(root, dir, name string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create directory for %q: %w", name, err)
 		}
+		// The entry is refused, whatever it is: what is a link here is a
+		// component of the path it would be written through, not the entry.
 		if fi.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("illegal link target in zip: %q is written through a symlink", name)
+			return fmt.Errorf("illegal entry in zip: %q is written through a symlink", name)
 		}
 		// A file entry that took this component's name would only surface
 		// later as the raw ENOTDIR off whatever tries to write below it.

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -518,6 +518,59 @@ func TestUnzip_LinkTargetThroughAnotherLinkIsRejected(t *testing.T) {
 	}
 }
 
+func TestUnzip_RejectionLeavesNoEscapingLink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	// Every link passes the check at creation time because subdir/parent is
+	// not on disk yet, so the sweep after the last entry is the only barrier
+	// these links have. It must keep going past the first one it removes,
+	// and it must run even when a later entry ended the extraction early.
+	for _, tt := range []struct {
+		name    string
+		entries []zipEntry
+		links   []string
+	}{
+		{
+			name: "second offender after the first",
+			entries: []zipEntry{
+				{name: "subdir/keep", body: "x"},
+				{name: "escape1", body: "subdir/parent/..", isLink: true},
+				{name: "escape2", body: "subdir/parent/..", isLink: true},
+				{name: "subdir/parent", body: "..", isLink: true},
+			},
+			links: []string{"escape1", "escape2"},
+		},
+		{
+			name: "entry rejected at creation",
+			entries: []zipEntry{
+				{name: "subdir/keep", body: "x"},
+				{name: "escape", body: "subdir/parent/..", isLink: true},
+				{name: "subdir/parent", body: "..", isLink: true},
+				{name: "bad", body: "/etc", isLink: true},
+			},
+			links: []string{"escape"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			zipPath := filepath.Join(dir, "chain.zip")
+			writeEntryZip(t, zipPath, tt.entries)
+
+			out := filepath.Join(dir, "out")
+			require.NoError(t, os.MkdirAll(out, 0755))
+
+			assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
+
+			for _, name := range tt.links {
+				_, err := os.Lstat(filepath.Join(out, name))
+				assert.ErrorIs(t, err, os.ErrNotExist, name)
+			}
+		})
+	}
+}
+
 func TestUnzip_DeepLinkTargetWithoutLinksIsAccepted(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -17,21 +17,6 @@ import (
 
 // writeZip builds a zip at path with one entry per name/content pair. A nil
 // map produces an empty zip.
-func writeZip(t *testing.T, path string, entries map[string]string) {
-	t.Helper()
-	f, err := os.Create(path)
-	require.NoError(t, err)
-	w := zip.NewWriter(f)
-	for name, content := range entries {
-		zw, err := w.Create(name)
-		require.NoError(t, err)
-		_, err = zw.Write([]byte(content))
-		require.NoError(t, err)
-	}
-	require.NoError(t, w.Close())
-	require.NoError(t, f.Close())
-}
-
 // requireZip builds the archive and requires that nothing was left out of it,
 // so a test that does not care about skipping still fails if an entry silently
 // goes missing.
@@ -258,9 +243,9 @@ func TestUnzip(t *testing.T) {
 	dir := t.TempDir()
 
 	zipPath := filepath.Join(dir, "test.zip")
-	writeZip(t, zipPath, map[string]string{
-		"root.txt":       "root",
-		"sub/nested.txt": "nested",
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "root.txt", body: "root"},
+		{name: "sub/nested.txt", body: "nested"},
 	})
 
 	extractDir := filepath.Join(dir, "out")
@@ -281,7 +266,7 @@ func TestUnzip_ZipSlipRejected(t *testing.T) {
 	dir := t.TempDir()
 
 	zipPath := filepath.Join(dir, "evil.zip")
-	writeZip(t, zipPath, map[string]string{"../../etc/passwd": "malicious"})
+	writeEntryZip(t, zipPath, []zipEntry{{name: "../../etc/passwd", body: "malicious"}})
 
 	extractDir := filepath.Join(dir, "out")
 	require.NoError(t, os.MkdirAll(extractDir, 0755))
@@ -473,14 +458,17 @@ func TestUnzip_EscapingLinkTargetIsRejected(t *testing.T) {
 	}
 	// Nothing constrains entry order, so a link arriving after the path that
 	// goes through it must be rejected just the same.
-	for name, entries := range map[string][]zipEntry{
-		"link first": escaping,
-		"link last":  {escaping[1], escaping[0]},
+	for _, tt := range []struct {
+		name    string
+		entries []zipEntry
+	}{
+		{"link first", escaping},
+		{"link last", []zipEntry{escaping[1], escaping[0]}},
 	} {
-		t.Run(name, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			zipPath := filepath.Join(dir, "evil.zip")
-			writeEntryZip(t, zipPath, entries)
+			writeEntryZip(t, zipPath, tt.entries)
 
 			out := filepath.Join(dir, "out")
 			require.NoError(t, os.MkdirAll(out, 0755))
@@ -505,14 +493,17 @@ func TestUnzip_LinkTargetThroughAnotherLinkIsRejected(t *testing.T) {
 	}
 	// Nothing constrains entry order, so the link that makes the chain escape
 	// may also arrive after the link that rides it.
-	for name, entries := range map[string][]zipEntry{
-		"rider last":  chain,
-		"rider first": {chain[2], chain[0], chain[1]},
+	for _, tt := range []struct {
+		name    string
+		entries []zipEntry
+	}{
+		{"rider last", chain},
+		{"rider first", []zipEntry{chain[2], chain[0], chain[1]}},
 	} {
-		t.Run(name, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			zipPath := filepath.Join(dir, "chain.zip")
-			writeEntryZip(t, zipPath, entries)
+			writeEntryZip(t, zipPath, tt.entries)
 
 			out := filepath.Join(dir, "out")
 			require.NoError(t, os.MkdirAll(out, 0755))
@@ -564,7 +555,7 @@ func TestUnzip_EntryWrittenThroughExistingLinkIsRejected(t *testing.T) {
 	require.NoError(t, os.Symlink(outside, filepath.Join(out, "a")))
 
 	zipPath := filepath.Join(dir, "evil.zip")
-	writeZip(t, zipPath, map[string]string{"a/passwd": "malicious"})
+	writeEntryZip(t, zipPath, []zipEntry{{name: "a/passwd", body: "malicious"}})
 
 	assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
 

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -764,6 +764,71 @@ func TestCreateZipAndUnzip_EmptyDirectoryModeIsPreserved(t *testing.T) {
 	assert.Equal(t, os.FileMode(0700), fi.Mode().Perm())
 }
 
+func TestUnzip_EntryNamingTheDestinationLeavesItsModeAlone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	// filepath.Join folds each of these names onto the destination itself. That
+	// directory is the caller's, so the mode the archive carries for it must
+	// not land: extraction runs as root, and 0777 here would open a user's home
+	// directory to everyone on the host.
+	for _, name := range []string{".", "./", "", "sub/../"} {
+		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
+			dir := t.TempDir()
+			zipPath := filepath.Join(dir, "self.zip")
+			writeEntryZip(t, zipPath, []zipEntry{
+				{name: name, mode: 0777 | os.ModeDir},
+				{name: "a.txt", body: "aaa"},
+			})
+
+			out := filepath.Join(dir, "out")
+			require.NoError(t, os.Mkdir(out, 0750))
+			before, err := os.Stat(out)
+			require.NoError(t, err)
+
+			require.NoError(t, Unzip(zipPath, out))
+
+			after, err := os.Stat(out)
+			require.NoError(t, err)
+			assert.Equal(t, before.Mode().Perm(), after.Mode().Perm())
+			assert.FileExists(t, filepath.Join(out, "a.txt"))
+		})
+	}
+}
+
+func TestUnzip_EntryReplacingTheDestinationIsRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	// A link entry at the destination's own name passes the target check with
+	// "." and would then swap the caller's directory for a link, since
+	// createSymlink removes whatever holds the path first.
+	for _, tt := range []struct {
+		name  string
+		entry zipEntry
+	}{
+		{name: "link", entry: zipEntry{name: ".", body: ".", isLink: true}},
+		{name: "file", entry: zipEntry{name: ".", body: "x"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			zipPath := filepath.Join(dir, "self.zip")
+			writeEntryZip(t, zipPath, []zipEntry{tt.entry})
+
+			out := filepath.Join(dir, "out")
+			require.NoError(t, os.Mkdir(out, 0755))
+
+			assert.ErrorContains(t, Unzip(zipPath, out), "illegal file path in zip")
+
+			fi, err := os.Lstat(out)
+			require.NoError(t, err)
+			assert.True(t, fi.IsDir())
+		})
+	}
+}
+
 func TestRecheckLinks_OffenderLeftOnDiskOutranksTheOnesRemoved(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -474,6 +474,65 @@ func TestUnzip_EscapingLinkTargetIsRejected(t *testing.T) {
 	}
 }
 
+func TestUnzip_LinkTargetThroughAnotherLinkIsRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	// filepath.Join folds "subdir/parent/.." into "subdir", so a target checked
+	// by text alone lands inside. The kernel follows subdir/parent first and
+	// ends up one level above destDir.
+	chain := []zipEntry{
+		{name: "subdir/keep", body: "x"},
+		{name: "subdir/parent", body: "..", isLink: true},
+		{name: "escape", body: "subdir/parent/..", isLink: true},
+	}
+	// Nothing constrains entry order, so the link that makes the chain escape
+	// may also arrive after the link that rides it.
+	for name, entries := range map[string][]zipEntry{
+		"rider last":  chain,
+		"rider first": {chain[2], chain[0], chain[1]},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			zipPath := filepath.Join(dir, "chain.zip")
+			writeEntryZip(t, zipPath, entries)
+
+			out := filepath.Join(dir, "out")
+			require.NoError(t, os.MkdirAll(out, 0755))
+
+			assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
+
+			_, err := os.Lstat(filepath.Join(out, "escape"))
+			assert.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestUnzip_LinkTargetMayGoThroughALinkInsideRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "chain.zip")
+	// Resolving the target must not turn every earlier link into a refusal:
+	// this chain stays inside destDir the whole way.
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "subdir/file.txt", body: "hi"},
+		{name: "alias", body: "subdir", isLink: true},
+		{name: "indirect", body: "alias/file.txt", isLink: true},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+	require.NoError(t, Unzip(zipPath, out))
+
+	content, err := os.ReadFile(filepath.Join(out, "indirect"))
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(content))
+}
+
 func TestUnzip_EntryWrittenThroughExistingLinkIsRejected(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -706,6 +706,58 @@ func TestUnzip_LinkWalkPastTheComponentBoundIsRejected(t *testing.T) {
 	assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
 }
 
+func TestUnzip_LinkCycleIsKeptButUnresolvable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "cycle.zip")
+	// A link that resolves through a cycle never lands anywhere: the kernel
+	// answers anyone who tries with ELOOP, so it can carry nobody outside and
+	// failing the archive over it would refuse a tree the host itself allows.
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "a", body: "b", isLink: true},
+		{name: "b", body: "a", isLink: true},
+		{name: "rider", body: "a/file.txt", isLink: true},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	require.NoError(t, Unzip(zipPath, out))
+
+	got, err := os.Readlink(filepath.Join(out, "a"))
+	require.NoError(t, err)
+	assert.Equal(t, "b", got)
+	_, err = os.Stat(filepath.Join(out, "rider"))
+	assert.ErrorContains(t, err, "too many levels of symbolic links")
+}
+
+func TestCreateZipAndUnzip_SelfReferentialLinkSurvives(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	// The host allows x -> x on disk, so CreateZip archives it and the round
+	// trip must not end in a rejection.
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	require.NoError(t, os.Mkdir(srcDir, 0755))
+	require.NoError(t, os.Symlink("x", filepath.Join(srcDir, "x")))
+
+	zipPath := filepath.Join(dir, "self.zip")
+	requireZip(t, zipPath, []string{srcDir}, true)
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.Mkdir(out, 0755))
+	require.NoError(t, Unzip(zipPath, out))
+
+	got, err := os.Readlink(filepath.Join(out, "src", "x"))
+	require.NoError(t, err)
+	assert.Equal(t, "x", got)
+}
+
 func TestUnzip_LinkTargetMayGoThroughALinkInsideRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -620,3 +620,18 @@ func TestCreateZipAndUnzip_EmptyDirectorySurvives(t *testing.T) {
 	// entry of its own or the download drops it.
 	assert.DirExists(t, filepath.Join(out, "src", "empty"))
 }
+
+func TestIsEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	empty, err := isEmptyDir(dir)
+	require.NoError(t, err)
+	assert.True(t, empty)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a"), nil, 0644))
+	empty, err = isEmptyDir(dir)
+	require.NoError(t, err)
+	assert.False(t, empty)
+
+	_, err = isEmptyDir(filepath.Join(dir, "missing"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -541,6 +542,40 @@ func TestUnzip_DeepLinkTargetWithoutLinksIsAccepted(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(out, "dots"))
 	require.NoError(t, err)
 	assert.Equal(t, "hi", string(content))
+}
+
+func TestUnzip_LinkWalkPastTheComponentBoundIsRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	// The hops stay under maxLinkResolution and each target under what the
+	// host allows, yet the walk visits far more components than the bound
+	// allows, since every hop splices its whole target in. Left unbounded, a
+	// small archive keeps a worker busy for tens of seconds.
+	// Under the 1024-byte target macOS allows.
+	padding := strings.Repeat("x/../", 196)
+	perHop := strings.Count(padding, "/")
+	hops := maxLinkWalk/perHop + 2
+	require.Less(t, hops, maxLinkResolution)
+
+	entries := []zipEntry{{name: "file.txt", body: "hi"}}
+	for i := range hops {
+		next := fmt.Sprintf("hop%d", i+1)
+		if i == hops-1 {
+			next = "file.txt"
+		}
+		entries = append(entries, zipEntry{name: fmt.Sprintf("hop%d", i), body: padding + next, isLink: true})
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "long.zip")
+	writeEntryZip(t, zipPath, entries)
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
 }
 
 func TestUnzip_LinkTargetMayGoThroughALinkInsideRoot(t *testing.T) {

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -316,9 +316,8 @@ func TestCreateZipAndUnzip_RoundTrip(t *testing.T) {
 	assert.Equal(t, "bbb", string(content))
 }
 
-// zipEntry is one entry for writeEntryZip: with isLink set it carries its
-// target as the body. A slice keeps the archive order, which the map writeZip
-// takes cannot.
+// zipEntry is one entry for writeEntryZip: with isLink set, body is the link
+// target. A slice keeps the archive order, which the map writeZip takes cannot.
 type zipEntry struct {
 	name   string
 	body   string
@@ -371,8 +370,7 @@ func TestUnzip_SymlinkIsRestored(t *testing.T) {
 	link := filepath.Join(out, "demo", "link")
 	fi, err := os.Lstat(link)
 	require.NoError(t, err)
-	// A link entry used to come back as a plain file holding the target path,
-	// so assert the type rather than just that something is there.
+	// A link entry used to come back as a plain file holding the target path.
 	require.NotZero(t, fi.Mode()&os.ModeSymlink, "link came back as %v", fi.Mode())
 
 	target, err := os.Readlink(link)
@@ -399,9 +397,8 @@ func TestUnzip_SetuidBitIsNotRestored(t *testing.T) {
 	require.NoError(t, os.MkdirAll(out, 0755))
 	require.NoError(t, Unzip(zipPath, out))
 
-	// Extraction runs in the alpamon process, which is root on a normal
-	// install, so an entry carrying setuid would land as a root-owned setuid
-	// file. newZipEntry already drops these bits when writing an archive.
+	// Extraction runs as root on a normal install, so this entry would land as
+	// a root-owned setuid file.
 	fi, err := os.Stat(filepath.Join(out, "payload"))
 	require.NoError(t, err)
 	assert.Zero(t, fi.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky))
@@ -421,8 +418,8 @@ func TestUnzip_AbsoluteLinkTargetIsRejected(t *testing.T) {
 func TestUnzip_OversizedLinkTargetIsRejected(t *testing.T) {
 	dir := t.TempDir()
 	zipPath := filepath.Join(dir, "long.zip")
-	// The read is bounded, so an over-long body used to arrive truncated and
-	// become a link to a path the archive never named.
+	// An over-long body used to arrive truncated: a link to a path the archive
+	// never named.
 	writeEntryZip(t, zipPath, []zipEntry{
 		{name: "link", body: strings.Repeat("a", maxSymlinkTarget+1), isLink: true},
 	})
@@ -439,9 +436,8 @@ func TestUnzip_OversizedLinkTargetIsRejected(t *testing.T) {
 func TestUnzip_RejectionMessageEscapesControlBytes(t *testing.T) {
 	dir := t.TempDir()
 	zipPath := filepath.Join(dir, "esc.zip")
-	// A zip entry name is arbitrary bytes, and the rejection message is
-	// returned to the console as the command result, so an escape sequence
-	// in it would reach a terminal as live input.
+	// The rejection reaches the console as the command result, so an escape
+	// sequence in an entry name would arrive at a terminal as live input.
 	writeEntryZip(t, zipPath, []zipEntry{{name: "\x1b[2Jgone", body: "/etc", isLink: true}})
 
 	out := filepath.Join(dir, "out")
@@ -453,14 +449,14 @@ func TestUnzip_RejectionMessageEscapesControlBytes(t *testing.T) {
 }
 
 func TestUnzip_EscapingLinkTargetIsRejected(t *testing.T) {
-	// The entry-name check passes for both: "a" sits inside destDir and so
-	// does "a/passwd". Only the link target puts the second write outside.
+	// Both names pass the entry-name check; only the link target puts the
+	// second write outside.
 	escaping := []zipEntry{
 		{name: "a", body: "../../etc", isLink: true},
 		{name: "a/passwd", body: "malicious"},
 	}
-	// Nothing constrains the order entries appear in, so the link arriving
-	// after the path that goes through it must be rejected just the same.
+	// Nothing constrains entry order, so a link arriving after the path that
+	// goes through it must be rejected just the same.
 	for name, entries := range map[string][]zipEntry{
 		"link first": escaping,
 		"link last":  {escaping[1], escaping[0]},
@@ -489,7 +485,7 @@ func TestUnzip_EntryWrittenThroughExistingLinkIsRejected(t *testing.T) {
 	out := filepath.Join(dir, "out")
 	require.NoError(t, os.MkdirAll(out, 0755))
 	// A link the archive never carried: the upload path extracts into the
-	// user's own directory, so one can already be sitting in it.
+	// user's own directory, where one can already be sitting.
 	require.NoError(t, os.Symlink(outside, filepath.Join(out, "a")))
 
 	zipPath := filepath.Join(dir, "evil.zip")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -611,3 +611,21 @@ func TestUnzip_ConcurrentExtractionsIntoOneDestination(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "file.txt", target)
 }
+
+func TestCreateZipAndUnzip_EmptyDirectorySurvives(t *testing.T) {
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "empty"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("aaa"), 0644))
+
+	zipPath := filepath.Join(dir, "archive.zip")
+	requireZip(t, zipPath, []string{srcDir}, true)
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+	require.NoError(t, Unzip(zipPath, out))
+
+	// A directory holding nothing has no file entry to carry it, so it needs an
+	// entry of its own or the download drops it.
+	assert.DirExists(t, filepath.Join(out, "src", "empty"))
+}

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -517,6 +517,32 @@ func TestUnzip_LinkTargetThroughAnotherLinkIsRejected(t *testing.T) {
 	}
 }
 
+func TestUnzip_DeepLinkTargetWithoutLinksIsAccepted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "deep.zip")
+	// The resolution bound counts links followed, not path components, so a
+	// tree deeper than the bound still round-trips when nothing in it is a
+	// link.
+	deep := strings.Repeat("d/", maxLinkResolution+8) + "file.txt"
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: deep, body: "hi"},
+		{name: "link", body: deep, isLink: true},
+		{name: "dots", body: strings.Repeat("./", maxLinkResolution+8) + "link", isLink: true},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+	require.NoError(t, Unzip(zipPath, out))
+
+	content, err := os.ReadFile(filepath.Join(out, "dots"))
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(content))
+}
+
 func TestUnzip_LinkTargetMayGoThroughALinkInsideRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -835,7 +835,9 @@ func TestUnzip_EntryWrittenThroughExistingLinkIsRejected(t *testing.T) {
 	zipPath := filepath.Join(dir, "evil.zip")
 	writeEntryZip(t, zipPath, []zipEntry{{name: "a/passwd", body: "malicious"}})
 
-	assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
+	// The entry is a plain file, so the rejection names the entry rather than
+	// a link target it does not have.
+	assert.ErrorContains(t, Unzip(zipPath, out), `illegal entry in zip: "a/passwd" is written through a symlink`)
 
 	_, err := os.Stat(filepath.Join(outside, "passwd"))
 	assert.ErrorIs(t, err, os.ErrNotExist, "the entry was written through the link")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -904,6 +904,31 @@ func TestUnzip_EntryReplacingTheDestinationIsRejected(t *testing.T) {
 	}
 }
 
+func TestCreateFile_DoesNotWriteThroughALink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	// extractFile clears a link before it opens the path, but another
+	// extraction into the same destination can put one back in between, and
+	// the open must not carry the entry's content through it.
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "victim.txt")
+	require.NoError(t, os.WriteFile(victim, []byte("keep"), 0644))
+	link := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink("victim.txt", link))
+
+	f, err := createFile(link, 0644)
+	if err == nil {
+		_ = f.Close()
+	}
+	assert.Error(t, err)
+
+	content, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	assert.Equal(t, "keep", string(content))
+}
+
 func TestRecheckLinks_OffenderLeftOnDiskOutranksTheOnesRemoved(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -349,6 +349,21 @@ func writeEntryZip(t *testing.T, path string, entries []zipEntry) {
 	require.NoError(t, f.Close())
 }
 
+func TestUnzip_MissingDestinationDirectoryIsCreated(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "plain.zip")
+	writeEntryZip(t, zipPath, []zipEntry{{name: "file.txt", body: "hi"}})
+
+	// The destination used to appear on its own with the first entry, and the
+	// upload path is not the only caller of an exported function.
+	out := filepath.Join(dir, "missing")
+	require.NoError(t, Unzip(zipPath, out))
+
+	content, err := os.ReadFile(filepath.Join(out, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(content))
+}
+
 func TestUnzip_SymlinkIsRestored(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -451,6 +451,32 @@ func TestUnzip_RejectionMessageEscapesControlBytes(t *testing.T) {
 	assert.NotContains(t, err.Error(), "\x1b")
 }
 
+func TestUnzip_LinkThroughAnEarlierLinkEntryIsRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	// "a" is a real directory while the first pass checks a/c's parent, and a
+	// link to "." by the time the second pass writes a/c: written through it,
+	// the entry would land at c and its target would resolve from the
+	// destination's parent, straight past every lexical check.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secret"), []byte("TOP SECRET"), 0600))
+	zipPath := filepath.Join(dir, "esc.zip")
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "a", body: ".", isLink: true},
+		{name: "a/c", body: "../secret", isLink: true},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.Mkdir(out, 0755))
+
+	assert.ErrorContains(t, Unzip(zipPath, out), "written through a symlink")
+
+	_, err := os.Lstat(filepath.Join(out, "c"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestUnzip_EscapingLinkTargetIsRejected(t *testing.T) {
 	// Both names pass the entry-name check; only the link target puts the
 	// second write outside.

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -481,6 +481,25 @@ func TestUnzip_ControlBytesInLinkTargetAreRejected(t *testing.T) {
 	assert.NotContains(t, err.Error(), "\x1b")
 }
 
+func TestUnzip_EntryWrittenUnderAFileIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "under.zip")
+	// Without its own check this surfaces as the raw ENOTDIR from OpenFile.
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "d", body: "keep"},
+		{name: "d/child.txt", body: "y"},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	assert.ErrorContains(t, Unzip(zipPath, out), "illegal entry in zip")
+
+	content, err := os.ReadFile(filepath.Join(out, "d"))
+	require.NoError(t, err)
+	assert.Equal(t, "keep", string(content))
+}
+
 func TestUnzip_LinkThroughAnEarlierLinkEntryIsRejected(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"archive/zip"
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -619,6 +620,27 @@ func TestCreateZipAndUnzip_EmptyDirectorySurvives(t *testing.T) {
 	// A directory holding nothing has no file entry to carry it, so it needs an
 	// entry of its own or the download drops it.
 	assert.DirExists(t, filepath.Join(out, "src", "empty"))
+}
+
+func TestUnzipReader_ExtractsAnInMemoryArchive(t *testing.T) {
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	zw, err := w.Create("hello.txt")
+	require.NoError(t, err)
+	_, err = zw.Write([]byte("hi"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// Nothing here was ever a file, so there is no ReadCloser to hand over.
+	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	out := filepath.Join(t.TempDir(), "out")
+	require.NoError(t, UnzipReader(r, out))
+
+	content, err := os.ReadFile(filepath.Join(out, "hello.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(content))
 }
 
 func TestUnzip_ErrorNamesTheEntry(t *testing.T) {

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -451,6 +451,36 @@ func TestUnzip_RejectionMessageEscapesControlBytes(t *testing.T) {
 	assert.NotContains(t, err.Error(), "\x1b")
 }
 
+func TestUnzip_ControlBytesInEntryNameAreRejected(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "esc.zip")
+	// An OS error embeds the raw path where %q cannot reach it, so a name
+	// carrying control bytes must not get far enough to raise one.
+	writeEntryZip(t, zipPath, []zipEntry{{name: "d\x1b[2J/x.txt", body: "x"}})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	err := Unzip(zipPath, out)
+	assert.ErrorContains(t, err, "illegal file path in zip")
+	assert.NotContains(t, err.Error(), "\x1b")
+}
+
+func TestUnzip_ControlBytesInLinkTargetAreRejected(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "esc.zip")
+	// The same route the entry-name check closes: a failure past the checks
+	// wraps the OS error, which embeds the raw target where %q cannot reach.
+	writeEntryZip(t, zipPath, []zipEntry{{name: "lnk", body: "\x1b[2Jx", isLink: true}})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	err := Unzip(zipPath, out)
+	assert.ErrorContains(t, err, "illegal link target in zip")
+	assert.NotContains(t, err.Error(), "\x1b")
+}
+
 func TestUnzip_LinkThroughAnEarlierLinkEntryIsRejected(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -323,6 +323,7 @@ type zipEntry struct {
 	name   string
 	body   string
 	isLink bool
+	mode   os.FileMode // zero means a plain 0644 file
 }
 
 func writeEntryZip(t *testing.T, path string, entries []zipEntry) {
@@ -331,9 +332,12 @@ func writeEntryZip(t *testing.T, path string, entries []zipEntry) {
 	require.NoError(t, err)
 	w := zip.NewWriter(f)
 	for _, e := range entries {
-		mode := os.FileMode(0644)
-		if e.isLink {
+		mode := e.mode
+		switch {
+		case e.isLink:
 			mode = 0777 | os.ModeSymlink
+		case mode == 0:
+			mode = 0644
 		}
 		hdr := &zip.FileHeader{Name: e.name, Method: zip.Store}
 		hdr.SetMode(mode)
@@ -378,6 +382,29 @@ func TestUnzip_SymlinkIsRestored(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(link, "file.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "hi", string(content))
+}
+
+func TestUnzip_SetuidBitIsNotRestored(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows has no setuid bit")
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "suid.zip")
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "payload", body: "x", mode: 0755 | os.ModeSetuid | os.ModeSetgid | os.ModeSticky},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+	require.NoError(t, Unzip(zipPath, out))
+
+	// Extraction runs in the alpamon process, which is root on a normal
+	// install, so an entry carrying setuid would land as a root-owned setuid
+	// file. newZipEntry already drops these bits when writing an archive.
+	fi, err := os.Stat(filepath.Join(out, "payload"))
+	require.NoError(t, err)
+	assert.Zero(t, fi.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky))
 }
 
 func TestUnzip_AbsoluteLinkTargetIsRejected(t *testing.T) {

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -313,4 +314,146 @@ func TestCreateZipAndUnzip_RoundTrip(t *testing.T) {
 	content, err = os.ReadFile(filepath.Join(outDir, "src", "sub", "b.txt"))
 	require.NoError(t, err, "sub/b.txt not found after round-trip")
 	assert.Equal(t, "bbb", string(content))
+}
+
+// zipEntry is one entry for writeEntryZip: with isLink set it carries its
+// target as the body. A slice keeps the archive order, which the map writeZip
+// takes cannot.
+type zipEntry struct {
+	name   string
+	body   string
+	isLink bool
+}
+
+func writeEntryZip(t *testing.T, path string, entries []zipEntry) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	w := zip.NewWriter(f)
+	for _, e := range entries {
+		mode := os.FileMode(0644)
+		if e.isLink {
+			mode = 0777 | os.ModeSymlink
+		}
+		hdr := &zip.FileHeader{Name: e.name, Method: zip.Store}
+		hdr.SetMode(mode)
+		zw, err := w.CreateHeader(hdr)
+		require.NoError(t, err)
+		_, err = zw.Write([]byte(e.body))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+}
+
+func TestUnzip_SymlinkIsRestored(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	demo := filepath.Join(dir, "demo")
+	require.NoError(t, os.MkdirAll(filepath.Join(demo, "real"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(demo, "real", "file.txt"), []byte("hi"), 0644))
+	require.NoError(t, os.Symlink("real", filepath.Join(demo, "link")))
+
+	zipPath := filepath.Join(dir, "demo.zip")
+	requireZip(t, zipPath, []string{demo}, true)
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+	require.NoError(t, Unzip(zipPath, out))
+
+	link := filepath.Join(out, "demo", "link")
+	fi, err := os.Lstat(link)
+	require.NoError(t, err)
+	// A link entry used to come back as a plain file holding the target path,
+	// so assert the type rather than just that something is there.
+	require.NotZero(t, fi.Mode()&os.ModeSymlink, "link came back as %v", fi.Mode())
+
+	target, err := os.Readlink(link)
+	require.NoError(t, err)
+	assert.Equal(t, "real", target)
+
+	content, err := os.ReadFile(filepath.Join(link, "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(content))
+}
+
+func TestUnzip_AbsoluteLinkTargetIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "abs.zip")
+	writeEntryZip(t, zipPath, []zipEntry{{name: "etc", body: "/etc", isLink: true}})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
+}
+
+func TestUnzip_OversizedLinkTargetIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "long.zip")
+	// The read is bounded, so an over-long body used to arrive truncated and
+	// become a link to a path the archive never named.
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "link", body: strings.Repeat("a", maxSymlinkTarget+1), isLink: true},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
+
+	_, err := os.Lstat(filepath.Join(out, "link"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestUnzip_EscapingLinkTargetIsRejected(t *testing.T) {
+	// The entry-name check passes for both: "a" sits inside destDir and so
+	// does "a/passwd". Only the link target puts the second write outside.
+	escaping := []zipEntry{
+		{name: "a", body: "../../etc", isLink: true},
+		{name: "a/passwd", body: "malicious"},
+	}
+	// Nothing constrains the order entries appear in, so the link arriving
+	// after the path that goes through it must be rejected just the same.
+	for name, entries := range map[string][]zipEntry{
+		"link first": escaping,
+		"link last":  {escaping[1], escaping[0]},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			zipPath := filepath.Join(dir, "evil.zip")
+			writeEntryZip(t, zipPath, entries)
+
+			out := filepath.Join(dir, "out")
+			require.NoError(t, os.MkdirAll(out, 0755))
+
+			assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
+		})
+	}
+}
+
+func TestUnzip_EntryWrittenThroughExistingLinkIsRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "outside")
+	require.NoError(t, os.MkdirAll(outside, 0755))
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+	// A link the archive never carried: the upload path extracts into the
+	// user's own directory, so one can already be sitting in it.
+	require.NoError(t, os.Symlink(outside, filepath.Join(out, "a")))
+
+	zipPath := filepath.Join(dir, "evil.zip")
+	writeZip(t, zipPath, map[string]string{"a/passwd": "malicious"})
+
+	assert.ErrorContains(t, Unzip(zipPath, out), "illegal link target in zip")
+
+	_, err := os.Stat(filepath.Join(outside, "passwd"))
+	assert.ErrorIs(t, err, os.ErrNotExist, "the entry was written through the link")
 }

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -436,6 +436,22 @@ func TestUnzip_OversizedLinkTargetIsRejected(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
+func TestUnzip_RejectionMessageEscapesControlBytes(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "esc.zip")
+	// A zip entry name is arbitrary bytes, and the rejection message is
+	// returned to the console as the command result, so an escape sequence
+	// in it would reach a terminal as live input.
+	writeEntryZip(t, zipPath, []zipEntry{{name: "\x1b[2Jgone", body: "/etc", isLink: true}})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	err := Unzip(zipPath, out)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "\x1b")
+}
+
 func TestUnzip_EscapingLinkTargetIsRejected(t *testing.T) {
 	// The entry-name check passes for both: "a" sits inside destDir and so
 	// does "a/passwd". Only the link target puts the second write outside.

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -621,6 +621,26 @@ func TestCreateZipAndUnzip_EmptyDirectorySurvives(t *testing.T) {
 	assert.DirExists(t, filepath.Join(out, "src", "empty"))
 }
 
+func TestUnzip_ErrorNamesTheEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "collide.zip")
+	// The error reaches the console as the command result, so a bare OS error
+	// with an internal absolute path and no entry name is not actionable.
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "d/file.txt", body: "hi"},
+		{name: "d", body: "file.txt", isLink: true},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	assert.ErrorContains(t, Unzip(zipPath, out), `link "d"`)
+}
+
 func TestIsEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 	empty, err := isEmptyDir(dir)

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -758,6 +758,42 @@ func TestCreateZipAndUnzip_SelfReferentialLinkSurvives(t *testing.T) {
 	assert.Equal(t, "x", got)
 }
 
+func TestUnzip_DirectoryModeFromANonUnixArchiveIsIgnored(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "fat.zip")
+	f, err := os.Create(zipPath)
+	require.NoError(t, err)
+	w := zip.NewWriter(f)
+	// No SetMode: a FAT-creator header, the kind Compress-Archive writes.
+	// archive/zip derives 0666 from its attributes, a directory nobody chose
+	// to make unenterable.
+	_, err = w.CreateHeader(&zip.FileHeader{Name: "sub/", Method: zip.Store})
+	require.NoError(t, err)
+	zw, err := w.Create("sub/f.txt")
+	require.NoError(t, err)
+	_, err = zw.Write([]byte("x"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.Mkdir(out, 0755))
+	require.NoError(t, Unzip(zipPath, out))
+
+	ref := filepath.Join(dir, "ref")
+	require.NoError(t, os.Mkdir(ref, 0755))
+	refInfo, err := os.Stat(ref)
+	require.NoError(t, err)
+
+	fi, err := os.Stat(filepath.Join(out, "sub"))
+	require.NoError(t, err)
+	assert.Equal(t, refInfo.Mode().Perm(), fi.Mode().Perm())
+}
+
 func TestUnzip_LinkTargetMayGoThroughALinkInsideRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix-specific behavior")

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -736,6 +736,175 @@ func TestCreateZipAndUnzip_EmptyDirectorySurvives(t *testing.T) {
 	assert.DirExists(t, filepath.Join(out, "src", "empty"))
 }
 
+func TestCreateZipAndUnzip_EmptyDirectoryModeIsPreserved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	private := filepath.Join(srcDir, "private")
+	require.NoError(t, os.MkdirAll(private, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("aaa"), 0644))
+
+	zipPath := filepath.Join(dir, "archive.zip")
+	requireZip(t, zipPath, []string{srcDir}, true)
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+	require.NoError(t, Unzip(zipPath, out))
+
+	// Only a directory holding nothing gets an entry of its own, so it is the
+	// one whose mode makes the trip; one holding files comes back with the
+	// default. Extraction runs as root on a normal install, so a directory
+	// that came back wider than it left would be readable by everyone on the
+	// host.
+	fi, err := os.Stat(filepath.Join(out, "src", "private"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), fi.Mode().Perm())
+}
+
+func TestRecheckLinks_OffenderLeftOnDiskOutranksTheOnesRemoved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root removes from a read-only directory regardless")
+	}
+
+	// No archive can leave a link's parent read-only before the sweep, since
+	// directory modes land after it, so the sweep is driven directly.
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "ro"), 0755))
+	require.NoError(t, os.Symlink("../..", filepath.Join(root, "ro", "stuck")))
+	require.NoError(t, os.Symlink("..", filepath.Join(root, "gone")))
+	require.NoError(t, os.Chmod(filepath.Join(root, "ro"), 0500))
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(root, "ro"), 0700) })
+
+	rejected, left := recheckLinks(root, []deferredEntry{
+		{file: &zip.File{FileHeader: zip.FileHeader{Name: "gone"}}, path: filepath.Join(root, "gone")},
+		{file: &zip.File{FileHeader: zip.FileHeader{Name: "ro/stuck"}}, path: filepath.Join(root, "ro", "stuck")},
+	})
+	assert.ErrorContains(t, rejected, `illegal link target in zip: "gone"`)
+	assert.ErrorContains(t, left, `failed to remove link "ro/stuck"`)
+
+	_, err := os.Lstat(filepath.Join(root, "gone"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Lstat(filepath.Join(root, "ro", "stuck"))
+	assert.NoError(t, err)
+}
+
+func TestUnzip_ReadOnlyDirectoryEntryDoesNotBlockItsChildren(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root writes into a read-only directory regardless")
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "ro.zip")
+	// zip -r lists a directory before what it holds, whatever the directory's
+	// mode, so the mode has to land after the children or none of them can be
+	// written. The parent's mode has to land after the child's too, since a
+	// parent without search permission blocks the chmod below it.
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "ro/", mode: 0400 | os.ModeDir},
+		{name: "ro/sub/", mode: 0700 | os.ModeDir},
+		{name: "ro/sub/file.txt", body: "hi"},
+		{name: "ro/sub/link", body: "file.txt", isLink: true},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(out, "ro"), 0700) })
+	require.NoError(t, Unzip(zipPath, out))
+
+	fi, err := os.Stat(filepath.Join(out, "ro"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0400), fi.Mode().Perm())
+
+	require.NoError(t, os.Chmod(filepath.Join(out, "ro"), 0700))
+	content, err := os.ReadFile(filepath.Join(out, "ro", "sub", "link"))
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(content))
+
+	fi, err = os.Stat(filepath.Join(out, "ro", "sub"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), fi.Mode().Perm())
+}
+
+func TestUnzip_LinkReplacingADirectoryEntryIsRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	// The link lands after the directory it is named for, so by the time the
+	// directory's mode is applied the path is a link. os.Chmod follows links,
+	// and the mode would land on whatever the link points at. An entry that
+	// carries no mode gets nothing applied, and is refused all the same.
+	for _, tt := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{"with mode", 0777 | os.ModeDir},
+		{"without mode", os.ModeDir},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			zipPath := filepath.Join(dir, "swap.zip")
+			writeEntryZip(t, zipPath, []zipEntry{
+				{name: "victim.txt", body: "secret", mode: 0600},
+				{name: "d/", mode: tt.mode},
+				{name: "d", body: "victim.txt", isLink: true},
+			})
+
+			out := filepath.Join(dir, "out")
+			require.NoError(t, os.MkdirAll(out, 0755))
+
+			assert.ErrorContains(t, Unzip(zipPath, out), "illegal entry in zip")
+
+			fi, err := os.Stat(filepath.Join(out, "victim.txt"))
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0600), fi.Mode().Perm())
+		})
+	}
+}
+
+func TestUnzip_DirectoryEntryWithoutModeKeepsTheDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "nomode.zip")
+	// A Unix-flagged archive with empty external attributes reads back as
+	// mode 0, which is an absent mode rather than a directory nobody may
+	// enter.
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "d/", mode: os.ModeDir},
+		{name: "d/file.txt", body: "hi"},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+	require.NoError(t, Unzip(zipPath, out))
+
+	// The default is whatever os.Mkdir leaves under this process's umask, so
+	// a directory made the same way is the reference, not a literal 0755.
+	ref := filepath.Join(dir, "ref")
+	require.NoError(t, os.Mkdir(ref, 0755))
+	want, err := os.Stat(ref)
+	require.NoError(t, err)
+	fi, err := os.Stat(filepath.Join(out, "d"))
+	require.NoError(t, err)
+	assert.Equal(t, want.Mode().Perm(), fi.Mode().Perm())
+
+	content, err := os.ReadFile(filepath.Join(out, "d", "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(content))
+}
+
 func TestUnzipReader_ExtractsAnInMemoryArchive(t *testing.T) {
 	var buf bytes.Buffer
 	w := zip.NewWriter(&buf)

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -569,4 +570,44 @@ func TestUnzip_EntryWrittenThroughExistingLinkIsRejected(t *testing.T) {
 
 	_, err := os.Stat(filepath.Join(outside, "passwd"))
 	assert.ErrorIs(t, err, os.ErrNotExist, "the entry was written through the link")
+}
+
+func TestUnzip_ConcurrentExtractionsIntoOneDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "links.zip")
+	writeEntryZip(t, zipPath, []zipEntry{
+		{name: "file.txt", body: "hi"},
+		{name: "sub/file.txt", body: "hi"},
+		{name: "link", body: "file.txt", isLink: true},
+		{name: "sub/link", body: "file.txt", isLink: true},
+	})
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0755))
+
+	// Commands run on a worker pool, so one directory can take two extractions
+	// at once. A regular entry rides that out because O_TRUNC overwrites in a
+	// single call, while a link is removed and created in two.
+	const workers = 8
+	errs := make(chan error, workers)
+	var start sync.WaitGroup
+	start.Add(1)
+	for range workers {
+		go func() {
+			start.Wait()
+			errs <- Unzip(zipPath, out)
+		}()
+	}
+	start.Done()
+	for range workers {
+		assert.NoError(t, <-errs)
+	}
+
+	target, err := os.Readlink(filepath.Join(out, "link"))
+	require.NoError(t, err)
+	assert.Equal(t, "file.txt", target)
 }

--- a/pkg/utils/archive_unix.go
+++ b/pkg/utils/archive_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package utils
+
+// symlinkUnsupported reports whether os.Symlink failed because the host makes
+// no links at all. On Unix nothing says only that: EPERM covers a filesystem
+// without link support and a plain permission denial alike, so every failure
+// here is reported.
+func symlinkUnsupported(error) bool { return false }

--- a/pkg/utils/archive_unix.go
+++ b/pkg/utils/archive_unix.go
@@ -2,8 +2,7 @@
 
 package utils
 
-// symlinkUnsupported reports whether os.Symlink failed because the host makes
-// no links at all. On Unix nothing says only that: EPERM covers a filesystem
-// without link support and a plain permission denial alike, so every failure
-// here is reported.
+// symlinkUnsupported reports whether os.Symlink failed because the host makes no
+// links at all. Nothing on Unix says only that: EPERM covers a filesystem without
+// link support and a plain permission denial alike.
 func symlinkUnsupported(error) bool { return false }

--- a/pkg/utils/archive_unix.go
+++ b/pkg/utils/archive_unix.go
@@ -12,6 +12,9 @@ import (
 // link support and a plain permission denial alike.
 func symlinkUnsupported(error) bool { return false }
 
+// noFollow makes createFile refuse a link sitting at its path.
+const noFollow = syscall.O_NOFOLLOW
+
 // chmodDir sets mode on the directory at path without following a link that
 // may have taken its place since it was checked: a handle opened with
 // O_NOFOLLOW is the directory itself, and fchmod acts on the handle.

--- a/pkg/utils/archive_unix.go
+++ b/pkg/utils/archive_unix.go
@@ -2,7 +2,24 @@
 
 package utils
 
+import (
+	"os"
+	"syscall"
+)
+
 // symlinkUnsupported reports whether os.Symlink failed because the host makes no
 // links at all. Nothing on Unix says only that: EPERM covers a filesystem without
 // link support and a plain permission denial alike.
 func symlinkUnsupported(error) bool { return false }
+
+// chmodDir sets mode on the directory at path without following a link that
+// may have taken its place since it was checked: a handle opened with
+// O_NOFOLLOW is the directory itself, and fchmod acts on the handle.
+func chmodDir(path string, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_DIRECTORY, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return f.Chmod(mode)
+}

--- a/pkg/utils/archive_unix_test.go
+++ b/pkg/utils/archive_unix_test.go
@@ -42,6 +42,31 @@ func TestCreateZip_IrregularEntriesAreSkipped(t *testing.T) {
 	assert.Equal(t, "demo/file.txt", r.File[0].Name)
 }
 
+func TestCreateZip_DirectoryHoldingOnlySpecialFilesKeepsItsEntry(t *testing.T) {
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	sub := filepath.Join(srcDir, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0755))
+	require.NoError(t, syscall.Mkfifo(filepath.Join(sub, "fifo"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("aaa"), 0644))
+
+	dest := filepath.Join(dir, "out.zip")
+	// The FIFO is dropped the way the walk drops every special file, but that
+	// must not take the directory down with it: without an entry of its own
+	// it would vanish from the download without a trace.
+	requireZip(t, dest, []string{srcDir}, true)
+
+	r, err := zip.OpenReader(dest)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	names := make([]string, 0, len(r.File))
+	for _, f := range r.File {
+		names = append(names, f.Name)
+	}
+	assert.Contains(t, names, "src/sub/")
+}
+
 func TestCreateZip_ListedIrregularPathIsSkipped(t *testing.T) {
 	dir := t.TempDir()
 

--- a/pkg/utils/archive_windows.go
+++ b/pkg/utils/archive_windows.go
@@ -8,10 +8,9 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// symlinkUnsupported reports whether os.Symlink failed because this host makes
-// no links: no SeCreateSymbolicLink and developer mode off, or a filesystem
-// without link support. Neither says anything about the archive, so the entry
-// is dropped instead of failing the extraction.
+// symlinkUnsupported reports whether os.Symlink failed because this host makes no
+// links: no SeCreateSymbolicLink with developer mode off, or a filesystem without
+// link support. Neither says anything about the archive.
 func symlinkUnsupported(err error) bool {
 	return errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD) ||
 		errors.Is(err, windows.ERROR_NOT_SUPPORTED) ||

--- a/pkg/utils/archive_windows.go
+++ b/pkg/utils/archive_windows.go
@@ -4,6 +4,7 @@ package utils
 
 import (
 	"errors"
+	"os"
 
 	"golang.org/x/sys/windows"
 )
@@ -15,4 +16,11 @@ func symlinkUnsupported(err error) bool {
 	return errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD) ||
 		errors.Is(err, windows.ERROR_NOT_SUPPORTED) ||
 		errors.Is(err, windows.ERROR_INVALID_FUNCTION)
+}
+
+// chmodDir sets mode on the directory at path. Windows has no O_NOFOLLOW to
+// pin the handle to the directory itself, and os.Chmod there only toggles the
+// read-only attribute, so there is no mode to misplace.
+func chmodDir(path string, mode os.FileMode) error {
+	return os.Chmod(path, mode)
 }

--- a/pkg/utils/archive_windows.go
+++ b/pkg/utils/archive_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package utils
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// symlinkUnsupported reports whether os.Symlink failed because this host makes
+// no links: no SeCreateSymbolicLink and developer mode off, or a filesystem
+// without link support. Neither says anything about the archive, so the entry
+// is dropped instead of failing the extraction.
+func symlinkUnsupported(err error) bool {
+	return errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD) ||
+		errors.Is(err, windows.ERROR_NOT_SUPPORTED) ||
+		errors.Is(err, windows.ERROR_INVALID_FUNCTION)
+}

--- a/pkg/utils/archive_windows.go
+++ b/pkg/utils/archive_windows.go
@@ -18,6 +18,10 @@ func symlinkUnsupported(err error) bool {
 		errors.Is(err, windows.ERROR_INVALID_FUNCTION)
 }
 
+// noFollow is empty: Windows has no O_NOFOLLOW, so a link put at a path
+// between extractFile's check and its open is followed.
+const noFollow = 0
+
 // chmodDir sets mode on the directory at path. Windows has no O_NOFOLLOW to
 // pin the handle to the directory itself, and os.Chmod there only toggles the
 // read-only attribute, so there is no mode to misplace.

--- a/pkg/utils/fs_test.go
+++ b/pkg/utils/fs_test.go
@@ -182,7 +182,7 @@ func TestOpenIfZip(t *testing.T) {
 
 	t.Run("valid zip returns handle", func(t *testing.T) {
 		p := filepath.Join(tmpDir, "valid.zip")
-		writeZip(t, p, nil)
+		writeEntryZip(t, p, nil)
 		rc := OpenIfZip(p, ".zip")
 		require.NotNil(t, rc)
 		_ = rc.Close()
@@ -217,7 +217,7 @@ func TestOpenIfZip(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := filepath.Join(tmpDir, tc.file)
 			if tc.isZip {
-				writeZip(t, p, nil)
+				writeEntryZip(t, p, nil)
 			} else {
 				require.NoError(t, os.WriteFile(p, []byte("hello"), 0644))
 			}


### PR DESCRIPTION
## Background

A folder downloaded through WebFTP and uploaded back with `allow_unzip` lost every symlink in it. #433 taught `CreateZip` to store a symlink as a zip link entry, the target path as the entry body with `ModeSymlink` in the external attributes, but left the other half undone and said so: "`UnzipReader` has no link branch, so re-uploading a downloaded archive with `allow_unzip` turns each link entry back into a plain text file holding the target path."

`UnzipReader` in `pkg/utils/archive.go` branched only on `IsDir()`. Everything else went to `os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())`, and `os.OpenFile` ignores the type bits in its permission argument, so `ModeSymlink` was discarded and `io.Copy` wrote the target path as file content. A link named `demo/link -> real` came back as a regular 0755 file holding the four bytes `real`.

Opening a link branch opens routes out of the destination directory that the entry-name check does not close. Those are fixed here as separate commits, because shipping the branch without them would be shipping the escape.

## Changes

29 commits, 1484 insertions and 48 deletions across 7 files. Each commit is one idea and each has a test that was seen failing first.

Extraction now mirrors compression. `extractSymlink` and `extractFile` sit next to each other the way `addSymlinkToZip` and `addFileToZip` already do, and a link entry is recreated with `os.Symlink`.

### Containment

A parent component that is itself a link is refused: `os.MkdirAll` follows one, so `mkdirAllInside` walks the path a component at a time and stops at the first link. A component that is a regular file is refused for the same reason, since walking past it only surfaces later as a raw `ENOTDIR`. Both refusals name the entry rather than a link target, because the entry they refuse is usually a plain file and the link is a component of the path under it. The link in the way can come from an earlier entry in the same archive or from the destination directory itself, which on the upload path is the user's own, so neither the entry order nor a clean archive makes that check unnecessary. The destination is resolved once with `filepath.EvalSymlinks`, since comparing against it unresolved reads every extraction under `/tmp` on darwin as an escape.

The link target itself is refused when it is absolute, and when a relative one lands outside the destination. Deciding that by text does not work: `filepath.Join` folds `subdir/parent/..` down to `subdir`, while the kernel follows `subdir/parent` first and ends up wherever that link points. `isValidLinkTarget` walks the target component by component, follows every link already on disk, takes `..` one real level up, and checks at each step that the path is still inside the destination. CodeQL reports the same shape as `go/unsafe-unzip-symlink`, and its help calls out the `filepath.Rel` check by name as the ineffective one.

Two bounds sit on that walk, and they measure different things. `maxLinkResolution` counts the links followed, not the components visited, so a deep tree with no link in it is not mistaken for a chain. `maxLinkWalk` counts components across the whole walk, because every link followed splices a whole target in front of the parts still to walk and the hop bound alone leaves a small archive able to hold a worker for tens of seconds.

Resolution alone stays order-dependent, because a link the archive lists later can turn an earlier one into an escape. Two passes close that. Link entries are held back until every regular entry is out, and `recheckLinks` then walks each one again with the archive fully on disk. It sweeps every link rather than stopping at the first offender, and the caller runs it even when an entry ended the run, so no link is left holding an escape the sweep never looked at. Holding links back also gives Windows what it needs at creation time: `os.Symlink` there picks a directory link or a file link by what the target is when the link is made, and entry order does not promise the target has been extracted yet.

Deferring links opens one more window of its own. Link entries are written in archive order, so an earlier one can replace a directory on the path of a later one between the first pass and the write. `extractSymlink` therefore walks its parent chain again immediately before writing, which refuses a component that has become a link.

An entry whose name folds onto the destination itself is refused, or skipped where it is a directory entry. `filepath.Join` maps `.`, `./`, the empty name and `sub/../` onto the destination, and `isInside` passes them because the relative path is `.`. The destination is the caller's directory and not the archive's, so its mode must not be set from an entry and it must not be replaced by one.

### Modes

Directory entries keep the mode they carry. This branch is what taught `newZipEntry` to store `ModeDir` and `addDirToZip` to write the entry, so the archive carries the real mode; extraction was making every directory 0755, and alpamon runs as root on a normal install, so a private directory came back world-readable after a round trip. The mode lands after every entry rather than at mkdir time, because `zip -r` writes a directory entry before the entries below it and a read-only mode landing first would block them; deepest first, because a parent with no search permission blocks the chmod under it. `chmodDir` opens with `O_NOFOLLOW|O_DIRECTORY` and calls `fchmod` on the handle, so a link that took the directory's name cannot be chmod'd through.

A mode is read out of a header only when its creator says a Unix host wrote it, which is the condition `archive/zip` itself uses. For any other creator `archive/zip` derives the mode from FAT attributes, and a directory entry with no attribute bits set comes out 0666—a directory with no execute bit and so no way in. `AllowUnzip` extracts whatever archive the user uploaded, so that path is reachable.

Setuid, setgid and sticky are dropped on extraction. `newZipEntry` already strips them when writing an archive, and the comment there names this exact hazard: "`Unzip` would hand them to `os.OpenFile`". Only half of it was done. The write is the half that matters, because `writeFileAs` demotes by piping through a `tee` child process while `UnzipReader` runs in the alpamon process itself, which is root on a normal install, so an uploaded archive carrying a 04755 entry landed a root-owned setuid file in the user's directory.

### Concurrency

Every websocket command is submitted to the worker pool at `pkg/runner/client.go:380`, so two unzips into the same tree can run at once. Losing a race to another extraction is not a failure, and four places now say so: `os.Mkdir` losing the create, `createSymlink` losing the final retry to a winner that wrote the same target, `recheckLinks` finding a link another sweep already removed, and `isValidLinkTarget` finding a component swept between its `Lstat` and its `Readlink`. The last one mattered most: the sweep deletes what it refuses, so a link that was always valid could be removed for a race it had no part in.

One race is closed rather than tolerated. `extractFile` clears a link at its path and then opens it, and a second extraction can put one back in between; `createFile` opens with `O_NOFOLLOW` so the race fails the entry instead of writing one entry's content through another entry's link. Windows has no equivalent and that window stays open there, stated at the `noFollow` constant.

A mutex was rejected for all of this: the pool is in-process, but `Unzip` is exported and reachable from more than one process, so a lock would pass an in-process test while leaving the real case broken.

### Console output

Rejection messages quote the values they name, and values that cannot be quoted are refused at the gate. The entry name and the link target are arbitrary bytes out of the archive, and `pkg/executor/handlers/file/file.go:290` returns the message to the console as the command result. `%q` covers the messages this code writes, but an OS error raised past those checks embeds the raw path where `%q` cannot reach it, so an entry name or link target carrying control bytes is rejected before it can raise one.

Every OS error that does escape now names the entry it came from. `mkdirAllInside`, `extractSymlink` and `extractFile` used to hand back the raw error, which read as `remove /private/var/folders/.../out/d: directory not empty`—no archive, no entry name, and an absolute path off the host.

### Other

`UnzipReader` creates the destination directory when it is missing. Resolving it up front had quietly made it a precondition, where every entry used to call `os.MkdirAll` on its own parent. The upload path always hands over a directory that already holds the archive, but the function is exported and the next caller need not.

The link target body is read through an `io.LimitReader`, and a body longer than the limit is rejected instead of silently truncated. Without the length check the read was bounded but the result was used anyway, so an over-long target produced a link to a path the archive never named.

A link target is normalized with `filepath.ToSlash` on the way into the archive and on the way out of it, the way entry names already are. A backslash target archived on Windows arrived on Unix as a single opaque component, which came back a broken link and skipped the per-component checks on the way.

`CreateZip` gives a directory holding nothing an entry of its own. `filepath.Walk` hands over every directory it descends into and `CreateZip` returned from all of them, so a directory reached the archive only through the entries below it. An empty one had none, and every empty directory vanished from a downloaded tree. `isEmptyDir` answers the question the archive actually asks—whether anything in the directory will be archived—so a directory holding only sockets, FIFOs or device nodes keeps its entry too, rather than disappearing along with the special files the walk drops. Directories that carry archivable content still get no entry, so the archive an existing request produces is byte for byte what it was, and a directory entry does not count as content either, so an archive whose every file was skipped still fails rather than reporting a finished download.

`isEmptyDir` also stops at the first entry instead of reading and sorting the whole directory. `filepath.Walk` calls it once per directory, so it sits on the whole download path: 1888560 ns/op against 28096 ns/op on a 5000-entry directory, and about 8 percent off `CreateZip` over 40k files in 20 large directories.

## Behavior change

`UnzipReader` takes `*zip.Reader` instead of `*zip.ReadCloser`. The doc says the caller owns the reader and the function never calls `Close`, so the old signature asked for more than the work needs and shut out a caller holding an archive that was never a file. A caller holding a `*zip.ReadCloser` passes `&rc.Reader` and keeps closing it itself. Both call sites in this repo are updated; this is a breaking change for anyone outside it.

A link entry now produces a real symlink where it used to produce a regular file holding the target path. That is the fix, but it is visible to anyone who was reading those files as text.

An archive whose link target escapes the destination, or whose entry is written through a symlink or a regular file, now fails the extraction with `illegal link target in zip` or `illegal entry in zip`. Such an archive previously extracted without complaint, because the link was never created and the entry that would have gone through it was written as an ordinary file inside the destination.

A directory entry's mode is now applied. A tree downloaded and re-uploaded keeps its directory permissions instead of coming back 0755; an archive from a non-Unix creator still gets the default, since its header carries no mode anyone chose.

A link cycle is kept rather than refused. `x -> x` and mutually referring links resolve for nobody—past 64 hops the kernel has already given up, at 40 on Linux and 32 on darwin—so they cannot carry anything outside, and `CreateZip` archives them off a real disk. Anyone who follows one gets `ELOOP`, exactly as they would from a cycle the host made itself. The component bound still rejects, so an archive built to spin the walk is unaffected.

An extraction into a directory that does not exist creates it again, as it did before the destination was resolved up front.

A downloaded directory tree keeps its empty directories, and its directories that hold only special files. An archive of a tree with neither in it is unchanged.

On a Windows host that will not make links at all, the link entry is dropped and the rest of the archive still extracts. Failing the download there would be the all-or-nothing shape #432 set out to remove, and writing the file with the target as its content is the bug this PR fixes. `syscall.Errno.Is` does not map `ERROR_PRIVILEGE_NOT_HELD` to `os.ErrPermission`, so the check names the Windows error codes directly, in a build-tagged file beside a `!windows` counterpart that reports every failure: Linux returns `EPERM` for a filesystem without link support and for a plain permission denial alike, so there is nothing to key off there.

## Testing

`go test ./... -p 1 -count=1` on the pushed head exits 0 with 46 packages `ok` and no failures. `go test -race -count=1 ./pkg/utils/ ./pkg/executor/handlers/file/` prints `ok ... pkg/utils 3.092s` and `ok ... pkg/executor/handlers/file 2.025s`, and `go test ./pkg/utils/ -race -count=20` over the link and concurrency tests is clean. `gofmt -l pkg/` is empty, `go vet ./...` is clean on darwin, `GOOS=windows go vet ./pkg/utils/ ./pkg/executor/handlers/file/` and `GOOS=linux go build ./...` both pass, and `golangci-lint run ./pkg/utils/` reports `0 issues.`

Every new test was seen failing first, against the unfixed code or a deliberate mutation of the fixed code. The escapes were reproduced before they were closed:

| Reproduction | Before |
|---|---|
| `a -> "."` then `a/c -> "../secret"` | `Unzip` returned nil and left `out/c` resolving outside the destination |
| `escape1`, `escape2`, `subdir/parent -> ".."` | `escape2` survived, resolving to the destination's parent |
| `escape`, `subdir/parent -> ".."`, `bad -> /etc` | `bad` ended the run before the sweep; `escape` survived |
| directory entry named `./` with mode 0777 | destination went from 0750 to 0777, extraction reported success |
| link entry named `.` | the destination directory was replaced by a link |
| `x -> "x"` | `illegal link target in zip: "x" -> "x"`, and the link deleted |
| `sub/` from a FAT-creator header | extracted `drw-rw-rw-`, nothing could be written under it |
| `d` (file) then `d/child.txt` | `open .../out/d/child.txt: not a directory` |
| `src/sub/` holding only a FIFO | 0 zip entries and 0 skips: the directory vanished |
| target of 71 components with no link in it | `illegal link target in zip` on a target that was never malformed |

Containment and restoration have tests on both sides, so a guard cannot be tightened into refusing what it should allow: `TestUnzip_LinkTargetMayGoThroughALinkInsideRoot` restores an `indirect -> alias/file.txt` chain that stays inside, `TestUnzip_DeepLinkTargetWithoutLinksIsAccepted` accepts a target past the hop bound with no link in it, and `TestUnzip_LinkCycleIsKeptButUnresolvable` requires `ELOOP` from the path through a kept cycle rather than an extraction failure. The two escaping-link tables run both entry orderings, since nothing constrains the order entries appear in.

`TestUnzip_ConcurrentExtractionsIntoOneDestination` runs eight extractions of one archive into one directory at once and requires every one to succeed. `TestRecheckLinks_OffenderLeftOnDiskOutranksTheOnesRemoved` drives the sweep directly, because no archive can leave a link's parent read-only before it runs. The two remaining races—`createSymlink`'s final retry and the `Lstat`/`Readlink` window in `isValidLinkTarget`—have no test, because neither can be reproduced deterministically from the outside.

The work was also exercised outside the test binary, against archives written by the real `zip --symlinks` CLI rather than by `CreateZip`, with a build of the merge base alongside for comparison. Fifteen attack archives were contained: neither build wrote anything outside the destination, and the file planted outside as bait was never touched. The concurrency failure was confirmed as one this branch introduced, since the merge-base build reported no error over three rounds of twelve; after the fix, five rounds of twelve all succeeded with the extracted tree identical to the source.

The CodeQL alerts on this branch were read rather than assumed. `go/unsafe-unzip-symlink`, alert 169, was the real one, and CodeQL reports it as fixed: the walk uses `os.Lstat` and `os.Readlink` rather than the `filepath.EvalSymlinks` its help suggests, which is not usable here because `filepath.Join` has already folded the `..` away by the time it would run and a link target need not exist, but the query accepts it.

The CodeQL check on this head is red, with 12 alerts numbered 207 to 218: one `go/zipslip` and eleven `go/path-injection`. Nine of them are sinks already reviewed and dismissed as false positives on this PR, renumbered because this round moved the code, which is the same renumbering that turned alert 165 into 168. The `go/zipslip` one is that same alert again, on the entry loop, and it is also open against `main`.

Three are sinks this round added: `os.Lstat(dir.path)` in `applyDirModes`, and the `os.OpenFile` in `createFile` and in `chmodDir`. The taint is real, since every path in the extraction comes out of the archive, but each call sits behind `isInside`, `mkdirAllInside`, or the link-target walk, and the query does not read a `filepath.Rel` comparison inside a helper as a barrier. The two `OpenFile` sinks open with `O_NOFOLLOW`, so they refuse the final component the query is worried about. None of the twelve is dismissed yet; they are left for review rather than cleared ahead of it.

The Windows path is still unverified. `GOOS=windows go build ./pkg/utils/` and `GOOS=windows go vet` pass, and the windows CI job runs `go test ./... -p 1`, so the platform-independent tests do run there; what remains unverified is behavior no test can reach from CI—whether the entry is actually dropped on a host without `SeCreateSymbolicLink`, and the `createFile` window that `noFollow` cannot close on Windows. Both will need a host with those properties.

Closes #434
