### PR TITLE
ci: expose a flat build-and-test check over the platform matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -122,10 +122,6 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
-      - name: TEMPORARY - fail one matrix leg to prove the aggregate reports red
-        if: matrix.distro == 'ubuntu-24.04'
-        run: exit 1
-
       - name: Install dependencies (Debian/Ubuntu)
         if: matrix.pkg_manager == 'apt-get'
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,10 @@ jobs:
           go mod tidy
           git diff --exit-code go.mod go.sum
 
-  build-and-test:
+  # Renamed from `build-and-test` so the flat aggregator at the bottom of this
+  # file can take that id: a job id and the aggregate check name cannot be the
+  # same string, and the aggregate is the one that has to be `build-and-test`.
+  build-and-test-linux:
     name: Build and Test (${{ matrix.distro }})
     runs-on: ${{ matrix.runner }}
     # PATH is pinned because the runner rebuilds each exec PATH from the container config, and opensuse/leap:15 alone defines none.
@@ -256,3 +259,43 @@ jobs:
 
       - name: Run Tests
         run: go test -v ./... -p 1
+
+  # The aggregate check. Every job above is matrixed or platform-specific, so
+  # each reports under a name that carries its distro—nineteen strings that
+  # change whenever the matrix does. A name that moves cannot be a required
+  # status check: a ruleset naming one that stops reporting leaves the pull
+  # request pending forever rather than red. This job is the one flat,
+  # stable string the matrix can be gated on.
+  #
+  # No `name:`, so the context is the job id: `build-and-test`, matching the
+  # other Go repositories.
+  #
+  # `if: always()` is load-bearing. Without it a failed leg SKIPS this job, and
+  # a skipped check run counts as PASSING for a required status check—so the
+  # gate would go green exactly when it has to go red. Running is not enough
+  # either: a job that runs and does nothing reports success whatever its legs
+  # did, hence the explicit check below.
+  build-and-test:
+    needs:
+      - verify-tidy
+      - build-and-test-linux
+      - build-and-test-windows
+      - build-and-test-macos
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # Anything other than `success` fails, so a cancelled or skipped leg is
+      # a failure too. No job here is conditional, so a skip means something
+      # went wrong upstream rather than a leg that correctly opted out.
+      - name: Require every job to have succeeded
+        # Through the environment rather than interpolated into the script:
+        # the values are GitHub's own job results, but keeping `${{ }}` out of
+        # `run:` is the habit that stops a future edit from pasting attacker
+        # input into a shell.
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "results: $RESULTS"
+          for r in $RESULTS; do
+            [ "$r" = success ] || exit 1
+          done

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -122,6 +122,10 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
+      - name: TEMPORARY - fail one matrix leg to prove the aggregate reports red
+        if: matrix.distro == 'ubuntu-24.04'
+        run: exit 1
+
       - name: Install dependencies (Debian/Ubuntu)
         if: matrix.pkg_manager == 'apt-get'
         run: |


### PR DESCRIPTION
## What

Adds a flat aggregating job with the id `build-and-test` to `build-and-test.yml`, and moves the distro matrix to `build-and-test-linux` so the aggregate can take that id.

## Why

Every build job in this workflow reports under a name that carries its platform: `Build and Test (almalinux-9)` and eighteen siblings, from the seventeen-distro matrix plus the separate Windows and macOS jobs. A matrixed name is not a stable string — it changes whenever the matrix does. A branch rule naming one stops being satisfiable the moment a distro is added or dropped, and the pull request then waits forever on a check that no longer reports, rather than going red.

The aggregate is one flat string that survives changes to the matrix.

## Shape

```yaml
  build-and-test:
    needs:
      - verify-tidy
      - build-and-test-linux
      - build-and-test-windows
      - build-and-test-macos
    if: always()
    runs-on: ubuntu-latest
    steps:
      - name: Require every job to have succeeded
        env:
          RESULTS: ${{ join(needs.*.result, ' ') }}
        run: |
          echo "results: $RESULTS"
          for r in $RESULTS; do
            [ "$r" = success ] || exit 1
          done
```

Both halves are load-bearing. Without `if: always()` a failed dependency *skips* the aggregate, and a skipped check counts as a pass — the gate would go green precisely when it has to go red. And `always()` alone is not enough either: a job that runs and does nothing reports success whatever its dependencies did, hence the explicit result loop.

The results are read strictly: anything other than `success` fails, so a cancelled or skipped dependency is a failure too. No job in this workflow is conditional, so a skip means something went wrong upstream rather than a job that correctly opted out.

## Contexts

No job `name:` changes, so all nineteen existing contexts are exactly as they were. One is added.

| | Before | After |
| --- | --- | --- |
| Pull request | `Build and Test (<platform>)` x19, `Verify go.mod and go.sum are tidy` | unchanged, plus `build-and-test` |
| Tag (`release.yml` calls this workflow) | `build-and-test / Build and Test (<platform>)` x19, `build-and-test / Verify go.mod and go.sum are tidy` | unchanged, plus `build-and-test / build-and-test` |

`release.yml`'s caller job keeps its own id, and its `needs:` points at that caller job, so the tag path is unaffected.

## Verification

- `actionlint` clean across all workflows in the repo.
- No `paths:` or `branches:` filter on the `pull_request` trigger, so the context reports on every pull request.
- The aggregate was proven able to fail, not merely to exist: a temporary commit failed one matrix leg, and the aggregate ran and reported red rather than skipping. Reverted before merge; see the run history on this branch.