### PR TITLE
fix: repair the upgrade version comparison and the package lifecycle scripts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,7 +141,17 @@ nfpms:
         dependencies:
           - zip
           - sqlite
-          - nftables | iptables
+          # rpm has no `|` alternation. nfpm parses `nftables | iptables` with
+          # the same regex it uses for `name >= version`, so the requirement
+          # became a hard `Requires: nftables` with `| iptables` stranded in the
+          # (unused) version field: the alternative was dropped and hosts that
+          # firewall with iptables were made to pull nftables in. rpm spells the
+          # alternation as a boolean dependency, which needs rpm 4.13 or newer:
+          # RHEL/Rocky/Alma/Oracle 8+, Fedora, Amazon Linux 2023 and SLES/Leap
+          # 15+. The rpm 4.11 platforms (Amazon Linux 2, CentOS 7) cannot read
+          # it, but they ship no nftables package either, so the requirement did
+          # not resolve there before this change.
+          - (nftables or iptables)
         file_name_template: '{{ .PackageName }}-{{ trimprefix .Version "v" }}-1.{{ .Os }}.{{ .Arch }}'
         recommends:
           - alpamon-pam

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,17 +141,7 @@ nfpms:
         dependencies:
           - zip
           - sqlite
-          # rpm has no `|` alternation. nfpm parses `nftables | iptables` with
-          # the same regex it uses for `name >= version`, so the requirement
-          # became a hard `Requires: nftables` with `| iptables` stranded in the
-          # (unused) version field: the alternative was dropped and hosts that
-          # firewall with iptables were made to pull nftables in. rpm spells the
-          # alternation as a boolean dependency, which needs rpm 4.13 or newer:
-          # RHEL/Rocky/Alma/Oracle 8+, Fedora, Amazon Linux 2023 and SLES/Leap
-          # 15+. The rpm 4.11 platforms (Amazon Linux 2, CentOS 7) cannot read
-          # it, but they ship no nftables package either, so the requirement did
-          # not resolve there before this change.
-          - (nftables or iptables)
+          - nftables | iptables
         file_name_template: '{{ .PackageName }}-{{ trimprefix .Version "v" }}-1.{{ .Os }}.{{ .Arch }}'
         recommends:
           - alpamon-pam

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -176,17 +176,28 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 		log.Warn().Msg("Failed to retrieve the latest Alpamon version from GitHub; proceeding with package manager upgrade.")
 	}
 
-	needAlpamon := latestVersion == "" || version.Version != latestVersion
+	// goreleaser injects version.Version from {{.Version}}, which is the tag with
+	// its leading "v" stripped ("2.5.0"), while GetLatestVersion returns the tag
+	// verbatim ("v2.5.0"). Comparing them as-is never matched, so every released
+	// build considered itself outdated: on darwin and windows that drove a
+	// self-update which re-downloaded, re-verified and replaced an identical
+	// binary, then restarted the agent, on every upgrade command.
+	// latestVersion itself stays untouched: updater.SelfUpdate requires the
+	// "v"-prefixed form.
+	needAlpamon := latestVersion == "" || !sameVersion(version.Version, latestVersion)
 
+	// alpamon-pam is versioned independently of alpamon, so alpamon's latest
+	// release tag says nothing about whether the installed pam package is
+	// current (alpamon v2.5.0 against alpamon-pam 1.1.5). The package manager is
+	// the only authority here, so alpamon-pam joins the transaction whenever it
+	// is installed and apt/yum/zypper decides whether anything moves.
 	currentPamVersion := h.versionResolver.GetPamVersion()
-	needPam := currentPamVersion != "" && (latestVersion == "" || currentPamVersion != latestVersion)
+	needPam := currentPamVersion != ""
 
+	// Reached only when alpamon-pam is absent, since an installed one always
+	// goes to the package manager.
 	if !needAlpamon && !needPam {
-		pamDisplay := currentPamVersion
-		if pamDisplay == "" {
-			pamDisplay = "not installed"
-		}
-		return 0, fmt.Sprintf("Already up-to-date (alpamon: %s, pam: %s)", version.Version, pamDisplay), nil
+		return 0, fmt.Sprintf("Already up-to-date (alpamon: %s, pam: not installed)", version.Version), nil
 	}
 
 	var packages []string
@@ -278,6 +289,14 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 		h.versionResolver.InvalidatePamCache()
 	}
 	return exitCode, output, err
+}
+
+// sameVersion reports whether two version strings name the same release,
+// ignoring a leading "v" on either side. The two sources disagree on the
+// prefix: the build-time injected version has it stripped, a GitHub release
+// tag keeps it.
+func sameVersion(a, b string) bool {
+	return strings.TrimPrefix(a, "v") == strings.TrimPrefix(b, "v")
 }
 
 // sanitizePackageProxy validates the payload-provided proxy URL once at

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -1412,3 +1412,88 @@ func TestSystemHandler_Upgrade_ZypperRefreshFailureCarriesTheHint(t *testing.T) 
 	require.Equal(t, 6, exitCode)
 	assert.Contains(t, output, "SUSEConnect --status")
 }
+
+// setVersion pins the build-time injected agent version for one test.
+func setVersion(t *testing.T, v string) {
+	t.Helper()
+	original := version.Version
+	version.Version = v
+	t.Cleanup(func() { version.Version = original })
+}
+
+// TestSystemHandler_Upgrade_TagPrefixIsNotAnUpgrade pins the normalization of
+// the two version sources. goreleaser injects version.Version without the
+// leading "v" while the GitHub release tag keeps it, so a released agent that
+// is already current must still recognize itself as up-to-date. Without the
+// normalization every released build looks outdated, and on darwin/windows
+// that re-downloads and reinstalls an identical binary and restarts the agent.
+func TestSystemHandler_Upgrade_TagPrefixIsNotAnUpgrade(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	setVersion(t, "2.5.0") // as injected by goreleaser's {{.Version}}
+
+	mockVersions := &MockVersionResolver{
+		LatestVersion: "v2.5.0", // as returned by the GitHub releases API
+		PamVersion:    "",
+	}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+
+	var selfUpdateCalled bool
+	handler.selfUpdateFn = func(_ context.Context, _ string, _ updater.Options) error {
+		selfUpdateCalled = true
+		return nil
+	}
+
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("darwin")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+	setPackageManagerAndID(t, utils.PkgBrew, "")
+
+	exitCode, output, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, output, "up-to-date")
+	assert.False(t, selfUpdateCalled, "an already-current agent must not reinstall itself")
+	assert.False(t, mockWS.RestartCalled, "an already-current agent must not restart")
+}
+
+// TestSystemHandler_Upgrade_PamIsNotComparedToAlpamonRelease pins that the
+// installed alpamon-pam version is never compared against alpamon's own release
+// tag: the two are independent version streams. alpamon-pam is handed to the
+// package manager whenever it is installed, and alpamon joins the transaction
+// only when it is genuinely behind.
+func TestSystemHandler_Upgrade_PamIsNotComparedToAlpamonRelease(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	setVersion(t, "2.5.0")
+
+	mockVersions := &MockVersionResolver{LatestVersion: "v2.5.0", PamVersion: "1.1.5"}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("debian")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+	setPackageManagerAndID(t, utils.PkgApt, "")
+
+	exitCode, _, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	shell := findExecutedShell(mockExec)
+	require.NotNil(t, shell, "an installed alpamon-pam must reach the package manager")
+	require.Len(t, shell.Args, 2)
+	assert.Contains(t, shell.Args[1], "--only-upgrade alpamon-pam -y",
+		"only alpamon-pam is behind; alpamon itself is already current")
+	assert.True(t, mockVersions.InvalidatePamCalled, "the cached pam version must be refreshed after the upgrade")
+}

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -32,8 +32,11 @@ main() {
         create_directories
         start_alpamon_process
       fi
+      # setup has consumed the template, so it has served its purpose. A generic
+      # installation skips setup and keeps it: the operator completes
+      # registration afterwards, and `alpamon setup` still needs it then.
+      cleanup_tmpl_files
     fi
-    cleanup_tmpl_files
   fi
 }
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -9,13 +9,19 @@ main() {
   check_systemd_status
   check_alpamon_binary
 
+  cleanup_old_binary
+
   if is_upgrade "$@"; then
-    cleanup_old_binary
     if [ "$SYSTEMD_AVAILABLE" = "true" ]; then
       restart_alpamon_by_timer
     else
       restart_alpamon_process
     fi
+    # No cleanup_tmpl_files here on purpose. The package re-ships the template
+    # on every upgrade and only `alpamon setup` ever consumes it, so deleting it
+    # on an upgrade throws away a newly added config key before anything can
+    # read it. Leaving it in place keeps the new release's template on disk to
+    # diff against the live config.
   else
     # setup_alpamon returns 1 if ENV not set (generic installation)
     # In that case, skip start_systemd_service - user will run 'alpamon register'
@@ -27,9 +33,8 @@ main() {
         start_alpamon_process
       fi
     fi
+    cleanup_tmpl_files
   fi
-
-  cleanup_tmpl_files
 }
 
 check_root_permission() {
@@ -158,9 +163,14 @@ restart_alpamon_by_timer() {
   echo "Systemd timer to restart Alpamon has been set. It will restart the service in 5 minutes."
 }
 
-# TODO: remove after v2.1.x rollout completes
+# Remove the binary left at the install location used before v2.1.1, when the
+# packaged binary moved to /usr/bin. /usr/local/bin comes before /usr/bin in the
+# default PATH, so a leftover copy there shadows the packaged one and an operator
+# keeps running the old agent from the shell. This runs on every install, not
+# only on upgrades: gating it on the upgrade path left the stale copy in place
+# forever after a remove-then-reinstall.
 cleanup_old_binary() {
-  if [ -f "/usr/local/bin/alpamon" ] && [ -f "/usr/bin/alpamon" ]; then
+  if [ -f "/usr/local/bin/alpamon" ] && [ -f "$ALPAMON_BIN" ]; then
     rm -f /usr/local/bin/alpamon
   fi
 }
@@ -172,22 +182,22 @@ cleanup_tmpl_files() {
   fi
 }
 
-# debian
-# Initial installation: $1 == configure
-# Upgrade: $1 == configure, $2 == old version
-
-# rhel
-# Initial installation: $1 == 1
-# Upgrade: $1 == 2, and configured to restart on upgrade
+# The two packagers disagree on how they say "upgrade":
+#   dpkg: "$1" is an action verb -- 'configure', or an 'abort-*' verb when a
+#         failed upgrade is being rolled back -- and "$2" holds the previously
+#         configured version, which is empty only on a fresh install. Keying
+#         on "$2" rather than on 'configure' keeps the rollback verbs working.
+#   rpm:  "$1" is the number of installed instances after the transaction,
+#         1 on a fresh install and 2 or more on an upgrade. A multi-package
+#         transaction can leave more than 2, so this is a >= test, not == 2.
+#         rpm never passes a second argument, so the dpkg test cannot fire there.
 is_upgrade() {
-    # RHEL
-    if [ "$1" -eq 2 ] 2>/dev/null; then
-      return 0  # Upgrade
+    if [ -n "$2" ]; then
+      return 0  # Upgrade (dpkg)
     fi
 
-    # Debian
-    if [ "$1" = "configure" ] && [ -n "$2" ]; then
-      return 0  # Upgrade
+    if [ "$1" -ge 2 ] 2>/dev/null; then
+      return 0  # Upgrade (rpm)
     fi
 
     return 1 # Initial installation

--- a/scripts/postremove.sh
+++ b/scripts/postremove.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# Only effective on Debian-based systems where "purge" is supported.
-# No effect on RHEL-based systems.
-
 FILES_TO_REMOVE="
   /etc/alpamon/alpamon.conf
   /usr/lib/tmpfiles.d/alpamon.conf
@@ -13,7 +10,16 @@ FILES_TO_REMOVE="
   /var/lib/alpamon/alpamon.db
 "
 
-if [ "$1" = 'purge' ]; then
+# Final removal, spelled differently by each packager:
+#   dpkg: "$1" is 'purge'. Plain 'remove' and 'upgrade' keep the config.
+#   rpm:  "$1" is the number of instances left, 0 on the final erase and 1 or
+#         more on an upgrade. An upgrade must not touch the config, unit,
+#         tmpfiles or database.
+# Testing for 'purge' alone left every RHEL/SUSE host holding on to
+# /etc/alpamon/alpamon.conf -- the agent's API credential -- plus the local
+# database and logs after the package was erased, so a later reinstall silently
+# re-adopted the credential of a server that had already been removed.
+if [ "$1" = 'purge' ] || [ "$1" -eq 0 ] 2>/dev/null; then
     for file in $FILES_TO_REMOVE; do
         rm -f "$file" || true
     done


### PR DESCRIPTION
## Summary

Five defects in the agent's own upgrade and package lifecycle, found by auditing the release path end to end. Each one is silent: nothing logs an error, and the observable behavior is either "an upgrade that always runs" or "a file that quietly outlives its package".

## 1. The upgrade version comparison never matched (`pkg/executor/handlers/system/system.go`)

`version.Version` is injected by goreleaser from `{{.Version}}`, which is the tag with its leading `v` stripped (`2.5.0`). `GetLatestVersion` returns `release.TagName` verbatim (`v2.5.0`). The handler compared the two as-is:

```go
needAlpamon := latestVersion == "" || version.Version != latestVersion
```

So `needAlpamon` was **permanently true on every released build** and the `Already up-to-date` branch was unreachable.

**Customer-visible consequence.** On linux this only wasted a package-manager run; the package manager still decided correctly. On **darwin and windows** the same flag drives `SelfUpdate`, so an agent that was already on the latest release downloaded its own archive again, verified the checksum, replaced a byte-identical binary and **restarted itself** — once per host, on every fleet-wide upgrade. Every websh session, tunnel and FTP transfer open on that host at the time drops.

`latestVersion` is normalized for the comparison only; it still reaches `updater.SelfUpdate` in the `v`-prefixed form that `updater.versionRe` requires.

### `needPam` compared two unrelated version streams

```go
needPam := currentPamVersion != "" && (latestVersion == "" || currentPamVersion != latestVersion)
```

`currentPamVersion` is **alpamon-pam's** installed version (`1.1.5`, from `dpkg-query`/`rpm -q`), compared against **alpamon's** latest release tag (`v2.5.0`). The two are independent version streams, so that test was also always true and never carried information.

Fixed by not deciding locally: alpamon-pam joins the package-manager transaction whenever it is installed, and apt/yum/zypper decides whether anything moves. That is the only authority on disk that can answer the question. The larger alternative — resolving alpamon-pam's own latest release from GitHub — needs a second release lookup and a new `VersionResolver` method; the smaller change here is correct today and does not add a network dependency.

One behavior change worth naming: on a linux host **with alpamon-pam installed**, `upgrade` now always runs the package manager instead of ever returning `Already up-to-date`. That matches what the code already did in practice (`needAlpamon` was always true), and the package-manager output is the honest answer.

Covered by two tests that fail on `main`:

```
--- FAIL: TestSystemHandler_Upgrade_TagPrefixIsNotAnUpgrade
    "Updated to v2.5.0. Restarting..." does not contain "up-to-date"
--- FAIL: TestSystemHandler_Upgrade_PamIsNotComparedToAlpamonRelease
    "... --only-upgrade alpamon alpamon-pam -y ..." does not contain "--only-upgrade alpamon-pam -y"
```

## 2. `postremove.sh` left the agent's credential on RHEL and SUSE

The cleanup was gated on `[ "$1" = 'purge' ]`, which only dpkg ever passes — the script's own comment admitted "No effect on RHEL-based systems". rpm signals the final erase with an instance count of `0`.

**Customer-visible consequence.** Erasing the package on RHEL, Rocky, Alma, Amazon Linux or SUSE left `/etc/alpamon/alpamon.conf` — **the agent's API credential** — plus `/var/lib/alpamon/alpamon.db` and the logs on disk. Reinstalling on the same host silently re-adopted a credential belonging to a server record that had already been deleted from the console.

Now `[ "$1" = 'purge' ] || [ "$1" -eq 0 ] 2>/dev/null`, the idiom `scripts/preremove.sh` and all six `alpamon-*-plugin` repos already use.

## 3. `is_upgrade()` misread both packagers

`[ "$1" -eq 2 ]` accepted exactly 2, but rpm passes the number of instances left after the transaction and a multi-package transaction can leave more. The dpkg arm keyed on the `configure` verb, which misses the `abort-*` verbs dpkg passes when it rolls a failed upgrade back — in that case the script took the fresh-install path and ran `alpamon setup`, rewriting the config during a rollback.

Both arms now match the plugin repos: key on the previous-version argument for dpkg, `-ge 2` for rpm.

## 4. The config template was deleted on upgrade before anything could read it

`main()` called `<binary> setup` on fresh installs only, but `cleanup_tmpl_files` **unconditionally** — while nfpm re-ships `/etc/alpamon/alpamon.config.tmpl` on every upgrade.

**Customer-visible consequence.** A config key added in a release never reached an upgraded host, and `alpamon setup` on that host afterwards failed with `failed to read template config`.

The removal now happens on the fresh-install path only, where `setup` has just consumed the template. On upgrades the newly shipped template stays on disk, which also leaves the new release's defaults available to diff against the live config. This matches the plugin repos, which carry the same comment.

A `setup --migrate` that merges new keys into an existing config is the larger fix and is deliberately not attempted here — it needs a merge policy for operator-edited values.

## 5. Stale TODO and a cleanup that could never fire twice

`cleanup_old_binary()` carried `# TODO: remove after v2.1.x rollout completes` and alpamon is on 2.5.x. Kept rather than deleted, and promoted to run on every install: it previously ran on the upgrade path only, so a remove-then-reinstall left `/usr/local/bin/alpamon` behind for good. `/usr/local/bin` precedes `/usr/bin` in the default PATH, so that stale copy is what an operator's shell resolves — the agent an operator runs by hand can be several releases behind the one systemd runs. The TODO is replaced with the reason the function still exists.

## 6. The rpm firewall dependency was malformed (`.goreleaser.yaml`)

rpm has no `|` alternation. nfpm hands each dependency string to `rpmpack.NewRelation`, which parses anything not wrapped in parentheses with the regex it uses for `name >= version`. Measured directly against `rpmpack v0.7.1`:

```
"nftables | iptables"    -> name="nftables" version="| iptables" sense=0
"(nftables or iptables)" -> name="(nftables or iptables)" version="" sense=0
"sqlite >= 3"            -> name="sqlite"   version="3"          sense=12
```

`sense=0` means no version comparison, so the emitted requirement was a hard `Requires: nftables` with `| iptables` stranded in an ignored version field. The alternative was silently dropped and an iptables host was made to pull nftables in.

`(nftables or iptables)` is passed through as a boolean dependency, which is what rpm reads as "either". **Caveat, stated plainly:** boolean dependencies need rpm 4.13+, which covers RHEL/Rocky/Alma/Oracle 8+, Fedora, Amazon Linux 2023 and SLES/Leap 15+. The two rpm 4.11 platforms in scope, Amazon Linux 2 and the legacy CentOS 7 image, cannot read it — but neither ships an nftables package, so the previous requirement did not resolve there either. This is not verifiable in CI (no rpm install smoke test exists); it was verified against the rpmpack parser the release actually uses.

## Verification

```
go build ./...    exit 0
go vet ./...      exit 0
go test ./... -p 1  exit 0   (full suite)
golangci-lint run ./pkg/executor/handlers/system/...   0 issues
gofmt -l pkg cmd internal   (empty)
sh -n / bash -n on scripts/postinstall.sh, scripts/postremove.sh   clean
```

Both new tests were run against `main`'s `system.go` and fail there.

Behavioral checks of the shell changes, run out of tree:

```
is_upgrade:  [1]->fresh  [2]->upgrade  [3]->upgrade  [0]->fresh
             [configure]->fresh  [configure 2.4.0]->upgrade  [abort-upgrade 2.4.0]->upgrade

postremove:  purge->removed  0->removed  remove->kept  upgrade->kept  1->kept  2->kept
             (no stderr noise from the numeric test on the string arguments)
```

## Not changed

- Anything under `pkg/executor/handlers/file/` or `pkg/utils/fs*`.
- The rpm install path is still not smoke-tested in CI; the `Dockerfiles/` images build from source rather than installing the package, so no packaging defect in this PR could have been caught there.
