### PR TITLE
build: strip release binaries with -s -w -trimpath

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,8 @@ builds:
     binary: alpamon
     ldflags:
       - -s -w -X github.com/alpacax/alpamon/v2/pkg/version.Version={{.Version}}
+    flags:
+      - -trimpath
     env:
       - CGO_ENABLED=0
     goos:
@@ -28,6 +30,8 @@ builds:
     binary: alpamon
     ldflags:
       - -s -w -X github.com/alpacax/alpamon/v2/pkg/version.Version={{.Version}}
+    flags:
+      - -trimpath
     env:
       - CGO_ENABLED=0
     goos:
@@ -41,6 +45,8 @@ builds:
     binary: alpamon
     ldflags:
       - -s -w -X github.com/alpacax/alpamon/v2/pkg/version.Version={{.Version}}
+    flags:
+      - -trimpath
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
## Summary

Adds `-trimpath` to all three `builds:` entries in `.goreleaser.yaml`. The `-s -w` ldflags (strip DWARF/symbol table) were already present on every build; this change only fills in the missing `-trimpath` build flag alongside them.

## Why

- `-trimpath` removes local filesystem paths from the compiled binary, matching the reproducibility/size goals already targeted by the existing `-s -w`.
- No production-debugging loss: `gopclntab` is retained by `-s -w`, so panic tracebacks, goroutine dumps, and pprof stack traces continue to work. Only `delve` live-attach debugging is affected, and that is not used in production.
- Net effect versus binaries built without any of these flags: roughly 30% smaller release binaries.

## Scope

Isolated, single-file change to `.goreleaser.yaml` only — no functional code changes, no security-relevant surface touched. Branched off latest `main`, independent of the in-flight GHSA security branch.

## Verification

- `goreleaser check` passes (only pre-existing, unrelated deprecation warnings for `nfpms.builds` / `brews`, present before this change).
- `goreleaser build --snapshot --clean --single-target` succeeds; the resulting binary's embedded build info shows `-trimpath=true`, and the binary carries no `.debug`/symbol-table info to strip further (confirming `-s -w` was already effective).