### PR TITLE
fix: close the db file handle InitDB only opened to create it

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -18,7 +18,7 @@ const dbFileName = "alpamon.db"
 
 func InitDB() *ent.Client {
 	dataDir := utils.DataDir()
-	dbPath := fmt.Sprintf("%s/%s", dataDir, dbFileName)
+	dbPath := filepath.Join(dataDir, dbFileName)
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
 		dbPath, _ = filepath.Abs(dbFileName)
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -61,12 +61,7 @@ func InitTestDB(path string) *ent.Client {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to open test db file: %v\n", err)
 		os.Exit(1)
 	}
-	// We only needed OpenFile to create-on-absence; the filename (and
-	// the sqlite driver, which opens its own handle) is what the
-	// migration and ent client consume. Keeping this handle open would
-	// prevent the test's TearDownSuite from os.Remove'ing the file on
-	// Windows, where open handles block deletion.
-	_ = dbFile.Close()
+	_ = dbFile.Close() // On Windows an open handle blocks TearDownSuite's os.Remove.
 
 	sql.Register("sqlite3", &sqlite.Driver{})
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -18,12 +18,12 @@ const dbFileName = "alpamon.db"
 
 func InitDB() *ent.Client {
 	dataDir := utils.DataDir()
-	fileName := fmt.Sprintf("%s/%s", dataDir, dbFileName)
+	dbPath := fmt.Sprintf("%s/%s", dataDir, dbFileName)
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
-		fileName, _ = filepath.Abs(dbFileName)
+		dbPath, _ = filepath.Abs(dbFileName)
 	}
 
-	dbFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0750)
+	dbFile, err := os.OpenFile(dbPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0750)
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to open db file: %v.", err)
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to open db file: %v\n", err)
@@ -36,13 +36,13 @@ func InitDB() *ent.Client {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	err = RunMigration(fileName, ctx)
+	err = RunMigration(dbPath, ctx)
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to migrate db: %v.", err)
 		os.Exit(1)
 	}
 
-	dbManager := NewDBClientManager(fileName)
+	dbManager := NewDBClientManager(dbPath)
 	client, err := dbManager.GetClient()
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to get db client: %v.", err)
@@ -53,8 +53,8 @@ func InitDB() *ent.Client {
 }
 
 func InitTestDB(path string) *ent.Client {
-	fileName, _ := filepath.Abs(path)
-	dbFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0750)
+	dbPath, _ := filepath.Abs(path)
+	dbFile, err := os.OpenFile(dbPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0750)
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to open test db file: %v.", err)
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to open test db file: %v\n", err)
@@ -72,13 +72,13 @@ func InitTestDB(path string) *ent.Client {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	err = RunMigration(fileName, ctx)
+	err = RunMigration(dbPath, ctx)
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to migrate test db: %v.", err)
 		os.Exit(1)
 	}
 
-	dbManager := NewDBClientManager(fileName)
+	dbManager := NewDBClientManager(dbPath)
 	client, err := dbManager.GetClient()
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to get db client: %v.", err)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -29,19 +29,20 @@ func InitDB() *ent.Client {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to open db file: %v\n", err)
 		os.Exit(1)
 	}
+	_ = dbFile.Close() // The migration and the ent client open the path themselves.
 
 	sql.Register("sqlite3", &sqlite.Driver{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	err = RunMigration(dbFile.Name(), ctx)
+	err = RunMigration(fileName, ctx)
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to migrate db: %v.", err)
 		os.Exit(1)
 	}
 
-	dbManager := NewDBClientManager(dbFile.Name())
+	dbManager := NewDBClientManager(fileName)
 	client, err := dbManager.GetClient()
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to get db client: %v.", err)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -23,6 +23,7 @@ func InitDB() *ent.Client {
 		dbPath, _ = filepath.Abs(dbFileName)
 	}
 
+	// O_CREATE at 0750 is the point: the sqlite driver would create the file at 0644.
 	dbFile, err := os.OpenFile(dbPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0750)
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to open db file: %v.", err)


### PR DESCRIPTION
## Background

`InitDB` (`pkg/db/db.go:19`) opens the database file with `os.OpenFile` and never closes the handle. Nothing downstream wants that handle: `RunMigration` takes the path and opens its own `database/sql` connection, and the ent client does the same through the sqlite driver. From the moment the file exists, the handle has no reader, but it stays open for the life of the process.

What the `os.OpenFile` call does contribute is its `0750` mode argument, and this PR originally described that wrongly. An earlier revision of this body said `O_CREATE` was the only reason for the call. It is not: the driver opens with `SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE` (`glebarez/go-sqlite@v1.23.0` `sqlite.go:816`), so `RunMigration`'s `sql.Open` would create the file on its own. Opening through the driver alone leaves the file at `0644` minus umask, measured as `0644` under umask `022` on darwin/arm64, so the explicit `0750` is what keeps the metrics DB off other users' read path on a fresh install. Raised by @geunwoonoh in review; the correction is in this body and in a code comment, since the commit that carried the wrong claim is already pushed under review and is not being rewritten.

`InitTestDB`, directly below in the same file, already closes at that point and says why in a comment. It has to, because an open handle blocks `os.Remove` on Windows and the test teardown removes the file. `InitDB` never removes it, so what is left is one leaked descriptor rather than a failure. The reason to fix it is that the two siblings disagree on the same step, which invites the pattern to spread.

## Changes

Five commits, none of them more than one line of code.

`InitDB` closes the handle right after the file is created:

```go
_ = dbFile.Close() // The migration and the ent client open the path themselves.
```

`RunMigration` and `NewDBClientManager` now take the path variable already in scope instead of `dbFile.Name()`. The value is identical: `os/file.go:63` returns the string stored at open time, and on both unix (`os/file_unix.go:279`) and Windows (`os/file_windows.go:163`) that string is the argument passed to `OpenFile`, unnormalized and untouched by `Close`. The change is for the reader, since calling a method on a handle closed two lines above makes anyone reviewing this stop and check.

The second commit renames that local from `fileName` to `dbPath` in both `InitDB` and `InitTestDB`. It holds a path, and it sat two lines below the `dbFileName` constant, which holds the bare `"alpamon.db"`—two similar names for two different kinds of value. `dbPath` is what the package already calls this value in `client_test.go` and `migrate_test.go`. Local variables only; no signature or caller changes.

The third commit builds that path with `filepath.Join` instead of `fmt.Sprintf("%s/%s", …)`:

```go
dbPath := filepath.Join(dataDir, dbFileName)
```

The hard-coded separator was not wrong in the sense of failing. On Windows `utils.DataDir()` returns `C:\ProgramData\alpamon\data`, so the old expression produced `C:\ProgramData\alpamon\data/alpamon.db`, and both the Windows API and Go's `filepath` accept `/` as a separator there. What it produced was a path that did not match how the rest of the package writes one. `filepath.Join` picks the platform separator and cleans the result.

The fourth commit records in the code why the `os.OpenFile` call is still there at all:

```go
// O_CREATE at 0750 is the point: the sqlite driver would create the file at 0644.
```

Before the first commit, the `dbFile.Name()` call two lines down made the handle look load-bearing. Now `Close` is its only use, and without this line the block reads as ceremony that a later cleanup could delete, dropping the permission with it. The mode argument only carries weight on Unix; Windows ignores the permission bits.

Two of the five commits go past what #445 describes, which is the unclosed handle alone. That is deliberate: the rename came out of reading the same four lines, the `filepath.Join` change came out of review on this PR, and each is a single line in the function already being edited. Splitting either into its own PR would cost more review attention than it saves. Nothing else in the file was touched—in particular the ignored `filepath.Abs` error on lines 23 and 57 is left as it is, since handling it means adding an error branch, and that is a change of a different size.

The fifth commit trims `InitTestDB`'s close comment from five lines to one:

```go
_ = dbFile.Close() // On Windows an open handle blocks TearDownSuite's os.Remove.
```

Its first three sentences said what the fourth commit now states once, thirty lines up, for both functions. What is left is the part specific to the test path, in the same trailing form `InitDB` uses. The claim in it holds: `TearDownSuite` calls `os.Remove` on the db file and asserts the result (`pkg/collector/check/realtime/cpu/cpu_test.go:48`).

Two further suggestions from review are deferred, not dropped. The duplication between `InitDB` and `InitTestDB`, which this PR made fully visible, and the duplicate `sql.Register("sqlite3", …)` that `database/sql` would panic on if both functions ever ran in one process, are both recorded on #446 (https://github.com/alpacax/alpamon/issues/446#issuecomment-5487965780).

## Testing

Run on the pushed head `3960ba98`.

| Check | Result |
| --- | --- |
| `go test ./... -p 1 -count=1` (darwin/arm64) | 46 packages ok, 0 FAIL |
| `go build ./...` for linux/amd64, darwin/arm64, windows/amd64 | ok |
| `go vet ./...` | clean |
| `gofmt -l pkg/db/db.go` | clean |

<sub>No test covers these changes, and that is a known gap. `InitDB` cannot be called from a test as it stands: it resolves its path through `utils.DataDir()` rather than taking one, calls `os.Exit(1)` on every error, and registers the sqlite driver inside the function, which panics on a second call. Rather than widen this PR, the work of making it testable—and of moving `InitTestDB` out of the production file—is filed separately as #446.</sub>

Closes #445

