### PR TITLE
fix: remove the extract source on Windows and stop a test from naming one platform's error

### DIFF
--- a/pkg/utils/archive_worker_test.go
+++ b/pkg/utils/archive_worker_test.go
@@ -40,7 +40,13 @@ func TestRunArchiveWorker_WritesZipAndReportsSkipped(t *testing.T) {
 	// reason has to survive the process boundary as text.
 	require.Len(t, resp.Skipped, 1)
 	assert.Equal(t, missing, resp.Skipped[0].Path)
-	assert.Contains(t, resp.Skipped[0].Reason, "no such file")
+	// The wording is the host's own, so ask the host for it rather than
+	// hard-coding one platform's: Unix says "no such file or directory" and
+	// Windows says "The system cannot find the file specified."
+	_, openErr := os.Open(missing)
+	var pathErr *os.PathError
+	require.ErrorAs(t, openErr, &pathErr)
+	assert.Contains(t, resp.Skipped[0].Reason, pathErr.Err.Error())
 
 	r, err := zip.OpenReader(dest)
 	require.NoError(t, err)

--- a/pkg/utils/extract_worker.go
+++ b/pkg/utils/extract_worker.go
@@ -30,9 +30,14 @@ func RunExtractWorker(srcPath, destDir string, status io.Writer) int {
 	if src == nil {
 		return 0
 	}
-	defer func() { _ = src.Close() }()
 
-	if err := UnzipFile(src, destDir); err != nil {
+	err := UnzipFile(src, destDir)
+	// Closed here rather than on a defer, because the unlink below has to come
+	// after it. Go opens without FILE_SHARE_DELETE, so on Windows a remove runs
+	// into a sharing violation while the handle is still open, and the error is
+	// discarded, which would leave the source behind on every extraction.
+	_ = src.Close()
+	if err != nil {
 		_, _ = fmt.Fprintln(status, err.Error())
 		return 1
 	}


### PR DESCRIPTION
Fixes the two failures on the `windows-amd64` job, red on `main` since 585e5e1. One is a real Windows bug, the other is a test that named one platform's wording.

## An extraction left its source archive behind on Windows

`RunExtractWorker` closed the source on a defer, so `os.Remove` ran while the handle was still open:

```go
defer func() { _ = src.Close() }()   // runs last
...
_ = os.Remove(srcPath)               // runs while the handle is open
```

Go's `syscall.Open` on Windows uses `FILE_SHARE_READ | FILE_SHARE_WRITE` and no `FILE_SHARE_DELETE`, so `DeleteFile` comes back with a sharing violation. The result is discarded on purpose, because a failed unlink must not fail a download that already succeeded, so the removal failed silently. Every `allow_unzip` extraction on Windows left the archive sitting next to the files it had just unpacked.

Unix never showed it. An open file can be unlinked there and the entry goes when the last handle closes.

The close now comes before the unlink, which is the order the in-process code used before the worker took the cleanup over.

`TestRunExtractWorker_RemovesTheSourceAfterExtracting` is the guard, and it is the test that was failing.

## A test named the Unix wording for a missing file

The archive worker reports why a path was skipped as text, since an error value does not survive the process boundary. The test pinned that text to `no such file`, so on Windows it read:

```
"The system cannot find the file specified." does not contain "no such file"
```

The worker had done the right thing. The expected wording now comes from the host: opening the same missing path yields the same `*os.PathError` the worker unwrapped, so the two agree everywhere without the test naming either platform.

## Verification

Windows behavior cannot be run locally, so the `windows-amd64` job on this PR is the check that matters.

| Check | Result |
| --- | --- |
| `go test ./... -p 1` (darwin/arm64) | 46 packages ok, 0 failed |
| `go build` for linux, darwin, windows | ok |
| `go vet ./...` | clean |
| `gofmt -l pkg/ cmd/` | clean |
| `golangci-lint run ./...` (`GOOS=windows`) | 13 issues, line for line identical to `main`; none added here |

## Note on the release

`v2.5.1` points at 585e5e1 and is already published, so the released Windows build carries the cleanup behavior above. A patch release picking this up would be worth doing.
