### PR TITLE
fix(runner): stop code-server that never became ready

### DIFF
--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -351,9 +351,7 @@ func (m *CodeServerManager) doStart() error {
 
 	// Wait for code-server to be ready (no lock needed)
 	if err := m.waitForReady(); err != nil {
-		m.mu.Lock()
-		_ = m.stopProcess()
-		m.mu.Unlock()
+		_ = m.Stop()
 		return fmt.Errorf("code-server failed to start: %w", err)
 	}
 
@@ -367,44 +365,43 @@ func (m *CodeServerManager) doStart() error {
 	return nil
 }
 
-// Stop gracefully terminates the code-server process.
+// Stop gracefully terminates the code-server process, and reaps it even when
+// m.started is false—the doStart failure path. It takes m.mu itself, so a
+// caller holding it deadlocks; the wait runs unlocked so Status() still answers.
 func (m *CodeServerManager) Stop() error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	cmd, port := m.cmd, m.port
+	m.cmd = nil
+	m.started = false
+	m.mu.Unlock()
 
-	return m.stopProcess()
-}
+	if m.cancel != nil {
+		defer m.cancel()
+	}
 
-// stopProcess stops the code-server process
-func (m *CodeServerManager) stopProcess() error {
-	if !m.started || m.cmd == nil || m.cmd.Process == nil {
+	if cmd == nil || cmd.Process == nil {
 		return nil
 	}
 
-	log.Info().Msgf("Stopping code-server on port %d...", m.port)
+	log.Info().Msgf("Stopping code-server on port %d...", port)
 
-	if err := terminateProcess(m.cmd.Process); err != nil {
+	if err := terminateProcess(cmd.Process); err != nil {
 		return fmt.Errorf("failed to stop code-server: %w", err)
 	}
 
 	done := make(chan error, 1)
 	go func() {
-		done <- m.cmd.Wait()
+		done <- cmd.Wait()
 	}()
 
 	select {
 	case <-done:
 		log.Info().Msg("code-server stopped.")
 	case <-time.After(10 * time.Second):
-		_ = terminateProcess(m.cmd.Process)
+		_ = terminateProcess(cmd.Process)
 		log.Warn().Msg("code-server killed after timeout.")
 	}
 
-	if m.cancel != nil {
-		m.cancel()
-	}
-
-	m.started = false
 	return nil
 }
 

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -418,18 +418,26 @@ func (m *CodeServerManager) Stop() error {
 		log.Warn().Err(err).Msg("Failed to signal code-server, waiting for it anyway.")
 	}
 
+	timer := time.NewTimer(codeServerStopGrace)
+	defer timer.Stop()
+
 	select {
 	case <-waitDone:
-		log.Info().Msg("code-server stopped.")
-	case <-time.After(codeServerStopGrace):
-		// Not terminateProcessFn: it would repeat the SIGTERM just ignored.
-		if err := killProcess(cmd.Process); err != nil {
-			log.Warn().Err(err).Msg("Failed to kill code-server after timeout.")
+	case <-timer.C:
+		// select picks at random when both are ready, so give the reap another look.
+		select {
+		case <-waitDone:
+		default:
+			// Not terminateProcessFn: it would repeat the SIGTERM just ignored.
+			if err := killProcess(cmd.Process); err != nil {
+				log.Warn().Err(err).Msg("Failed to kill code-server after timeout.")
+			}
+			log.Warn().Msg("code-server killed after timeout.")
+			return fmt.Errorf("code-server did not exit within %v", codeServerStopGrace)
 		}
-		log.Warn().Msg("code-server killed after timeout.")
-		return fmt.Errorf("code-server did not exit within %v", codeServerStopGrace)
 	}
 
+	log.Info().Msg("code-server stopped.")
 	return nil
 }
 

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -429,11 +429,10 @@ func (m *CodeServerManager) Stop() error {
 		case <-waitDone:
 		default:
 			// Not terminateProcessFn: it would repeat the SIGTERM just ignored.
-			if err := killProcess(cmd.Process); err != nil {
-				log.Warn().Err(err).Msg("Failed to kill code-server after timeout.")
-			}
-			log.Warn().Msg("code-server killed after timeout.")
-			return fmt.Errorf("code-server did not exit within %v", codeServerStopGrace)
+			timedOut := fmt.Errorf("code-server did not exit within %v", codeServerStopGrace)
+			killErr := killProcess(cmd.Process)
+			log.Warn().Err(killErr).Msgf("%v, sending SIGKILL.", timedOut)
+			return timedOut
 		}
 	}
 

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -57,6 +57,11 @@ type CodeServerConfig struct {
 // Minimum free memory required to start code-server.
 const minFreeMemoryForEditor uint64 = 512 * 1024 * 1024 // 512MB
 
+const (
+	codeServerReadyPollInterval = time.Second
+	codeServerReadyDialTimeout  = time.Second
+)
+
 var codeServerStopGrace = 10 * time.Second
 
 // defaultConfig is the singleton configuration instance.
@@ -459,10 +464,14 @@ func (m *CodeServerManager) IsRunning() bool {
 func (m *CodeServerManager) waitForReady(waitDone <-chan struct{}) error {
 	cfg := GetCodeServerConfig()
 	addr := net.JoinHostPort(loopbackHost, strconv.Itoa(m.port))
-	deadline := time.After(cfg.StartupTimeout)
+	deadline := time.NewTimer(cfg.StartupTimeout)
+	defer deadline.Stop()
+
+	ticker := time.NewTicker(codeServerReadyPollInterval)
+	defer ticker.Stop()
 
 	for {
-		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		conn, err := net.DialTimeout("tcp", addr, codeServerReadyDialTimeout)
 		if err == nil {
 			_ = conn.Close()
 			return nil
@@ -471,9 +480,9 @@ func (m *CodeServerManager) waitForReady(waitDone <-chan struct{}) error {
 		select {
 		case <-waitDone:
 			return fmt.Errorf("code-server process exited unexpectedly")
-		case <-deadline:
+		case <-deadline.C:
 			return fmt.Errorf("code-server not ready after %v", cfg.StartupTimeout)
-		case <-time.After(time.Second):
+		case <-ticker.C:
 		}
 	}
 }

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -60,9 +60,8 @@ const minFreeMemoryForEditor uint64 = 512 * 1024 * 1024 // 512MB
 const (
 	codeServerReadyPollInterval = time.Second
 	codeServerReadyDialTimeout  = time.Second
+	codeServerStopGrace         = 10 * time.Second
 )
-
-var codeServerStopGrace = 10 * time.Second
 
 // defaultConfig is the singleton configuration instance.
 var defaultConfig = &CodeServerConfig{
@@ -209,7 +208,7 @@ const (
 // CodeServerManager manages a code-server process for editor tunneling.
 type CodeServerManager struct {
 	cmd       *exec.Cmd
-	waitDone  chan struct{}
+	waitDone  <-chan struct{}
 	port      int
 	username  string
 	groupname string
@@ -222,6 +221,9 @@ type CodeServerManager struct {
 	lastError string
 	startOnce sync.Once
 	startErr  error
+
+	stopGrace   time.Duration
+	terminateFn func(*os.Process) error // a seam: a test needs signalling to fail
 }
 
 func NewCodeServerManager(parentCtx context.Context, username, groupname string) (*CodeServerManager, error) {
@@ -239,6 +241,9 @@ func NewCodeServerManager(parentCtx context.Context, username, groupname string)
 		ctx:       ctx,
 		cancel:    cancel,
 		status:    CodeServerStatusIdle,
+
+		stopGrace:   codeServerStopGrace,
+		terminateFn: terminateProcess,
 	}, nil
 }
 
@@ -376,15 +381,13 @@ func (m *CodeServerManager) doStart() error {
 	return nil
 }
 
-// A seam: a test needs signalling to fail without picking a pid it does not own.
-var terminateProcessFn = terminateProcess
-
-// reapProcess runs the only cmd.Wait this process gets—a second one would race it
-// over cmd.ProcessState—and closes done, so every waiter sees the reap, not just one.
-func reapProcess(cmd *exec.Cmd) chan struct{} {
+// reapProcess owns the only cmd.Wait: a second one would race it over cmd.ProcessState.
+func reapProcess(cmd *exec.Cmd) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
-		_ = cmd.Wait()
+		if err := cmd.Wait(); err != nil {
+			log.Debug().Err(err).Msg("code-server process exited.")
+		}
 		close(done)
 	}()
 	return done
@@ -396,6 +399,7 @@ func reapProcess(cmd *exec.Cmd) chan struct{} {
 func (m *CodeServerManager) Stop() error {
 	m.mu.Lock()
 	cmd, waitDone, port := m.cmd, m.waitDone, m.port
+	grace, terminate := m.stopGrace, m.terminateFn
 	m.cmd = nil
 	m.waitDone = nil
 	m.started = false
@@ -419,11 +423,11 @@ func (m *CodeServerManager) Stop() error {
 	log.Info().Msgf("Stopping code-server on port %d...", port)
 
 	// A failed signal still leaves a child to collect, so the wait below runs anyway.
-	if err := terminateProcessFn(cmd.Process); err != nil {
+	if err := terminate(cmd.Process); err != nil {
 		log.Warn().Err(err).Msg("Failed to signal code-server, waiting for it anyway.")
 	}
 
-	timer := time.NewTimer(codeServerStopGrace)
+	timer := time.NewTimer(grace)
 	defer timer.Stop()
 
 	select {
@@ -433,11 +437,10 @@ func (m *CodeServerManager) Stop() error {
 		select {
 		case <-waitDone:
 		default:
-			// Not terminateProcessFn: it would repeat the SIGTERM just ignored.
-			timedOut := fmt.Errorf("code-server did not exit within %v", codeServerStopGrace)
+			// Not terminate: it would repeat the SIGTERM just ignored.
 			killErr := killProcess(cmd.Process)
-			log.Warn().Err(killErr).Msgf("%v, sending SIGKILL.", timedOut)
-			return timedOut
+			log.Warn().Err(killErr).Dur("grace", grace).Msg("code-server did not exit in time, sending SIGKILL.")
+			return fmt.Errorf("code-server did not exit within %v", grace)
 		}
 	}
 

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -57,7 +57,7 @@ type CodeServerConfig struct {
 // Minimum free memory required to start code-server.
 const minFreeMemoryForEditor uint64 = 512 * 1024 * 1024 // 512MB
 
-const codeServerStopGrace = 10 * time.Second
+var codeServerStopGrace = 10 * time.Second
 
 // defaultConfig is the singleton configuration instance.
 var defaultConfig = &CodeServerConfig{
@@ -422,7 +422,10 @@ func (m *CodeServerManager) Stop() error {
 	case <-waitDone:
 		log.Info().Msg("code-server stopped.")
 	case <-time.After(codeServerStopGrace):
-		_ = terminateProcessFn(cmd.Process)
+		// Not terminateProcessFn: it would repeat the SIGTERM just ignored.
+		if err := killProcess(cmd.Process); err != nil {
+			log.Warn().Err(err).Msg("Failed to kill code-server after timeout.")
+		}
 		log.Warn().Msg("code-server killed after timeout.")
 		return fmt.Errorf("code-server did not exit within %v", codeServerStopGrace)
 	}

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -471,6 +471,13 @@ func (m *CodeServerManager) waitForReady(waitDone <-chan struct{}) error {
 	defer ticker.Stop()
 
 	for {
+		// Before the dial: a dead code-server's port may already answer for someone else.
+		select {
+		case <-waitDone:
+			return fmt.Errorf("code-server process exited unexpectedly")
+		default:
+		}
+
 		conn, err := net.DialTimeout("tcp", addr, codeServerReadyDialTimeout)
 		if err == nil {
 			_ = conn.Close()
@@ -479,7 +486,7 @@ func (m *CodeServerManager) waitForReady(waitDone <-chan struct{}) error {
 
 		select {
 		case <-waitDone:
-			return fmt.Errorf("code-server process exited unexpectedly")
+			// The loop head reports it.
 		case <-deadline.C:
 			return fmt.Errorf("code-server not ready after %v", cfg.StartupTimeout)
 		case <-ticker.C:

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -57,6 +57,8 @@ type CodeServerConfig struct {
 // Minimum free memory required to start code-server.
 const minFreeMemoryForEditor uint64 = 512 * 1024 * 1024 // 512MB
 
+const codeServerStopGrace = 10 * time.Second
+
 // defaultConfig is the singleton configuration instance.
 var defaultConfig = &CodeServerConfig{
 	// Timeouts
@@ -202,6 +204,7 @@ const (
 // CodeServerManager manages a code-server process for editor tunneling.
 type CodeServerManager struct {
 	cmd       *exec.Cmd
+	waitDone  chan struct{}
 	port      int
 	username  string
 	groupname string
@@ -345,12 +348,15 @@ func (m *CodeServerManager) doStart() error {
 		return err
 	}
 
+	waitDone := reapProcess(cmd)
+
 	m.mu.Lock()
 	m.cmd = cmd
+	m.waitDone = waitDone
 	m.mu.Unlock()
 
 	// Wait for code-server to be ready (no lock needed)
-	if err := m.waitForReady(); err != nil {
+	if err := m.waitForReady(waitDone); err != nil {
 		_ = m.Stop()
 		return fmt.Errorf("code-server failed to start: %w", err)
 	}
@@ -365,13 +371,28 @@ func (m *CodeServerManager) doStart() error {
 	return nil
 }
 
-// Stop gracefully terminates the code-server process, and reaps it even when
-// m.started is false—the doStart failure path. It takes m.mu itself, so a
-// caller holding it deadlocks; the wait runs unlocked so Status() still answers.
+// A seam: a test needs signalling to fail without picking a pid it does not own.
+var terminateProcessFn = terminateProcess
+
+// reapProcess runs the only cmd.Wait this process gets—a second one would race it
+// over cmd.ProcessState—and closes done, so every waiter sees the reap, not just one.
+func reapProcess(cmd *exec.Cmd) chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	return done
+}
+
+// Stop terminates code-server and waits for the reap, even before m.started is
+// set—the doStart failure path. It takes m.mu itself, so a caller holding it
+// deadlocks; the wait runs unlocked so Status() still answers.
 func (m *CodeServerManager) Stop() error {
 	m.mu.Lock()
-	cmd, port := m.cmd, m.port
+	cmd, waitDone, port := m.cmd, m.waitDone, m.port
 	m.cmd = nil
+	m.waitDone = nil
 	m.started = false
 	m.mu.Unlock()
 
@@ -383,23 +404,27 @@ func (m *CodeServerManager) Stop() error {
 		return nil
 	}
 
-	log.Info().Msgf("Stopping code-server on port %d...", port)
-
-	if err := terminateProcess(cmd.Process); err != nil {
-		return fmt.Errorf("failed to stop code-server: %w", err)
+	// A reaped pid is free for reuse: once the reaper is done, nothing here is ours.
+	select {
+	case <-waitDone:
+		return nil
+	default:
 	}
 
-	done := make(chan error, 1)
-	go func() {
-		done <- cmd.Wait()
-	}()
+	log.Info().Msgf("Stopping code-server on port %d...", port)
+
+	// A failed signal still leaves a child to collect, so the wait below runs anyway.
+	if err := terminateProcessFn(cmd.Process); err != nil {
+		log.Warn().Err(err).Msg("Failed to signal code-server, waiting for it anyway.")
+	}
 
 	select {
-	case <-done:
+	case <-waitDone:
 		log.Info().Msg("code-server stopped.")
-	case <-time.After(10 * time.Second):
-		_ = terminateProcess(cmd.Process)
+	case <-time.After(codeServerStopGrace):
+		_ = terminateProcessFn(cmd.Process)
 		log.Warn().Msg("code-server killed after timeout.")
+		return fmt.Errorf("code-server did not exit within %v", codeServerStopGrace)
 	}
 
 	return nil
@@ -419,27 +444,28 @@ func (m *CodeServerManager) IsRunning() bool {
 	return m.started
 }
 
-// waitForReady waits for code-server to start listening on its port.
-func (m *CodeServerManager) waitForReady() error {
+// waitForReady waits for code-server to listen on its port. It watches the reaper
+// channel, not m.cmd, which a concurrent Stop may have already cleared.
+func (m *CodeServerManager) waitForReady(waitDone <-chan struct{}) error {
 	cfg := GetCodeServerConfig()
 	addr := net.JoinHostPort(loopbackHost, strconv.Itoa(m.port))
-	deadline := time.Now().Add(cfg.StartupTimeout)
+	deadline := time.After(cfg.StartupTimeout)
 
-	for time.Now().Before(deadline) {
-		if m.cmd.ProcessState != nil && m.cmd.ProcessState.Exited() {
-			return fmt.Errorf("code-server process exited unexpectedly")
-		}
-
+	for {
 		conn, err := net.DialTimeout("tcp", addr, time.Second)
 		if err == nil {
 			_ = conn.Close()
 			return nil
 		}
 
-		time.Sleep(time.Second)
+		select {
+		case <-waitDone:
+			return fmt.Errorf("code-server process exited unexpectedly")
+		case <-deadline:
+			return fmt.Errorf("code-server not ready after %v", cfg.StartupTimeout)
+		case <-time.After(time.Second):
+		}
 	}
-
-	return fmt.Errorf("code-server not ready after %v", cfg.StartupTimeout)
 }
 
 func isCodeServerInstalled() bool {

--- a/pkg/runner/editor_test.go
+++ b/pkg/runner/editor_test.go
@@ -2,11 +2,14 @@ package runner
 
 import (
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindAvailablePort(t *testing.T) {
@@ -172,4 +175,24 @@ func TestToSettingsJSONGolden(t *testing.T) {
 	got, err := c.ToSettingsJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, want, string(got))
+}
+
+// TestWaitForReadyChecksTheExitBeforeTheDial: another process can grab the port
+// the moment code-server dies, and a dial that answers is then not our server.
+func TestWaitForReadyChecksTheExitBeforeTheDial(t *testing.T) {
+	ln, err := net.Listen("tcp", net.JoinHostPort(loopbackHost, "0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+
+	m := &CodeServerManager{}
+	m.port, err = strconv.Atoi(port)
+	require.NoError(t, err)
+
+	waitDone := make(chan struct{})
+	close(waitDone)
+
+	assert.ErrorContains(t, m.waitForReady(waitDone), "exited unexpectedly")
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -24,15 +24,22 @@ func newManagerWithProcess(t *testing.T) (*CodeServerManager, *exec.Cmd) {
 	cmd := exec.CommandContext(ctx, "sleep", "300")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	require.NoError(t, cmd.Start())
+
+	waitDone := reapProcess(cmd)
 	t.Cleanup(func() {
-		_ = terminateProcess(cmd.Process)
+		select {
+		case <-waitDone:
+		default:
+			_ = terminateProcess(cmd.Process)
+		}
 	})
 
 	m := &CodeServerManager{
-		cmd:    cmd,
-		ctx:    ctx,
-		cancel: cancel,
-		status: CodeServerStatusStarting,
+		cmd:      cmd,
+		waitDone: waitDone,
+		ctx:      ctx,
+		cancel:   cancel,
+		status:   CodeServerStatusStarting,
 	}
 	return m, cmd
 }
@@ -90,7 +97,7 @@ func TestStopKeepsStatusAnswerable(t *testing.T) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// os.Pipe, not cmd.StdoutPipe: the read end stays ours, so reading does not
-	// race the cmd.Wait() Stop runs concurrently.
+	// race the cmd.Wait() the reaper runs concurrently.
 	pr, pw, err := os.Pipe()
 	require.NoError(t, err)
 	cmd.Stdout = pw
@@ -103,10 +110,11 @@ func TestStopKeepsStatusAnswerable(t *testing.T) {
 	})
 
 	m := &CodeServerManager{
-		cmd:    cmd,
-		ctx:    ctx,
-		cancel: cancel,
-		status: CodeServerStatusStarting,
+		cmd:      cmd,
+		waitDone: reapProcess(cmd),
+		ctx:      ctx,
+		cancel:   cancel,
+		status:   CodeServerStatusStarting,
 	}
 
 	// The child announces itself once the trap is installed: an earlier SIGTERM
@@ -133,4 +141,40 @@ func TestStopKeepsStatusAnswerable(t *testing.T) {
 
 	require.NoError(t, syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL))
 	require.NoError(t, <-stopped)
+}
+
+// TestStopWaitsAfterSignalFailure: a signal that does not land still leaves a child to collect.
+func TestStopWaitsAfterSignalFailure(t *testing.T) {
+	m, cmd := newManagerWithProcess(t)
+
+	orig := terminateProcessFn
+	// Kills the child from inside the failing call, so the reap cannot land first.
+	terminateProcessFn = func(p *os.Process) error {
+		_ = syscall.Kill(-p.Pid, syscall.SIGKILL)
+		return syscall.ESRCH
+	}
+	t.Cleanup(func() { terminateProcessFn = orig })
+
+	require.NoError(t, m.Stop(), "a failed signal is not a failure to stop")
+	require.NotNil(t, cmd.ProcessState, "Stop returned before the process was reaped")
+}
+
+// TestWaitForReadySurvivesConcurrentStop covers TunnelClient.Close mid-startup, where Stop clears m.cmd.
+func TestWaitForReadySurvivesConcurrentStop(t *testing.T) {
+	m, _ := newManagerWithProcess(t)
+
+	// Nothing listens on it, so every dial fails and the loop keeps running.
+	port, err := findAvailablePort()
+	require.NoError(t, err)
+	m.port = port
+
+	// Read before Stop nils the field, not from inside the goroutine.
+	waitDone := m.waitDone
+	ready := make(chan error, 1)
+	go func() {
+		ready <- m.waitForReady(waitDone)
+	}()
+
+	require.NoError(t, m.Stop())
+	assert.ErrorContains(t, <-ready, "exited unexpectedly")
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -5,10 +5,12 @@ package runner
 import (
 	"bufio"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -177,4 +179,60 @@ func TestWaitForReadySurvivesConcurrentStop(t *testing.T) {
 
 	require.NoError(t, m.Stop())
 	assert.ErrorContains(t, <-ready, "exited unexpectedly")
+}
+
+// TestStopKillsGroupIgnoringSIGTERM: on timeout the whole group must die.
+// exec.CommandContext's own kill reaches only the leader.
+func TestStopKillsGroupIgnoringSIGTERM(t *testing.T) {
+	origGrace := codeServerStopGrace
+	codeServerStopGrace = 200 * time.Millisecond
+	t.Cleanup(func() { codeServerStopGrace = origGrace })
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Both shells ignore SIGTERM, so only SIGKILL at the group ends them.
+	cmd := exec.CommandContext(ctx, "sh", "-c",
+		`trap '' TERM; sh -c "trap '' TERM; while :; do sleep 1; done" & echo ready; while :; do sleep 1; done`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	pr, pw, err := os.Pipe()
+	require.NoError(t, err)
+	cmd.Stdout = pw
+	t.Cleanup(func() { _ = pr.Close() })
+
+	require.NoError(t, cmd.Start())
+	require.NoError(t, pw.Close())
+
+	pgid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	})
+
+	m := &CodeServerManager{
+		cmd:      cmd,
+		waitDone: reapProcess(cmd),
+		ctx:      ctx,
+		cancel:   cancel,
+		status:   CodeServerStatusStarting,
+	}
+
+	// Signalling before the trap is installed kills the child by default.
+	line, err := bufio.NewReader(pr).ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "ready\n", line)
+
+	require.ErrorContains(t, m.Stop(), "did not exit within")
+
+	// Signal 0 only checks for members, and ESRCH means the group is empty.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		err := syscall.Kill(-pgid, syscall.Signal(0))
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Stop gave up on the process group but left it running")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -5,7 +5,7 @@ package runner
 import (
 	"bufio"
 	"context"
-	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"syscall"
@@ -217,22 +217,25 @@ func TestStopKillsGroupIgnoringSIGTERM(t *testing.T) {
 	}
 
 	// Signalling before the trap is installed kills the child by default.
-	line, err := bufio.NewReader(pr).ReadString('\n')
+	child := bufio.NewReader(pr)
+	line, err := child.ReadString('\n')
 	require.NoError(t, err)
 	require.Equal(t, "ready\n", line)
 
 	require.ErrorContains(t, m.Stop(), "did not exit within")
 
-	// Signal 0 only checks for members, and ESRCH means the group is empty.
-	deadline := time.Now().Add(3 * time.Second)
-	for {
-		err := syscall.Kill(-pgid, syscall.Signal(0))
-		if errors.Is(err, syscall.ESRCH) {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("Stop gave up on the process group but left it running")
-		}
-		time.Sleep(20 * time.Millisecond)
+	// Both shells hold the write end, so EOF means both are gone. kill(-pgid, 0)
+	// would not do: it still finds a zombie that a container init never reaps.
+	drained := make(chan error, 1)
+	go func() {
+		_, err := io.ReadAll(child)
+		drained <- err
+	}()
+
+	select {
+	case err := <-drained:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop gave up on the process group but left it running")
 	}
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -53,13 +53,55 @@ func newManagerWithProcess(t *testing.T) (*CodeServerManager, *exec.Cmd) {
 	killGroupOnCleanup(t, cmd, waitDone)
 
 	m := &CodeServerManager{
-		cmd:      cmd,
-		waitDone: waitDone,
-		ctx:      ctx,
-		cancel:   cancel,
-		status:   CodeServerStatusStarting,
+		cmd:         cmd,
+		waitDone:    waitDone,
+		ctx:         ctx,
+		cancel:      cancel,
+		status:      CodeServerStatusStarting,
+		stopGrace:   codeServerStopGrace,
+		terminateFn: terminateProcess,
 	}
 	return m, cmd
+}
+
+// newManagerWithScript reads the "ready" line the script prints: a signal arriving
+// before the script installs its trap would kill it by the default disposition.
+func newManagerWithScript(t *testing.T, script string) (*CodeServerManager, *exec.Cmd, *bufio.Reader) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", script)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// os.Pipe, not cmd.StdoutPipe: the read end stays ours, so reading does not
+	// race the cmd.Wait() the reaper runs concurrently.
+	pr, pw, err := os.Pipe()
+	require.NoError(t, err)
+	cmd.Stdout = pw
+	t.Cleanup(func() { _ = pr.Close() })
+
+	require.NoError(t, cmd.Start())
+	require.NoError(t, pw.Close())
+
+	waitDone := reapProcess(cmd)
+	killGroupOnCleanup(t, cmd, waitDone)
+
+	child := bufio.NewReader(pr)
+	line, err := child.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "ready\n", line)
+
+	m := &CodeServerManager{
+		cmd:         cmd,
+		waitDone:    waitDone,
+		ctx:         ctx,
+		cancel:      cancel,
+		status:      CodeServerStatusStarting,
+		stopGrace:   codeServerStopGrace,
+		terminateFn: terminateProcess,
+	}
+	return m, cmd, child
 }
 
 // TestStopBeforeStarted covers doStart's waitForReady failure path: it calls
@@ -109,45 +151,15 @@ func TestStopClearsRunningState(t *testing.T) {
 // TestStopKeepsStatusAnswerable pins Stop inside its wait with a child that
 // ignores SIGTERM and reports it, so no sleep or deadline is needed.
 func TestStopKeepsStatusAnswerable(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-
-	cmd := exec.CommandContext(ctx, "sh", "-c", `trap 'echo signalled' TERM; echo ready; while :; do sleep 1; done`)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	// os.Pipe, not cmd.StdoutPipe: the read end stays ours, so reading does not
-	// race the cmd.Wait() the reaper runs concurrently.
-	pr, pw, err := os.Pipe()
-	require.NoError(t, err)
-	cmd.Stdout = pw
-	t.Cleanup(func() { _ = pr.Close() })
-
-	require.NoError(t, cmd.Start())
-	require.NoError(t, pw.Close())
-
-	waitDone := reapProcess(cmd)
-	killGroupOnCleanup(t, cmd, waitDone)
-
-	m := &CodeServerManager{
-		cmd:      cmd,
-		waitDone: waitDone,
-		ctx:      ctx,
-		cancel:   cancel,
-		status:   CodeServerStatusStarting,
-	}
-
-	// The child announces itself once the trap is installed: an earlier SIGTERM
-	// would kill it by default and the read below would see EOF.
-	child := bufio.NewReader(pr)
-	line, err := child.ReadString('\n')
-	require.NoError(t, err)
-	require.Equal(t, "ready\n", line)
+	m, cmd, child := newManagerWithScript(t,
+		`trap 'echo signalled' TERM; echo ready; while :; do sleep 1; done`)
 
 	stopped := make(chan error, 1)
 	go func() {
 		stopped <- m.Stop()
 	}()
 
-	line, err = child.ReadString('\n')
+	line, err := child.ReadString('\n')
 	require.NoError(t, err)
 	require.Equal(t, "signalled\n", line, "the child should have reported the SIGTERM Stop sent")
 
@@ -165,13 +177,11 @@ func TestStopKeepsStatusAnswerable(t *testing.T) {
 func TestStopWaitsAfterSignalFailure(t *testing.T) {
 	m, cmd := newManagerWithProcess(t)
 
-	orig := terminateProcessFn
 	// Kills the child from inside the failing call, so the reap cannot land first.
-	terminateProcessFn = func(p *os.Process) error {
+	m.terminateFn = func(p *os.Process) error {
 		_ = syscall.Kill(-p.Pid, syscall.SIGKILL)
 		return syscall.ESRCH
 	}
-	t.Cleanup(func() { terminateProcessFn = orig })
 
 	require.NoError(t, m.Stop(), "a failed signal is not a failure to stop")
 	require.NotNil(t, cmd.ProcessState, "Stop returned before the process was reaped")
@@ -200,41 +210,10 @@ func TestWaitForReadySurvivesConcurrentStop(t *testing.T) {
 // TestStopKillsGroupIgnoringSIGTERM: on timeout the whole group must die.
 // exec.CommandContext's own kill reaches only the leader.
 func TestStopKillsGroupIgnoringSIGTERM(t *testing.T) {
-	origGrace := codeServerStopGrace
-	codeServerStopGrace = 200 * time.Millisecond
-	t.Cleanup(func() { codeServerStopGrace = origGrace })
-
-	ctx, cancel := context.WithCancel(t.Context())
-
 	// Both shells ignore SIGTERM, so only SIGKILL at the group ends them.
-	cmd := exec.CommandContext(ctx, "sh", "-c",
+	m, _, child := newManagerWithScript(t,
 		`trap '' TERM; sh -c "trap '' TERM; while :; do sleep 1; done" & echo ready; while :; do sleep 1; done`)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	pr, pw, err := os.Pipe()
-	require.NoError(t, err)
-	cmd.Stdout = pw
-	t.Cleanup(func() { _ = pr.Close() })
-
-	require.NoError(t, cmd.Start())
-	require.NoError(t, pw.Close())
-
-	waitDone := reapProcess(cmd)
-	killGroupOnCleanup(t, cmd, waitDone)
-
-	m := &CodeServerManager{
-		cmd:      cmd,
-		waitDone: waitDone,
-		ctx:      ctx,
-		cancel:   cancel,
-		status:   CodeServerStatusStarting,
-	}
-
-	// Signalling before the trap is installed kills the child by default.
-	child := bufio.NewReader(pr)
-	line, err := child.ReadString('\n')
-	require.NoError(t, err)
-	require.Equal(t, "ready\n", line)
+	m.stopGrace = 200 * time.Millisecond
 
 	require.ErrorContains(t, m.Stop(), "did not exit within")
 

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -16,6 +16,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// killGroupOnCleanup kills the child's group unless the reaper already closed
+// done: a reaped pid is free for reuse, so the group may no longer be ours.
+func killGroupOnCleanup(t *testing.T, cmd *exec.Cmd, done <-chan struct{}) {
+	t.Helper()
+
+	pgid := cmd.Process.Pid
+	t.Cleanup(func() {
+		select {
+		case <-done:
+			return
+		default:
+		}
+
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("process group %d outlived the test", pgid)
+		}
+	})
+}
+
 // newManagerWithProcess puts the child in its own process group, so
 // terminateProcess signals it and not the test binary.
 func newManagerWithProcess(t *testing.T) (*CodeServerManager, *exec.Cmd) {
@@ -28,13 +50,7 @@ func newManagerWithProcess(t *testing.T) (*CodeServerManager, *exec.Cmd) {
 	require.NoError(t, cmd.Start())
 
 	waitDone := reapProcess(cmd)
-	t.Cleanup(func() {
-		select {
-		case <-waitDone:
-		default:
-			_ = terminateProcess(cmd.Process)
-		}
-	})
+	killGroupOnCleanup(t, cmd, waitDone)
 
 	m := &CodeServerManager{
 		cmd:      cmd,
@@ -107,13 +123,13 @@ func TestStopKeepsStatusAnswerable(t *testing.T) {
 
 	require.NoError(t, cmd.Start())
 	require.NoError(t, pw.Close())
-	t.Cleanup(func() {
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	})
+
+	waitDone := reapProcess(cmd)
+	killGroupOnCleanup(t, cmd, waitDone)
 
 	m := &CodeServerManager{
 		cmd:      cmd,
-		waitDone: reapProcess(cmd),
+		waitDone: waitDone,
 		ctx:      ctx,
 		cancel:   cancel,
 		status:   CodeServerStatusStarting,
@@ -203,14 +219,12 @@ func TestStopKillsGroupIgnoringSIGTERM(t *testing.T) {
 	require.NoError(t, cmd.Start())
 	require.NoError(t, pw.Close())
 
-	pgid := cmd.Process.Pid
-	t.Cleanup(func() {
-		_ = syscall.Kill(-pgid, syscall.SIGKILL)
-	})
+	waitDone := reapProcess(cmd)
+	killGroupOnCleanup(t, cmd, waitDone)
 
 	m := &CodeServerManager{
 		cmd:      cmd,
-		waitDone: reapProcess(cmd),
+		waitDone: waitDone,
 		ctx:      ctx,
 		cancel:   cancel,
 		status:   CodeServerStatusStarting,

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -1,0 +1,136 @@
+//go:build !windows
+
+package runner
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newManagerWithProcess puts the child in its own process group, so
+// terminateProcess signals it and not the test binary.
+func newManagerWithProcess(t *testing.T) (*CodeServerManager, *exec.Cmd) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	cmd := exec.CommandContext(ctx, "sleep", "300")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = terminateProcess(cmd.Process)
+	})
+
+	m := &CodeServerManager{
+		cmd:    cmd,
+		ctx:    ctx,
+		cancel: cancel,
+		status: CodeServerStatusStarting,
+	}
+	return m, cmd
+}
+
+// TestStopBeforeStarted covers doStart's waitForReady failure path: it calls
+// Stop before m.started is set—gating teardown on that flag leaks the process.
+func TestStopBeforeStarted(t *testing.T) {
+	m, cmd := newManagerWithProcess(t)
+
+	require.NoError(t, m.Stop())
+
+	require.NotNil(t, cmd.ProcessState, "Stop must terminate and reap the process")
+	ws, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	require.True(t, ok)
+	require.True(t, ws.Signaled(), "the process should have died from a signal, not exited on its own")
+	assert.Equal(t, syscall.SIGTERM, ws.Signal(), "Stop should terminate gracefully before falling back to SIGKILL")
+	assert.ErrorIs(t, m.ctx.Err(), context.Canceled, "Stop must cancel the manager context")
+}
+
+// TestStopTwice mirrors tunnel_client stopping a manager that doStart already
+// stopped on its failure path.
+func TestStopTwice(t *testing.T) {
+	m, _ := newManagerWithProcess(t)
+
+	require.NoError(t, m.Stop())
+	require.NoError(t, m.Stop(), "the second Stop must be a no-op, not another signal at a reaped pid")
+	assert.Nil(t, m.cmd, "Stop must clear m.cmd so a later Stop has nothing to signal")
+}
+
+// TestStopWithoutProcess covers Stop during the install phase, which must abort
+// installCodeServer through the context.
+func TestStopWithoutProcess(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	m := &CodeServerManager{ctx: ctx, cancel: cancel, status: CodeServerStatusInstalling}
+
+	require.NoError(t, m.Stop())
+	assert.ErrorIs(t, ctx.Err(), context.Canceled, "Stop must cancel the context even with no process to signal")
+}
+
+func TestStopClearsRunningState(t *testing.T) {
+	m, _ := newManagerWithProcess(t)
+	m.started = true
+
+	require.NoError(t, m.Stop())
+	assert.False(t, m.IsRunning(), "Stop must clear m.started")
+}
+
+// TestStopKeepsStatusAnswerable pins Stop inside its wait with a child that
+// ignores SIGTERM and reports it, so no sleep or deadline is needed.
+func TestStopKeepsStatusAnswerable(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", `trap 'echo signalled' TERM; echo ready; while :; do sleep 1; done`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// os.Pipe, not cmd.StdoutPipe: the read end stays ours, so reading does not
+	// race the cmd.Wait() Stop runs concurrently.
+	pr, pw, err := os.Pipe()
+	require.NoError(t, err)
+	cmd.Stdout = pw
+	t.Cleanup(func() { _ = pr.Close() })
+
+	require.NoError(t, cmd.Start())
+	require.NoError(t, pw.Close())
+	t.Cleanup(func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	})
+
+	m := &CodeServerManager{
+		cmd:    cmd,
+		ctx:    ctx,
+		cancel: cancel,
+		status: CodeServerStatusStarting,
+	}
+
+	// The child announces itself once the trap is installed: an earlier SIGTERM
+	// would kill it by default and the read below would see EOF.
+	child := bufio.NewReader(pr)
+	line, err := child.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "ready\n", line)
+
+	stopped := make(chan error, 1)
+	go func() {
+		stopped <- m.Stop()
+	}()
+
+	line, err = child.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "signalled\n", line, "the child should have reported the SIGTERM Stop sent")
+
+	require.True(t, m.mu.TryRLock(), "Stop must release m.mu before waiting on the process")
+	m.mu.RUnlock()
+
+	status, _ := m.Status()
+	assert.Equal(t, CodeServerStatusStarting, status)
+
+	require.NoError(t, syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL))
+	require.NoError(t, <-stopped)
+}

--- a/pkg/runner/process_unix.go
+++ b/pkg/runner/process_unix.go
@@ -17,3 +17,8 @@ func terminateProcess(p *os.Process) error {
 	}
 	return nil
 }
+
+// killProcess SIGKILLs the process group, for a SIGTERM that was ignored.
+func killProcess(p *os.Process) error {
+	return syscall.Kill(-p.Pid, syscall.SIGKILL)
+}

--- a/pkg/runner/process_windows.go
+++ b/pkg/runner/process_windows.go
@@ -7,3 +7,8 @@ import "os"
 func terminateProcess(p *os.Process) error {
 	return p.Kill()
 }
+
+// killProcess matches terminateProcess: Windows has no SIGTERM to ignore.
+func killProcess(p *os.Process) error {
+	return p.Kill()
+}


### PR DESCRIPTION
## Background

`CodeServerManager` spawns code-server, waits for it to answer on its port, and only then sets `m.started`. `stopProcess` gated its teardown on that flag, so the `waitForReady` failure path—which runs before it is set—returned early and did nothing: no SIGTERM, no `cmd.Wait`, no context cancel.

A process that had already died stayed a zombie for the life of alpamon, since nothing reaped it. One still running kept holding its port. Nothing reclaimed it later either: `startOnce` makes `Start` hand back the stored error, `StartAsync` refuses to re-enter once the status is `error`, and a later `Stop` hit the same guard. The same guard also meant `Stop` during the install phase never cancelled the context, so `installCodeServer` was not interrupted.

The tunnel daemon already handles its own version of this path correctly (`pkg/runner/tunnel_relay_unix.go`): on a readiness failure it kills, waits, and clears `daemonCmd`. Only the code-server path was missing that.

## Changes

### Teardown runs on every path

The guard now looks at the process alone, and the cancel runs whether or not there is one, so a `Stop` with no process still aborts the install. Teardown clears `m.cmd`, which is what keeps a second `Stop` from signalling a reaped pid; the case is real, since `pkg/runner/tunnel_client.go` stops a manager that `doStart` already stopped on its failure path. The old code got that protection by accident, as a side effect of the `m.started` guard.

`Stop` owns the whole teardown instead of delegating to `stopProcess`. With the locking moved inside, the wrapper was a one-line delegation with a single other caller. It holds `m.mu` only for the field reads and releases it before waiting on the process, so `Status()`, `Port()`, and `IsRunning()` keep answering while a stop is in flight. Previously both callers held the lock across a wait of up to 10 seconds.

A failed `terminateProcess` no longer ends the stop. A lost process group, or one that is not ours, still leaves a child to collect, and the wait is what collects it. The manager's `terminateFn` field is a seam for the test, because making a real `kill(2)` fail means signalling a pid we do not own.

### One reaper, watched by everyone

`Stop` cleared `m.cmd` while `doStart` could still be inside `waitForReady`, which read `m.cmd.ProcessState` with no lock, so a `TunnelClient.Close` during startup dereferenced a nil pointer. Passing `cmd` in as an argument would have traded that panic for a data race: the `cmd.Wait` that `Stop` ran wrote the `ProcessState` that `waitForReady` read.

The process gets exactly one reaper, started as soon as it is spawned, and neither `waitForReady` nor `Stop` calls `cmd.Wait` itself—both watch the channel it closes. Closing rather than sending matters, since a sent value would reach only whichever of the two arrived first and leave the other waiting out its full timeout.

The reaper hands out a receive-only channel, and logs the exit status at debug level. That status is the only account of why code-server died, and `waitForReady` can report the exit but not what it was.

### The stop timeout

`codeServerStopGrace` names the ten seconds a process gets after SIGTERM. It is the default for the manager's own `stopGrace` field, so a test shortens the grace on its manager instead of on a package-level var the whole package shares. The timeout branch is the one case where `Stop` returns an error, because it is the one case where it cannot confirm the process is gone.

That branch escalates through `killProcess` rather than calling `terminateProcess` again, which would only re-send a SIGTERM the group has already ignored—that helper reaches for SIGKILL solely when the `kill(2)` itself fails. `killProcess` signals the process group on Unix, and is `Process.Kill` on Windows, where there is no signal to ignore in the first place. The group is the point: `exec.CommandContext` already issues a leader-only kill on context cancel, which is what hid the defect, and code-server's children are spawned into the same group, so they outlive it.

The grace is a `time.NewTimer`, and the branch looks at the reaper channel once more before killing anything. `select` chooses at random among ready cases, so a process that exited just as the grace expired could otherwise be reported as a timeout and sent a SIGKILL it no longer needed.

The log reports the attempt rather than the outcome, since `killProcess` can fail too and the old pair of lines then contradicted itself: a `Failed to kill` warning followed by `code-server killed after timeout`. One line now carries the grace and the kill error as fields, and zerolog omits the error field when there is none.

### Readiness polling

`waitForReady` polls with a `time.Ticker` and a `time.Timer` it stops on return, instead of building a timer per iteration and holding a deadline it could not release. That is what `waitForDaemonReady` in `pkg/runner/tunnel_relay_unix.go` already does, so the two readiness waits read the same way. The two one-second values are named, being separate decisions that happen to share a number.

The loop looks at the reaper channel before it dials rather than after. A port that another process takes the moment code-server dies answers a dial just as well, and in the old order that set `m.started` on a dead process. The exit is reported at the head of the loop alone, so the message is written in one place.

## Testing

New file `pkg/runner/editor_unix_test.go`, tagged `!windows` because it needs `SysProcAttr.Setpgid` and a real child process. One further test needs no child and lives in the existing `pkg/runner/editor_test.go`. Every test was seen RED by reverting the line it covers.

| Test | Asserts | Regression it catches |
| --- | --- | --- |
| `TestStopBeforeStarted` | the process is reaped and died from SIGTERM, and the context is cancelled | the `!m.started` guard, this bug |
| `TestStopTwice` | a second `Stop` is a no-op and `m.cmd` is cleared | dropping `m.cmd = nil`, which signals a reaped pid |
| `TestStopWithoutProcess` | the context is cancelled with no process present | cancelling only when a process exists |
| `TestStopClearsRunningState` | `IsRunning()` is false afterwards | dropping `m.started = false` |
| `TestStopKeepsStatusAnswerable` | `m.mu` is free while `Stop` waits | holding the lock across the wait |
| `TestStopWaitsAfterSignalFailure` | `Stop` returns nil and the process is reaped although signalling failed | returning early on a failed signal, which skips the wait |
| `TestWaitForReadySurvivesConcurrentStop` | `waitForReady` reports the exit instead of panicking when `Stop` runs beside it | reading `m.cmd` from `waitForReady` |
| `TestStopKillsGroupIgnoringSIGTERM` | every member of the group has released the pipe once `Stop` reports the timeout | re-sending SIGTERM instead of escalating, which leaves the group running |
| `TestWaitForReadyChecksTheExitBeforeTheDial` | the exit is reported although the port answers | dialling before the exit check, which reads a foreign listener as our server |

`TestStopKeepsStatusAnswerable` uses a child that ignores SIGTERM and reports receiving it, so `Stop` is pinned inside its wait with no sleep or deadline in the test, and checks the lock with `m.mu.TryRLock()`. `testing/synctest` does not fit here: its clock only advances while every goroutine in the bubble is blocked on a channel, mutex, or timer, and `cmd.Wait()` blocks in a syscall.

`TestStopKillsGroupIgnoringSIGTERM` reads the child's pipe to EOF rather than calling `kill(-pgid, 0)`. Signal 0 answers for a zombie as well as a live process, and in the distribution images the test binary is PID 1, so the orphaned inner shell is reparented to something that never reaps it. A process releases its descriptors at exit, before it becomes a zombie, so EOF is the portable proof. It was seen red and green under `golang:1.25.13` as well as on darwin.

Every test cleans up through `killGroupOnCleanup`, which skips the kill once the reaper has closed and otherwise waits for the reap and fails the test if the group outlives it. Killing unconditionally would signal a pid that is free for reuse, which is the very thing `Stop` checks for before it signals anything.

The two tests that drive a shell share `newManagerWithScript`, which puts it in its own process group and reads the `ready` line it prints before returning. The handshake is what makes those tests honest: a SIGTERM that arrives before the script installs its trap kills it by the default disposition, and the test then passes against the unfixed code. Both the grace and the signal seam are per-manager, so no test depends on another restoring a global.

Two changes carry no test of their own. The `select` tie needs both cases to become ready in the same scheduling instant, which is a coincidence rather than a state a test can arrange, and the timeout log change leaves the returned error exactly as it was.

Checks run on darwin/arm64:

| Check | Result |
| --- | --- |
| `go test ./... -p 1` | 46 packages ok, no failures |
| `go test -race ./pkg/runner/` | ok |
| `go vet ./pkg/runner/` | clean |
| `GOOS=windows go vet ./pkg/runner/` | clean |
| `gofmt -l pkg/runner/` | clean |

The new tests also run on Linux, so the distribution jobs on this PR are the check for that; they are excluded on Windows, where code-server is unsupported (`pkg/runner/tunnel_windows.go`).

## Follow-up

Three residuals of the same defect class predate this PR and are tracked in #454: a `Stop` landing in the spawn window before `m.cmd` is published, an already-reaped leader whose children go unsignalled, and a clean stop leaving `m.status` stale.

Closes #448

