### PR TITLE
fix: close the websocket even when the close handshake fails

### DIFF
--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -244,8 +245,8 @@ func (wc *WebsocketClient) Close() {
 		drainCloseReply(conn)
 	}
 
-	err = conn.Close() // a broken connection must not leak its fd across reconnects
-	if err != nil {
+	// Close unconditionally so a broken connection cannot leak its fd; net.ErrClosed only means the reconnect path already closed it.
+	if err = conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 		log.Debug().Err(err).Msg("Failed to close websocket connection.")
 	}
 }

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -223,15 +223,17 @@ func (wc *WebsocketClient) CloseAndReconnect(ctx context.Context) {
 	wc.Connect()
 }
 
-// Cleanly close the websocket connection by sending a close message
+// Cleanly close the websocket connection by sending a close message, waiting for
+// the peer's reply when that frame went out, and closing the connection either way.
 // Do not close quitChan, as the purpose here is to disconnect the WebSocket,
 // not to terminate RunForever.
 func (wc *WebsocketClient) Close() {
-	if wc.Conn == nil {
+	conn := wc.Conn // Connect() may swap wc.Conn from the RunForever goroutine mid-close; every step below must act on the one connection we started with.
+	if conn == nil {
 		return
 	}
 
-	err := wc.Conn.WriteControl(
+	err := conn.WriteControl(
 		websocket.CloseMessage,
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 		time.Now().Add(5*time.Second),
@@ -239,19 +241,19 @@ func (wc *WebsocketClient) Close() {
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to write close message to websocket.")
 	} else {
-		wc.drainCloseReply()
+		drainCloseReply(conn)
 	}
 
-	err = wc.Conn.Close() // a broken connection must not leak its fd across reconnects
+	err = conn.Close() // a broken connection must not leak its fd across reconnects
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to close websocket connection.")
 	}
 }
 
-func (wc *WebsocketClient) drainCloseReply() {
-	_ = wc.Conn.SetReadDeadline(time.Now().Add(5 * time.Second)) // the peer only answers a close frame that actually went out
+func drainCloseReply(conn *websocket.Conn) {
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second)) // the peer only answers a close frame that actually went out
 	for {
-		if _, _, err := wc.Conn.NextReader(); err != nil {
+		if _, _, err := conn.NextReader(); err != nil {
 			break
 		}
 	}

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -238,21 +238,20 @@ func (wc *WebsocketClient) Close() {
 	)
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to write close message to websocket.")
-		return
+	} else {
+		_ = wc.Conn.SetReadDeadline(time.Now().Add(5 * time.Second)) // the peer only answers a close frame that actually went out
+		for {
+			_, _, err = wc.Conn.NextReader()
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				break
+			}
+			if err != nil {
+				break
+			}
+		}
 	}
 
-	_ = wc.Conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-	for {
-		_, _, err = wc.Conn.NextReader()
-		if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-			break
-		}
-		if err != nil {
-			break
-		}
-	}
-
-	err = wc.Conn.Close()
+	err = wc.Conn.Close() // a broken connection must not leak its fd across reconnects
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to close websocket connection.")
 	}

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -239,21 +239,21 @@ func (wc *WebsocketClient) Close() {
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to write close message to websocket.")
 	} else {
-		_ = wc.Conn.SetReadDeadline(time.Now().Add(5 * time.Second)) // the peer only answers a close frame that actually went out
-		for {
-			_, _, err = wc.Conn.NextReader()
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				break
-			}
-			if err != nil {
-				break
-			}
-		}
+		wc.drainCloseReply()
 	}
 
 	err = wc.Conn.Close() // a broken connection must not leak its fd across reconnects
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to close websocket connection.")
+	}
+}
+
+func (wc *WebsocketClient) drainCloseReply() {
+	_ = wc.Conn.SetReadDeadline(time.Now().Add(5 * time.Second)) // the peer only answers a close frame that actually went out
+	for {
+		if _, _, err := wc.Conn.NextReader(); err != nil {
+			break
+		}
 	}
 }
 

--- a/pkg/runner/client_close_test.go
+++ b/pkg/runner/client_close_test.go
@@ -6,11 +6,53 @@ package runner
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
+
+// closeReplyServer answers the client's close frame; the pty test double never reads, so a drain against it would only end on the read deadline.
+type closeReplyServer struct {
+	url       string
+	closeCode atomic.Int32
+}
+
+func newCloseReplyServer(t *testing.T) *closeReplyServer {
+	t.Helper()
+	s := &closeReplyServer{}
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+
+		c.SetCloseHandler(func(code int, text string) error {
+			s.closeCode.Store(int32(code))
+			// SetCloseHandler replaces gorilla's default reply; without this the client drains until its deadline.
+			_ = c.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(code, ""), time.Now().Add(time.Second))
+			return nil
+		})
+
+		for {
+			if _, _, err := c.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	s.url = strings.Replace(ts.URL, "http", "ws", 1)
+	return s
+}
 
 func dialTracked(t *testing.T, url string) (*websocket.Conn, *trackedConn) {
 	t.Helper()
@@ -45,4 +87,30 @@ func TestWebsocketClientClose_ClosesConnAfterWriteControlFailure(t *testing.T) {
 
 	require.True(t, tracked.closed.Load(), "Close() did not close the websocket connection after WriteControl failure")
 	require.Equal(t, deadlines, tracked.readDeadlines.Load(), "Close() waited for a close reply the peer can never send, because the close frame never went out")
+}
+
+func TestWebsocketClientClose_DrainsReplyAfterSuccessfulHandshake(t *testing.T) {
+	s := newCloseReplyServer(t)
+	conn, tracked := dialTracked(t, s.url)
+
+	wc := &WebsocketClient{Conn: conn}
+
+	deadlines := tracked.readDeadlines.Load()
+	wc.Close()
+
+	require.Equal(t, int32(websocket.CloseNormalClosure), s.closeCode.Load(), "the peer did not receive a normal-closure close frame")
+	require.Greater(t, tracked.readDeadlines.Load(), deadlines, "Close() skipped the drain even though the close frame went out")
+	require.True(t, tracked.closed.Load(), "Close() did not close the websocket connection after a successful handshake")
+}
+
+func TestWebsocketClientClose_IsSafeToCallTwice(t *testing.T) {
+	// Close() deliberately leaves wc.Conn in place: the reconnect handler closes it, then RunForever's next read failure sends CloseAndReconnect at the same conn.
+	s := newCloseReplyServer(t)
+	conn, tracked := dialTracked(t, s.url)
+
+	wc := &WebsocketClient{Conn: conn}
+
+	wc.Close()
+	require.True(t, tracked.closed.Load(), "the first Close() did not close the websocket connection")
+	require.NotPanics(t, wc.Close, "the second Close() on an already closed connection panicked")
 }

--- a/pkg/runner/client_close_test.go
+++ b/pkg/runner/client_close_test.go
@@ -90,3 +90,19 @@ func TestWebsocketClientClose_IsSafeToCallTwice(t *testing.T) {
 	require.True(t, tracked.closed.Load(), "the first Close() did not close the websocket connection")
 	require.NotPanics(t, wc.Close, "the second Close() on an already closed connection panicked")
 }
+
+func TestWebsocketClientClose_ClosesTheConnItStartedWith(t *testing.T) {
+	// Connect() writes wc.Conn from the RunForever goroutine while Close() runs on another; the field swap is played out here from inside the close-frame write.
+	s := newCloseReplyServer(t)
+	first, firstTracked := dialTracked(t, s.url)
+	second, secondTracked := dialTracked(t, s.url)
+	t.Cleanup(func() { _ = second.Close() })
+
+	wc := &WebsocketClient{Conn: first}
+	firstTracked.onWrite = func() { wc.Conn = second }
+
+	wc.Close()
+
+	require.True(t, firstTracked.closed.Load(), "Close() left the connection it started with open")
+	require.False(t, secondTracked.closed.Load(), "Close() closed the connection Connect() had just swapped in")
+}

--- a/pkg/runner/client_close_test.go
+++ b/pkg/runner/client_close_test.go
@@ -1,11 +1,8 @@
-//go:build !windows
-
 package runner
 
 // The backhaul mirror of the pty client's close tests in pty_recovery_test.go; keep the two in step.
 
 import (
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -54,30 +51,9 @@ func newCloseReplyServer(t *testing.T) *closeReplyServer {
 	return s
 }
 
-func dialTracked(t *testing.T, url string) (*websocket.Conn, *trackedConn) {
-	t.Helper()
-
-	var tracked *trackedConn
-	dialer := websocket.Dialer{
-		NetDial: func(network, addr string) (net.Conn, error) {
-			c, err := net.Dial(network, addr)
-			if err != nil {
-				return nil, err
-			}
-			tracked = &trackedConn{Conn: c}
-			return tracked, nil
-		},
-	}
-	conn, _, err := dialer.Dial(url, nil)
-	require.NoError(t, err)
-	require.NotNil(t, tracked, "the dialer never went through NetDial, so nothing is being tracked")
-
-	return conn, tracked
-}
-
 func TestWebsocketClientClose_ClosesConnAfterWriteControlFailure(t *testing.T) {
-	s := newWshServer(t)
-	conn, tracked := dialTracked(t, s.wsURL())
+	s := newCloseReplyServer(t)
+	conn, tracked := dialTracked(t, s.url)
 
 	wc := &WebsocketClient{Conn: conn}
 

--- a/pkg/runner/client_close_test.go
+++ b/pkg/runner/client_close_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package runner
+
+// The backhaul mirror of the pty client's close tests in pty_recovery_test.go; keep the two in step.
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func dialTracked(t *testing.T, url string) (*websocket.Conn, *trackedConn) {
+	t.Helper()
+
+	var tracked *trackedConn
+	dialer := websocket.Dialer{
+		NetDial: func(network, addr string) (net.Conn, error) {
+			c, err := net.Dial(network, addr)
+			if err != nil {
+				return nil, err
+			}
+			tracked = &trackedConn{Conn: c}
+			return tracked, nil
+		},
+	}
+	conn, _, err := dialer.Dial(url, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tracked, "the dialer never went through NetDial, so nothing is being tracked")
+
+	return conn, tracked
+}
+
+func TestWebsocketClientClose_ClosesConnAfterWriteControlFailure(t *testing.T) {
+	s := newWshServer(t)
+	conn, tracked := dialTracked(t, s.wsURL())
+
+	wc := &WebsocketClient{Conn: conn}
+
+	deadlines := tracked.readDeadlines.Load()
+	tracked.failWrites.Store(true)
+	wc.Close()
+
+	require.True(t, tracked.closed.Load(), "Close() did not close the websocket connection after WriteControl failure")
+	require.Equal(t, deadlines, tracked.readDeadlines.Load(), "Close() waited for a close reply the peer can never send, because the close frame never went out")
+}

--- a/pkg/runner/conn_test.go
+++ b/pkg/runner/conn_test.go
@@ -19,6 +19,7 @@ type trackedConn struct {
 	failWrites    atomic.Bool
 	closed        atomic.Bool
 	readDeadlines atomic.Int32
+	onWrite       func() // set before the write under test, and only from the goroutine that drives it
 }
 
 func (c *trackedConn) SetReadDeadline(t time.Time) error {
@@ -27,6 +28,9 @@ func (c *trackedConn) SetReadDeadline(t time.Time) error {
 }
 
 func (c *trackedConn) Write(b []byte) (int, error) {
+	if c.onWrite != nil {
+		c.onWrite()
+	}
 	if c.failWrites.Load() {
 		return 0, errors.New("simulated write failure")
 	}

--- a/pkg/runner/conn_test.go
+++ b/pkg/runner/conn_test.go
@@ -1,0 +1,60 @@
+package runner
+
+// The websocket test conn lives here, untagged, so close tests that have no Unix-specific behavior stay in the Windows CI job.
+
+import (
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// trackedConn fails writes on demand, so a test can play out a broken connection without breaking a real one.
+type trackedConn struct {
+	net.Conn
+	failWrites    atomic.Bool
+	closed        atomic.Bool
+	readDeadlines atomic.Int32
+}
+
+func (c *trackedConn) SetReadDeadline(t time.Time) error {
+	c.readDeadlines.Add(1)
+	return c.Conn.SetReadDeadline(t)
+}
+
+func (c *trackedConn) Write(b []byte) (int, error) {
+	if c.failWrites.Load() {
+		return 0, errors.New("simulated write failure")
+	}
+	return c.Conn.Write(b)
+}
+
+func (c *trackedConn) Close() error {
+	c.closed.Store(true)
+	return c.Conn.Close()
+}
+
+func dialTracked(t *testing.T, url string) (*websocket.Conn, *trackedConn) {
+	t.Helper()
+
+	var tracked *trackedConn
+	dialer := websocket.Dialer{
+		NetDial: func(network, addr string) (net.Conn, error) {
+			c, err := net.Dial(network, addr)
+			if err != nil {
+				return nil, err
+			}
+			tracked = &trackedConn{Conn: c}
+			return tracked, nil
+		},
+	}
+	conn, _, err := dialer.Dial(url, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tracked, "the dialer never went through NetDial, so nothing is being tracked")
+
+	return conn, tracked
+}

--- a/pkg/runner/pty_recovery_test.go
+++ b/pkg/runner/pty_recovery_test.go
@@ -6,8 +6,6 @@ package runner
 
 import (
 	"context"
-	"errors"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -22,31 +20,6 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
-
-// trackedConn fails writes on demand, so a test can play out a broken connection without breaking a real one.
-type trackedConn struct {
-	net.Conn
-	failWrites    atomic.Bool
-	closed        atomic.Bool
-	readDeadlines atomic.Int32
-}
-
-func (c *trackedConn) SetReadDeadline(t time.Time) error {
-	c.readDeadlines.Add(1)
-	return c.Conn.SetReadDeadline(t)
-}
-
-func (c *trackedConn) Write(b []byte) (int, error) {
-	if c.failWrites.Load() {
-		return 0, errors.New("simulated write failure")
-	}
-	return c.Conn.Write(b)
-}
-
-func (c *trackedConn) Close() error {
-	c.closed.Store(true)
-	return c.Conn.Close()
-}
 
 // wshServer is a local Websh test double: a WebSocket endpoint plus the pty-channels recovery API, with server-side handles to kill connections.
 type wshServer struct {

--- a/pkg/runner/pty_recovery_test.go
+++ b/pkg/runner/pty_recovery_test.go
@@ -22,6 +22,25 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// trackedConn fails writes on demand, so a test can play out a broken connection without breaking a real one.
+type trackedConn struct {
+	net.Conn
+	failWrites atomic.Bool
+	closed     atomic.Bool
+}
+
+func (c *trackedConn) Write(b []byte) (int, error) {
+	if c.failWrites.Load() {
+		return 0, errors.New("simulated write failure")
+	}
+	return c.Conn.Write(b)
+}
+
+func (c *trackedConn) Close() error {
+	c.closed.Store(true)
+	return c.Conn.Close()
+}
+
 // wshServer is a local Websh test double: a WebSocket endpoint plus the pty-channels recovery API, with server-side handles to kill connections.
 type wshServer struct {
 	ts            *httptest.Server
@@ -221,24 +240,6 @@ func TestPtyRecovery_StormNoGoroutineLeak(t *testing.T) {
 		n := runtime.Stack(buf, true)
 		t.Fatalf("recovery goroutines did not exit after reconnect storm:\n%s", buf[:n])
 	}
-}
-
-type trackedConn struct {
-	net.Conn
-	failWrites atomic.Bool
-	closed     atomic.Bool
-}
-
-func (c *trackedConn) Write(b []byte) (int, error) {
-	if c.failWrites.Load() {
-		return 0, errors.New("simulated write failure")
-	}
-	return c.Conn.Write(b)
-}
-
-func (c *trackedConn) Close() error {
-	c.closed.Store(true)
-	return c.Conn.Close()
 }
 
 func TestPtyClose_ClosesConnAfterWriteControlFailure(t *testing.T) {

--- a/pkg/runner/pty_recovery_test.go
+++ b/pkg/runner/pty_recovery_test.go
@@ -25,8 +25,14 @@ import (
 // trackedConn fails writes on demand, so a test can play out a broken connection without breaking a real one.
 type trackedConn struct {
 	net.Conn
-	failWrites atomic.Bool
-	closed     atomic.Bool
+	failWrites    atomic.Bool
+	closed        atomic.Bool
+	readDeadlines atomic.Int32
+}
+
+func (c *trackedConn) SetReadDeadline(t time.Time) error {
+	c.readDeadlines.Add(1)
+	return c.Conn.SetReadDeadline(t)
 }
 
 func (c *trackedConn) Write(b []byte) (int, error) {

--- a/pkg/runner/pty_recovery_test.go
+++ b/pkg/runner/pty_recovery_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/alpacax/alpamon/v2/pkg/config"
 	"github.com/alpacax/alpamon/v2/pkg/scheduler"
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
 )
 
 // trackedConn fails writes on demand, so a test can play out a broken connection without breaking a real one.
@@ -250,22 +251,7 @@ func TestPtyRecovery_StormNoGoroutineLeak(t *testing.T) {
 
 func TestPtyClose_ClosesConnAfterWriteControlFailure(t *testing.T) {
 	s := newWshServer(t)
-
-	var tracked *trackedConn
-	dialer := websocket.Dialer{
-		NetDial: func(network, addr string) (net.Conn, error) {
-			c, err := net.Dial(network, addr)
-			if err != nil {
-				return nil, err
-			}
-			tracked = &trackedConn{Conn: c}
-			return tracked, nil
-		},
-	}
-	conn, _, err := dialer.Dial(s.wsURL(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	conn, tracked := dialTracked(t, s.wsURL())
 
 	pc := &PtyClient{
 		conn:      conn,
@@ -276,7 +262,5 @@ func TestPtyClose_ClosesConnAfterWriteControlFailure(t *testing.T) {
 	tracked.failWrites.Store(true)
 	pc.close()
 
-	if !tracked.closed.Load() {
-		t.Fatal("close() did not close the websocket connection after WriteControl failure")
-	}
+	require.True(t, tracked.closed.Load(), "close() did not close the websocket connection after WriteControl failure")
 }


### PR DESCRIPTION
## Background

`WebsocketClient.Close()` returned on a failed close-frame write, skipping `Conn.Close()` entirely.

```go
if err != nil {
    log.Debug()...
    return                    // leaves here
}
...drain...
err = wc.Conn.Close()         // never reached
```

The write only fails when the connection is already broken, which is exactly the reconnect path. `CloseAndReconnect` calls `Close()`, gets nothing done, and `Connect()` then overwrites `wc.Conn` with a fresh connection. Nothing holds the old socket any more. The runtime finalizer on `netFD` (`net/fd_posix.go:44`) collects it eventually, but that is not a bound worth relying on: fds accumulate while reconnects repeat.

The sibling clients—`pty.go`, `control_client.go`, `tunnel_client.go`, `ftp.go`—all close unconditionally.

## Changes

Nine commits, oldest first. The last six answer review feedback.

| Commit | Change |
| --- | --- |
| `4bebacc` | move `trackedConn` above the pty recovery tests (pure move) |
| `3772e33` | the fix: `Conn.Close()` runs whether or not the close frame went out |
| `b59f3cb` | the drain and repeat-call assertions |
| `80fc471` | the pty close test reuses `dialTracked` instead of its own copy of that dialer |
| `a1c4340` | `trackedConn` and `dialTracked` move to an untagged `conn_test.go`, so the close tests run on Windows |
| `bc2e389` | the drain moves into `drainCloseReply`; the dead `IsCloseError` branch goes |
| `8ba2c25` | `Close()` captures the connection once instead of re-reading `wc.Conn` four times |
| `35cf82d` | `net.ErrClosed` no longer logs on the second close of the same connection |
| `6c87384` | a test pins that capture: `wc.Conn` is swapped mid-write and `Close()` still closes the connection it started with |

The drain that waits for the peer's close reply moved into the `else` branch. A peer only answers a frame that actually went out, so there is nothing to wait for once the write failed. `Conn.Close()` runs either way.

`wc.Conn` is deliberately left in place rather than set to nil. `ControlClient` guards its connection with a mutex; `WebsocketClient` has none, and other goroutines read `wc.Conn` directly, so nilling it would introduce the race it looks like it prevents. The `MessageTypeReconnect` handler and `CloseAndReconnect` therefore both close the same connection, which gorilla tolerates.

`Close()` now reads `wc.Conn` into a local before doing anything with it. `Connect()` assigns that field from the `RunForever` goroutine by way of `CloseAndReconnect`, while `gracefulShutdown` (`cmd/alpamon/command/root.go:231`) calls `Close()` from the main goroutine, so the field can change between two reads of it. Close would then send the close frame to one connection and close another. That field race predates this branch, but the branch widened it: `Close()` used to return before reaching `Conn.Close()` on a write error, and now every path reaches it.

## Known limitations

Two problems in this file are left open on purpose, both pre-existing and neither made worse here. Both are now filed as #452, together with the field race described above, because all three come down to `WebsocketClient` having no owner for its connection.

`Close()` and `drainCloseReply()` read the socket while `RunForever` can be blocked in `ReadMessage()` on the same connection, which gorilla does not allow—it permits one concurrent reader. The drain was already on the success path before this branch and its exposure is unchanged. Fixing it means giving reads a single owner rather than patching the close path.

`ShutDown()` calls `close(wc.ShutDownChan)` with no guard, and it is reachable from the worker pool (`pkg/executor/handlers/system/system.go:574,644,648,704`), from `CommandRequestHandler` inline in the `RunForever` goroutine, and from `wirePendingMigration`. Two of those firing together panics the process. This branch does not touch `ShutDown()`.

The capture in `8ba2c25` narrows the field race rather than closing it: `conn := wc.Conn` is still an unsynchronized read racing `Connect()`'s write at `client.go:209`. Closing it needs a mutex around every read and write of the field, which is #452's first item.

## Testing

Four tests in `pkg/runner/client_close_test.go`, and they now run on Windows as well—`GOOS=windows go list -f '{{.TestGoFiles}}' ./pkg/runner/` lists both `client_close_test.go` and `conn_test.go`.

| Test | Asserts |
| --- | --- |
| `ClosesConnAfterWriteControlFailure` | the socket closes after a failed handshake, and the drain is skipped |
| `DrainsReplyAfterSuccessfulHandshake` | the peer receives a normal-closure frame, the drain runs, then the socket closes |
| `IsSafeToCallTwice` | closing the same connection twice is harmless |
| `ClosesTheConnItStartedWith` | a `wc.Conn` swap from inside the close-frame write does not move which connection gets closed |

Whether the drain ran is read from the `SetReadDeadline` call count, not from how long `Close()` took, so the assertion does not depend on the clock and will not flake on a loaded runner.

The regression test was seen failing again after the refactoring commits, by restoring the early return in `Close()`:

```
--- FAIL: TestWebsocketClientClose_ClosesConnAfterWriteControlFailure (0.00s)
    client_close_test.go:64:
        	Error:      	Should be true
        	Messages:   	Close() did not close the websocket connection after WriteControl failure
```

`ClosesTheConnItStartedWith` was seen red the same way, by restoring the four separate reads of `wc.Conn` in `Close()`:

```
--- FAIL: TestWebsocketClientClose_ClosesTheConnItStartedWith (5.00s)
    client_close_test.go:106:
        	Error:      	Should be true
        	Messages:   	Close() left the connection it started with open
```

It takes five seconds in that state because the drain then runs against a connection the peer sent no close frame to, and only the read deadline ends it. The test that swaps the connection reads both sides, so the mirror assertion—the connection that arrived mid-call stays open—fails there too.

`IsSafeToCallTwice` was never seen red. It pins the assumption that gorilla's `Conn.Close` is idempotent rather than guarding a regression. The drain assertion was checked the other way, by deleting the drain from `client.go` and watching it fail.

| Check | Result |
| --- | --- |
| `go test ./pkg/runner/ -race -count=2` | ok, 76.956s |
| `go vet ./pkg/runner/` | clean |
| `GOOS=windows go vet ./pkg/runner/` | clean |
| `gofmt -l pkg/runner/` | clean |

Closes #443

https://claude.ai/code/session_01PTAG5uCwFCRxF6tmdTy8AA

