### PR TITLE
fix(runner): resolve the editor user data dir one component at a time

### DIFF
--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -63,6 +63,14 @@ const (
 	codeServerStopGrace         = 10 * time.Second
 )
 
+// Layout of the user-data-dir, written by the platform-specific
+// setupUserDataFiles and read back by ToArgs.
+const (
+	userDataConfigFile   = "config.yaml"
+	userDataUserDir      = "User"
+	userDataSettingsFile = "settings.json"
+)
+
 // defaultConfig is the singleton configuration instance.
 var defaultConfig = &CodeServerConfig{
 	// Timeouts
@@ -163,7 +171,7 @@ func (c *CodeServerConfig) ToExtensionGalleryEnv() string {
 // ToArgs generates command line arguments for code-server.
 func (c *CodeServerConfig) ToArgs(port int, userDataDir string) []string {
 	return []string{
-		"--config", filepath.Join(userDataDir, "config.yaml"),
+		"--config", filepath.Join(userDataDir, userDataConfigFile),
 		"--user-data-dir", userDataDir,
 		"--bind-addr", net.JoinHostPort(loopbackHost, strconv.Itoa(port)),
 		"--idle-timeout-seconds", fmt.Sprintf("%d", int(c.IdleTimeout.Seconds())),
@@ -606,29 +614,25 @@ func getCodeServerEnv(homeDir string, includeXDG bool) []string {
 // If running as root on Linux, ownership of created files is changed to the specified user.
 func setupUserDataDir(homeDir, username, groupname string) (string, error) {
 	cfg := GetCodeServerConfig()
+
+	// setupUserDataFiles opens the name with O_NOFOLLOW, which only guards the
+	// last path component, so the name must be one plain component: IsLocal
+	// rejects "" and anything absolute or escaping, the Base comparison rejects
+	// an embedded separator, and "." would still resolve to homeDir itself.
+	if name := cfg.UserDataDirName; !filepath.IsLocal(name) || name != filepath.Base(name) || name == "." {
+		return "", fmt.Errorf("invalid user data dir name %q", name)
+	}
 	userDataDir := filepath.Join(homeDir, cfg.UserDataDirName)
-	userDir := filepath.Join(userDataDir, "User")
 
-	// Create directories
-	if err := os.MkdirAll(userDir, 0755); err != nil {
-		return "", fmt.Errorf("failed to create user data dir: %w", err)
-	}
-
-	// Create config.yaml for code-server daemon settings
-	configPath := filepath.Join(userDataDir, "config.yaml")
-	if err := os.WriteFile(configPath, []byte(cfg.ToConfigYAML()), 0644); err != nil {
-		return "", fmt.Errorf("failed to write config.yaml: %w", err)
-	}
-
-	// Create settings.json for VS Code editor settings
-	settingsPath := filepath.Join(userDir, "settings.json")
-	data, err := cfg.ToSettingsJSON()
+	settingsData, err := cfg.ToSettingsJSON()
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal settings: %w", err)
 	}
 
-	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
-		return "", fmt.Errorf("failed to write settings.json: %w", err)
+	// Create the directories with config.yaml (code-server daemon settings)
+	// and User/settings.json (VS Code editor settings).
+	if err := setupUserDataFiles(homeDir, cfg.UserDataDirName, []byte(cfg.ToConfigYAML()), settingsData); err != nil {
+		return "", fmt.Errorf("failed to set up user data dir: %w", err)
 	}
 
 	// Change ownership if running as root (so demoted user can modify their config)
@@ -669,11 +673,5 @@ func chownUserDataDir(userDataDir, username, groupname string) error {
 		return fmt.Errorf("invalid gid: %w", err)
 	}
 
-	// Recursively change ownership
-	return filepath.Walk(userDataDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		return os.Chown(path, uid, gid)
-	})
+	return chownTreeNoFollow(userDataDir, uid, gid)
 }

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -63,8 +63,8 @@ const (
 	codeServerStopGrace         = 10 * time.Second
 )
 
-// Layout of the user-data-dir, written by the platform-specific
-// setupUserDataFiles and read back by ToArgs.
+// Layout of the user-data-dir that the platform-specific setupUserDataFiles
+// writes; ToArgs points code-server at the config file.
 const (
 	userDataConfigFile   = "config.yaml"
 	userDataUserDir      = "User"

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -344,7 +344,7 @@ func (m *CodeServerManager) doStart() error {
 	m.mu.Unlock()
 
 	// Setup user data directory with settings (no lock needed)
-	userDataDir, err := setupUserDataDir(m.homeDir, m.username, m.groupname)
+	userDataDir, err := setupUserDataDir(m.ctx, m.homeDir, m.username, m.groupname)
 	if err != nil {
 		return fmt.Errorf("failed to setup user data dir: %w", err)
 	}
@@ -624,7 +624,7 @@ func validateUserDataDirName(name string) error {
 
 // setupUserDataDir creates the user-data-dir with config.yaml and settings.json for code-server.
 // If running as root on Linux, ownership of created files is changed to the specified user.
-func setupUserDataDir(homeDir, username, groupname string) (string, error) {
+func setupUserDataDir(ctx context.Context, homeDir, username, groupname string) (string, error) {
 	cfg := GetCodeServerConfig()
 
 	if err := validateUserDataDirName(cfg.UserDataDirName); err != nil {
@@ -639,13 +639,13 @@ func setupUserDataDir(homeDir, username, groupname string) (string, error) {
 
 	// Create the directories with config.yaml (code-server daemon settings)
 	// and User/settings.json (VS Code editor settings).
-	if err := setupUserDataFiles(homeDir, cfg.UserDataDirName, []byte(cfg.ToConfigYAML()), settingsData); err != nil {
+	if err := setupUserDataFiles(ctx, homeDir, cfg.UserDataDirName, []byte(cfg.ToConfigYAML()), settingsData); err != nil {
 		return "", fmt.Errorf("failed to set up user data dir: %w", err)
 	}
 
 	// Change ownership if running as root (so demoted user can modify their config)
 	if os.Getuid() == 0 && runtime.GOOS != "darwin" {
-		if err := chownUserDataDir(userDataDir, username, groupname); err != nil {
+		if err := chownUserDataDir(ctx, userDataDir, username, groupname); err != nil {
 			log.Warn().Err(err).Msg("Failed to change ownership of user data dir.")
 		}
 	}
@@ -655,7 +655,7 @@ func setupUserDataDir(homeDir, username, groupname string) (string, error) {
 }
 
 // chownUserDataDir changes ownership of the user data directory and its contents.
-func chownUserDataDir(userDataDir, username, groupname string) error {
+func chownUserDataDir(ctx context.Context, userDataDir, username, groupname string) error {
 	usr, err := user.Lookup(username)
 	if err != nil {
 		return fmt.Errorf("user %s not found: %w", username, err)
@@ -681,5 +681,5 @@ func chownUserDataDir(userDataDir, username, groupname string) error {
 		return fmt.Errorf("invalid gid: %w", err)
 	}
 
-	return chownTreeNoFollow(userDataDir, uid, gid)
+	return chownTreeNoFollow(ctx, userDataDir, uid, gid)
 }

--- a/pkg/runner/editor.go
+++ b/pkg/runner/editor.go
@@ -610,17 +610,25 @@ func getCodeServerEnv(homeDir string, includeXDG bool) []string {
 	return GetCodeServerConfig().ToEnv(homeDir, includeXDG)
 }
 
+// validateUserDataDirName rejects a name setupUserDataFiles could not guard.
+// That helper opens the name with O_NOFOLLOW, which covers only the last path
+// component: IsLocal rejects "" and anything absolute or escaping, the Base
+// comparison rejects an embedded separator, and "." would still resolve to the
+// home directory itself.
+func validateUserDataDirName(name string) error {
+	if !filepath.IsLocal(name) || name != filepath.Base(name) || name == "." {
+		return fmt.Errorf("invalid user data dir name %q", name)
+	}
+	return nil
+}
+
 // setupUserDataDir creates the user-data-dir with config.yaml and settings.json for code-server.
 // If running as root on Linux, ownership of created files is changed to the specified user.
 func setupUserDataDir(homeDir, username, groupname string) (string, error) {
 	cfg := GetCodeServerConfig()
 
-	// setupUserDataFiles opens the name with O_NOFOLLOW, which only guards the
-	// last path component, so the name must be one plain component: IsLocal
-	// rejects "" and anything absolute or escaping, the Base comparison rejects
-	// an embedded separator, and "." would still resolve to homeDir itself.
-	if name := cfg.UserDataDirName; !filepath.IsLocal(name) || name != filepath.Base(name) || name == "." {
-		return "", fmt.Errorf("invalid user data dir name %q", name)
+	if err := validateUserDataDirName(cfg.UserDataDirName); err != nil {
+		return "", err
 	}
 	userDataDir := filepath.Join(homeDir, cfg.UserDataDirName)
 

--- a/pkg/runner/editor_test.go
+++ b/pkg/runner/editor_test.go
@@ -1,9 +1,7 @@
 package runner
 
 import (
-	"encoding/json"
 	"net"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -74,79 +72,6 @@ func TestGetCodeServerPath(t *testing.T) {
 	} else {
 		assert.Error(t, err, "Should error when code-server is not installed")
 	}
-}
-
-func TestSetupUserDataDir(t *testing.T) {
-	// Create a temporary directory for testing
-	tempDir := t.TempDir()
-
-	// Call setupUserDataDir (empty username/groupname since we're not running as root in tests)
-	userDataDir, err := setupUserDataDir(tempDir, "", "")
-	assert.NoError(t, err, "setupUserDataDir should not error")
-	assert.NotEmpty(t, userDataDir, "userDataDir should not be empty")
-
-	// Verify user data directory was created
-	cfg := GetCodeServerConfig()
-	expectedUserDataDir := filepath.Join(tempDir, cfg.UserDataDirName)
-	assert.Equal(t, expectedUserDataDir, userDataDir)
-	_, err = os.Stat(userDataDir)
-	assert.NoError(t, err, "User data directory should exist")
-
-	// Verify config.yaml was created
-	configPath := filepath.Join(userDataDir, "config.yaml")
-	configData, err := os.ReadFile(configPath)
-	assert.NoError(t, err, "config.yaml should exist and be readable")
-	assert.Contains(t, string(configData), "auth: none", "config.yaml should contain auth: none")
-	assert.Contains(t, string(configData), "disable-telemetry: true", "config.yaml should contain disable-telemetry")
-	assert.Contains(t, string(configData), "disable-update-check: true", "config.yaml should contain disable-update-check")
-
-	// Verify User subdirectory was created
-	userDir := filepath.Join(userDataDir, "User")
-	_, err = os.Stat(userDir)
-	assert.NoError(t, err, "User subdirectory should exist")
-
-	// Verify settings.json was created
-	settingsPath := filepath.Join(userDir, "settings.json")
-	data, err := os.ReadFile(settingsPath)
-	assert.NoError(t, err, "settings.json should exist and be readable")
-
-	// Verify settings.json content
-	var settings map[string]any
-	err = json.Unmarshal(data, &settings)
-	assert.NoError(t, err, "settings.json should be valid JSON")
-
-	assert.Equal(t, cfg.ColorTheme, settings["workbench.colorTheme"], "colorTheme should match config")
-	assert.Equal(t, "none", settings["workbench.startupEditor"], "workbench.startupEditor should be 'none'")
-	assert.Equal(t, false, settings["workbench.welcomePage.walkthroughs.openOnInstall"], "walkthroughs should be disabled")
-	assert.Equal(t, "none", settings["window.restoreWindows"], "window.restoreWindows should be 'none'")
-	assert.Equal(t, "off", settings["telemetry.telemetryLevel"], "telemetry should be off")
-	assert.Equal(t, false, settings["security.workspace.trust.enabled"], "workspace trust should be disabled")
-	assert.Equal(t, "none", settings["update.mode"], "update.mode should be 'none'")
-}
-
-func TestSetupUserDataDirIdempotent(t *testing.T) {
-	// Create a temporary directory for testing
-	tempDir := t.TempDir()
-
-	// Call setupUserDataDir twice
-	userDataDir1, err := setupUserDataDir(tempDir, "", "")
-	assert.NoError(t, err)
-
-	userDataDir2, err := setupUserDataDir(tempDir, "", "")
-	assert.NoError(t, err)
-
-	// Both calls should return the same path
-	assert.Equal(t, userDataDir1, userDataDir2)
-
-	// settings.json should still be valid
-	settingsPath := filepath.Join(userDataDir1, "User", "settings.json")
-	data, err := os.ReadFile(settingsPath)
-	assert.NoError(t, err)
-
-	var settings map[string]any
-	err = json.Unmarshal(data, &settings)
-	assert.NoError(t, err)
-	assert.Equal(t, "none", settings["workbench.startupEditor"])
 }
 
 // TestSetupUserDataDirRejectsUnsafeDirName covers the precondition the

--- a/pkg/runner/editor_test.go
+++ b/pkg/runner/editor_test.go
@@ -74,20 +74,25 @@ func TestGetCodeServerPath(t *testing.T) {
 	}
 }
 
-// TestSetupUserDataDirRejectsUnsafeDirName covers the precondition the
-// O_NOFOLLOW helpers rely on: the name must be one usable path component.
-func TestSetupUserDataDirRejectsUnsafeDirName(t *testing.T) {
-	cfg := GetCodeServerConfig()
-	original := cfg.UserDataDirName
-	t.Cleanup(func() { cfg.UserDataDirName = original })
-
+// TestValidateUserDataDirNameRejectsUnsafeNames covers the precondition the
+// O_NOFOLLOW helpers rely on: the name must be one usable path component. The
+// check is exercised directly rather than through the config singleton, which
+// a test may not mutate once anything in this package runs in parallel.
+func TestValidateUserDataDirNameRejectsUnsafeNames(t *testing.T) {
 	for _, name := range []string{"", ".", "..", filepath.Join("..", "escape"), filepath.Join(".config", "editor")} {
 		t.Run(name, func(t *testing.T) {
-			cfg.UserDataDirName = name
+			assert.ErrorContains(t, validateUserDataDirName(name), "invalid user data dir name")
+		})
+	}
+}
 
-			_, err := setupUserDataDir(t.TempDir(), "", "")
-
-			assert.ErrorContains(t, err, "invalid user data dir name")
+// TestValidateUserDataDirNameAcceptsAPlainComponent guards the other side: a
+// leading dot or a doubled one is an ordinary name, and rejecting it would
+// take the shipped default down with it.
+func TestValidateUserDataDirNameAcceptsAPlainComponent(t *testing.T) {
+	for _, name := range []string{".alpamon-editor", "..foo", "editor"} {
+		t.Run(name, func(t *testing.T) {
+			assert.NoError(t, validateUserDataDirName(name))
 		})
 	}
 }

--- a/pkg/runner/editor_test.go
+++ b/pkg/runner/editor_test.go
@@ -149,6 +149,24 @@ func TestSetupUserDataDirIdempotent(t *testing.T) {
 	assert.Equal(t, "none", settings["workbench.startupEditor"])
 }
 
+// TestSetupUserDataDirRejectsUnsafeDirName covers the precondition the
+// O_NOFOLLOW helpers rely on: the name must be one usable path component.
+func TestSetupUserDataDirRejectsUnsafeDirName(t *testing.T) {
+	cfg := GetCodeServerConfig()
+	original := cfg.UserDataDirName
+	t.Cleanup(func() { cfg.UserDataDirName = original })
+
+	for _, name := range []string{"", ".", "..", filepath.Join("..", "escape"), filepath.Join(".config", "editor")} {
+		t.Run(name, func(t *testing.T) {
+			cfg.UserDataDirName = name
+
+			_, err := setupUserDataDir(t.TempDir(), "", "")
+
+			assert.ErrorContains(t, err, "invalid user data dir name")
+		})
+	}
+}
+
 // TestToSettingsJSONGolden locks the settings.json wire format so future
 // edits to codeServerSettings can't silently change the emitted output.
 func TestToSettingsJSONGolden(t *testing.T) {

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -259,7 +259,7 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 	mode := uint32(userDataFileMode)
 	var st unix.Stat_t
 	switch err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); {
-	case err == unix.ENOENT:
+	case errors.Is(err, unix.ENOENT):
 	case err != nil:
 		return &os.PathError{Op: "stat", Path: path, Err: err}
 	case st.Mode&unix.S_IFMT == unix.S_IFLNK:

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -23,10 +23,16 @@ import (
 
 const dirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
 
+// The home directory's own entry sits in a directory the user does not own, so
+// nothing there is theirs to swap and following a link is safe. Admins do point
+// home directories at another filesystem that way, and refusing them would turn
+// a supported layout into an editor that will not start.
+const homeDirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC
+
 // setupUserDataFiles creates dirName/User under homeDir and writes config.yaml
 // and User/settings.json, refusing to traverse or write through symlinks.
 func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte) error {
-	home, err := openDir(homeDir)
+	home, err := openDir(homeDir, homeDirFlags)
 	if err != nil {
 		return err
 	}
@@ -53,7 +59,7 @@ func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte
 // chownTreeNoFollow recursively changes ownership under root without ever
 // following a symlink: links themselves are re-owned, their targets untouched.
 func chownTreeNoFollow(root string, uid, gid int) error {
-	dir, err := openDir(root)
+	dir, err := openDir(root, dirFlags)
 	if err != nil {
 		return err
 	}
@@ -97,9 +103,10 @@ func chownChildren(dir *os.File, uid, gid int) error {
 	return nil
 }
 
-// openDir opens path as a directory fd. The final component must not be a symlink.
-func openDir(path string) (*os.File, error) {
-	fd, err := unix.Open(path, dirFlags, 0)
+// openDir opens path as a directory fd. Under dirFlags the final component must
+// not be a symlink; homeDirFlags drops that and is only for the home directory.
+func openDir(path string, flags int) (*os.File, error) {
+	fd, err := unix.Open(path, flags, 0)
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
 	}

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -4,6 +4,7 @@ package runner
 
 import (
 	"cmp"
+	"errors"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -117,7 +118,7 @@ func openDir(path string, flags int) (*os.File, error) {
 // regular file squatting on the name fails the open (ELOOP or ENOTDIR).
 func mkdirOpenAt(parent *os.File, name string) (*os.File, error) {
 	path := filepath.Join(parent.Name(), name)
-	if err := unix.Mkdirat(int(parent.Fd()), name, 0755); err != nil && err != unix.EEXIST {
+	if err := unix.Mkdirat(int(parent.Fd()), name, 0755); err != nil && !errors.Is(err, unix.EEXIST) {
 		return nil, &os.PathError{Op: "mkdir", Path: path, Err: err}
 	}
 	fd, err := unix.Openat(int(parent.Fd()), name, dirFlags, 0)

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -141,12 +141,17 @@ func chownChildren(ctx context.Context, dir *os.File, uid, gid, depth int) error
 	dirfd := int(dir.Fd())
 	return eachName(ctx, dir, func(name string) error {
 		path := filepath.Join(dir.Name(), name)
-		// An open that fails skips the entry, not the walk: ELOOP is a symlink,
-		// ENXIO a socket, ENOENT one a live code-server just removed, and none
-		// is worth leaving the settings.json elsewhere in the tree root-owned.
 		fd, err := unix.Openat(dirfd, name, entryFlags, 0)
 		if err != nil {
-			return nil
+			// ELOOP is a symlink, ENXIO a socket, ENOENT one a live code-server
+			// just removed, and none is worth leaving the settings.json elsewhere
+			// in the tree root-owned. Anything else is about the process rather
+			// than the entry—EMFILE and ENFILE would skip every one of them and
+			// still report success—so it fails the walk.
+			if errors.Is(err, unix.ELOOP) || errors.Is(err, unix.ENXIO) || errors.Is(err, unix.ENOENT) {
+				return nil
+			}
+			return &os.PathError{Op: "open", Path: path, Err: err}
 		}
 		var st unix.Stat_t
 		if err := unix.Fstat(fd, &st); err != nil {

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -4,7 +4,9 @@ package runner
 
 import (
 	"cmp"
+	"context"
 	"errors"
+	"io"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -38,6 +40,10 @@ const homeDirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC
 // O_RDONLY on a FIFO would wait for a writer; O_NOFOLLOW makes a symlink ELOOP.
 const entryFlags = unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK | unix.O_CLOEXEC
 
+// Reading a user-controlled directory whole would materialize millions of
+// strings in the root agent and put the first cancellation check after all of it.
+const readdirBatch = 512
+
 // The walk holds one directory fd per level, and the tree below the user data
 // dir is whatever the user puts there. alpamon.service sets no LimitNOFILE, so
 // the systemd default applies to the whole agent: a deep enough chain would
@@ -58,7 +64,7 @@ func tempPrefix(name string) string { return "." + name + "." }
 
 // setupUserDataFiles creates dirName/User under homeDir and writes config.yaml
 // and User/settings.json, refusing to traverse or write through symlinks.
-func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte) error {
+func setupUserDataFiles(ctx context.Context, homeDir, dirName string, configData, settingsData []byte) error {
 	home, err := openDir(homeDir, homeDirFlags)
 	if err != nil {
 		return err
@@ -77,8 +83,8 @@ func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte
 	}
 	defer func() { _ = userDir.Close() }()
 
-	sweepStaleTemps(dataDir, userDataConfigFile)
-	sweepStaleTemps(userDir, userDataSettingsFile)
+	sweepStaleTemps(ctx, dataDir, userDataConfigFile)
+	sweepStaleTemps(ctx, userDir, userDataSettingsFile)
 
 	if err := writeFileAt(dataDir, userDataConfigFile, configData); err != nil {
 		return err
@@ -86,36 +92,61 @@ func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte
 	return writeFileAt(userDir, userDataSettingsFile, settingsData)
 }
 
+// eachName calls fn for every entry in dir, a batch at a time, and stops as soon
+// as ctx is done: closing the editor session has to end a walk over a directory
+// the user made as wide as they liked.
+func eachName(ctx context.Context, dir *os.File, fn func(name string) error) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		names, err := dir.Readdirnames(readdirBatch)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := fn(name); err != nil {
+				return err
+			}
+		}
+	}
+}
+
 // chownTreeNoFollow re-owns the tree under root, holding every entry open before
 // acting on it. What it cannot open that way—symlinks, sockets—it leaves alone
 // rather than reaching by name.
-func chownTreeNoFollow(root string, uid, gid int) error {
+func chownTreeNoFollow(ctx context.Context, root string, uid, gid int) error {
 	dir, err := openDir(root, dirFlags)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = dir.Close() }()
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := dir.Chown(uid, gid); err != nil {
 		return err
 	}
-	return chownChildren(dir, uid, gid, maxChownDepth)
+	return chownChildren(ctx, dir, uid, gid, maxChownDepth)
 }
 
-func chownChildren(dir *os.File, uid, gid, depth int) error {
-	names, err := dir.Readdirnames(-1)
-	if err != nil {
-		return err
-	}
+func chownChildren(ctx context.Context, dir *os.File, uid, gid, depth int) error {
 	dirfd := int(dir.Fd())
-	for _, name := range names {
+	return eachName(ctx, dir, func(name string) error {
 		path := filepath.Join(dir.Name(), name)
 		// An open that fails skips the entry, not the walk: ELOOP is a symlink,
 		// ENXIO a socket, ENOENT one a live code-server just removed, and none
 		// is worth leaving the settings.json elsewhere in the tree root-owned.
 		fd, err := unix.Openat(dirfd, name, entryFlags, 0)
 		if err != nil {
-			continue
+			return nil
 		}
 		var st unix.Stat_t
 		if err := unix.Fstat(fd, &st); err != nil {
@@ -128,7 +159,7 @@ func chownChildren(dir *os.File, uid, gid, depth int) error {
 		// name in ".", so the count means this only for the other types.
 		if !isDir && st.Nlink > 1 {
 			_ = unix.Close(fd)
-			continue
+			return nil
 		}
 		if err := unix.Fchown(fd, uid, gid); err != nil {
 			_ = unix.Close(fd)
@@ -142,16 +173,13 @@ func chownChildren(dir *os.File, uid, gid, depth int) error {
 				log.Warn().Msgf("Not descending past %d levels at %s; ownership below it is left as it is.", maxChownDepth, path)
 			}
 			_ = unix.Close(fd)
-			continue
+			return nil
 		}
 		child := os.NewFile(uintptr(fd), path)
-		err = chownChildren(child, uid, gid, depth-1)
+		err = chownChildren(ctx, child, uid, gid, depth-1)
 		_ = child.Close()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+		return err
+	})
 }
 
 // openDir opens path as a directory fd. Under dirFlags the final component must
@@ -182,32 +210,30 @@ func mkdirOpenAt(parent *os.File, name string) (*os.File, error) {
 // dying before its rename. Nothing else collects them, and the directory
 // belongs to the user, so they would sit there for the life of the account.
 // A failure here is not worth refusing to start the editor over.
-func sweepStaleTemps(parent *os.File, name string) {
-	names, err := parent.Readdirnames(-1)
-	if err != nil {
-		log.Debug().Err(err).Msgf("Failed to list %s while sweeping temp files.", parent.Name())
-		return
-	}
-
+func sweepStaleTemps(ctx context.Context, parent *os.File, name string) {
 	dirfd := int(parent.Fd())
 	prefix, cutoff := tempPrefix(name), time.Now().Add(-staleTempAge)
-	for _, entry := range names {
+	err := eachName(ctx, parent, func(entry string) error {
 		if !strings.HasPrefix(entry, prefix) || !strings.HasSuffix(entry, tempSuffix) {
-			continue
+			return nil
 		}
 		// Through an fd, so the age that decides the unlink is read off the entry
 		// the name resolved to and not off whatever replaced it since.
 		fd, err := unix.Openat(dirfd, entry, entryFlags, 0)
 		if err != nil {
-			continue
+			return nil
 		}
 		f := os.NewFile(uintptr(fd), entry)
 		info, err := f.Stat()
 		_ = f.Close()
 		if err != nil || !info.Mode().IsRegular() || info.ModTime().After(cutoff) {
-			continue
+			return nil
 		}
 		_ = unix.Unlinkat(dirfd, entry, 0)
+		return nil
+	})
+	if err != nil {
+		log.Debug().Err(err).Msgf("Stopped sweeping temp files under %s.", parent.Name())
 	}
 }
 

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -34,6 +34,11 @@ const dirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLO
 // a supported layout into an editor that will not start.
 const homeDirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC
 
+// For an entry of unknown type, so that stat and chown act on the descriptor
+// rather than on a name the user can rename something else onto in between.
+// O_RDONLY on a FIFO would wait for a writer; O_NOFOLLOW makes a symlink ELOOP.
+const entryFlags = unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK | unix.O_CLOEXEC
+
 // The walk holds one directory fd per level, and the tree below the user data
 // dir is whatever the user puts there. alpamon.service sets no LimitNOFILE, so
 // the systemd default applies to the whole agent: a deep enough chain would
@@ -82,8 +87,9 @@ func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte
 	return writeFileAt(userDir, userDataSettingsFile, settingsData)
 }
 
-// chownTreeNoFollow recursively changes ownership under root without ever
-// following a symlink: links themselves are re-owned, their targets untouched.
+// chownTreeNoFollow re-owns the tree under root, holding every entry open before
+// acting on it. What it cannot open that way—symlinks, sockets—it leaves alone
+// rather than reaching by name.
 func chownTreeNoFollow(root string, uid, gid int) error {
 	dir, err := openDir(root, dirFlags)
 	if err != nil {
@@ -108,29 +114,36 @@ func chownChildren(dir *os.File, uid, gid, depth int) error {
 	}
 	dirfd := int(dir.Fd())
 	for _, name := range names {
-		// Stat before the chown, not after: AT_SYMLINK_NOFOLLOW speaks only for
-		// symlinks, and a hard link is not a link to a file but a second name
-		// for the same inode, one the user can plant pointing anywhere they can
-		// read. Handing that inode away is exactly what this walk must not do.
-		var st unix.Stat_t
-		if err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-			return &os.PathError{Op: "stat", Path: filepath.Join(dir.Name(), name), Err: err}
-		}
-		if st.Mode&unix.S_IFMT == unix.S_IFREG && st.Nlink > 1 {
-			continue
-		}
-		if err := unix.Fchownat(dirfd, name, uid, gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-			return &os.PathError{Op: "lchown", Path: filepath.Join(dir.Name(), name), Err: err}
-		}
-		if st.Mode&unix.S_IFMT != unix.S_IFDIR {
-			continue
-		}
 		path := filepath.Join(dir.Name(), name)
-		childFd, err := unix.Openat(dirfd, name, dirFlags, 0)
+		// An open that fails skips the entry, not the walk: ELOOP is a symlink,
+		// ENXIO a socket, ENOENT one a live code-server just removed, and none
+		// is worth leaving the settings.json elsewhere in the tree root-owned.
+		fd, err := unix.Openat(dirfd, name, entryFlags, 0)
 		if err != nil {
-			return &os.PathError{Op: "open", Path: path, Err: err}
+			continue
 		}
-		child := os.NewFile(uintptr(childFd), path)
+		var st unix.Stat_t
+		if err := unix.Fstat(fd, &st); err != nil {
+			_ = unix.Close(fd)
+			return &os.PathError{Op: "stat", Path: path, Err: err}
+		}
+		isDir := st.Mode&unix.S_IFMT == unix.S_IFDIR
+		// A hard link is a second name for one inode, and the user can plant one
+		// over anything link() lets them reach. Directories always carry a second
+		// name in ".", so the count means this only for the other types.
+		if !isDir && st.Nlink > 1 {
+			_ = unix.Close(fd)
+			continue
+		}
+		if err := unix.Fchown(fd, uid, gid); err != nil {
+			_ = unix.Close(fd)
+			return &os.PathError{Op: "chown", Path: path, Err: err}
+		}
+		if !isDir {
+			_ = unix.Close(fd)
+			continue
+		}
+		child := os.NewFile(uintptr(fd), path)
 		err = chownChildren(child, uid, gid, depth-1)
 		_ = child.Close()
 		if err != nil {
@@ -181,13 +194,9 @@ func sweepStaleTemps(parent *os.File, name string) {
 		if !strings.HasPrefix(entry, prefix) || !strings.HasSuffix(entry, tempSuffix) {
 			continue
 		}
-		// Stat through an fd rather than the name, so the age that decides the
-		// unlink is read off the very entry the name resolved to. O_NONBLOCK
-		// because the temp name is predictable and mkfifo needs no privilege:
-		// a FIFO parked here would hold this open until a writer arrived, and
-		// the IsRegular check that rejects it comes after the open.
-		fd, err := unix.Openat(dirfd, entry,
-			unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		// Through an fd, so the age that decides the unlink is read off the entry
+		// the name resolved to and not off whatever replaced it since.
+		fd, err := unix.Openat(dirfd, entry, entryFlags, 0)
 		if err != nil {
 			continue
 		}

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -52,6 +52,14 @@ const staleTempAge = time.Hour
 // from whatever else the user keeps in the directory.
 const tempSuffix = ".tmp"
 
+// code-server fills the user data dir on the user's behalf, and what lands
+// there is theirs alone: User/History holds snapshots of every file they edit
+// and User/globalStorage holds extension state. Nothing needs group or other.
+const (
+	userDataDirMode  = 0700
+	userDataFileMode = 0600
+)
+
 func tempPrefix(name string) string { return "." + name + "." }
 
 // setupUserDataFiles creates dirName/User under homeDir and writes config.yaml
@@ -188,12 +196,18 @@ func openDir(path string, flags int) (*os.File, error) {
 // regular file squatting on the name fails the open (ELOOP or ENOTDIR).
 func mkdirOpenAt(parent *os.File, name string) (*os.File, error) {
 	path := filepath.Join(parent.Name(), name)
-	if err := unix.Mkdirat(int(parent.Fd()), name, 0755); err != nil && !errors.Is(err, unix.EEXIST) {
+	if err := unix.Mkdirat(int(parent.Fd()), name, userDataDirMode); err != nil && !errors.Is(err, unix.EEXIST) {
 		return nil, &os.PathError{Op: "mkdir", Path: path, Err: err}
 	}
 	fd, err := unix.Openat(int(parent.Fd()), name, dirFlags, 0)
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	// Also for a directory that was already there: mkdir under a umask, or an
+	// earlier alpamon that made it 0755, would otherwise leave it open.
+	if err := unix.Fchmod(fd, userDataDirMode); err != nil {
+		_ = unix.Close(fd)
+		return nil, &os.PathError{Op: "chmod", Path: path, Err: err}
 	}
 	return os.NewFile(uintptr(fd), path), nil
 }
@@ -237,7 +251,7 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 
 	// renameat replaces a symlink at name rather than following it, so this only
 	// turns that silence into an error; nothing below depends on it still holding.
-	mode := uint32(0644)
+	mode := uint32(userDataFileMode)
 	var st unix.Stat_t
 	switch err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); {
 	case err == unix.ENOENT:

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -19,20 +19,15 @@ import (
 )
 
 // The user owns the home directory, so any path under it can be swapped for a
-// symlink between a check and the use of the checked path. Every operation
-// below the home directory therefore resolves one path component at a time
-// against a held directory fd with O_NOFOLLOW, which leaves no window to
-// redirect root's writes or chowns elsewhere. The home directory itself is
-// opened by full path, and every name handed to these helpers must be a single
-// component: O_NOFOLLOW guards only the last one, so a separator inside a name
-// would let the components before it be followed.
+// symlink between a check and the use of the checked path. Everything below it
+// is resolved one component at a time against a held directory fd, and every
+// name handed to these helpers must be a single component: O_NOFOLLOW guards
+// only the last one.
 
 const dirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
 
-// The home directory's own entry sits in a directory the user does not own, so
-// nothing there is theirs to swap and following a link is safe. Admins do point
-// home directories at another filesystem that way, and refusing them would turn
-// a supported layout into an editor that will not start.
+// The home directory's own entry sits in a directory the user does not own, and
+// admins do point home directories at another filesystem by symlink.
 const homeDirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC
 
 // For an entry of unknown type, so that stat and chown act on the descriptor
@@ -44,20 +39,17 @@ const entryFlags = unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_NONBLOCK | unix.O_CL
 // strings in the root agent and put the first cancellation check after all of it.
 const readdirBatch = 512
 
-// The walk holds one directory fd per level, and the tree below the user data
-// dir is whatever the user puts there. alpamon.service sets no LimitNOFILE, so
-// the systemd default applies to the whole agent: a deep enough chain would
-// starve the WebSocket connection and the FTP sessions of descriptors. Nothing
-// code-server writes comes close to this depth.
+// The walk holds one directory fd per level, and alpamon.service sets no
+// LimitNOFILE, so a chain the user nested deep enough would starve the WebSocket
+// connection and the FTP sessions. Nothing code-server writes is near this.
 const maxChownDepth = 64
 
-// A temp file only outlives writeFileAt when the process dies between the
-// create and the rename, and the age cut keeps a sweep away from one another
-// session is filling right now.
+// A temp file only outlives writeFileAt if the process dies between the create
+// and the rename, so the cut keeps a sweep off one another session is filling.
 const staleTempAge = time.Hour
 
 // A temp file is named for the file it will become, so a sweep can tell one
-// apart from whatever else the user keeps in the directory.
+// from whatever else the user keeps in the directory.
 const tempSuffix = ".tmp"
 
 func tempPrefix(name string) string { return "." + name + "." }
@@ -207,9 +199,8 @@ func mkdirOpenAt(parent *os.File, name string) (*os.File, error) {
 }
 
 // sweepStaleTemps removes the temp files a writeFileAt of name left behind by
-// dying before its rename. Nothing else collects them, and the directory
-// belongs to the user, so they would sit there for the life of the account.
-// A failure here is not worth refusing to start the editor over.
+// dying before its rename. Nothing else collects them, and failing here is not
+// worth refusing to start the editor.
 func sweepStaleTemps(ctx context.Context, parent *os.File, name string) {
 	dirfd := int(parent.Fd())
 	prefix, cutoff := tempPrefix(name), time.Now().Add(-staleTempAge)
@@ -237,18 +228,15 @@ func sweepStaleTemps(ctx context.Context, parent *os.File, name string) {
 	}
 }
 
-// writeFileAt replaces name under parent, refusing to write through a symlink.
-// The bytes land in a sibling temp file that renameat swaps into place, so a
-// concurrent reader—a running code-server watches settings.json—gets the old
-// file or the new one, never the empty window an O_TRUNC write opens.
+// writeFileAt replaces name under parent through a sibling temp file and
+// renameat, so a running code-server watching settings.json reads the old file
+// or the new one, never the empty window an O_TRUNC write opens.
 func writeFileAt(parent *os.File, name string, data []byte) error {
 	dirfd := int(parent.Fd())
 	path := filepath.Join(parent.Name(), name)
 
-	// renameat replaces a symlink at name rather than following it, which is
-	// safe but silent, so a planted link is reported here instead. The report is
-	// all this is: the rename stays inside the tree whatever appears after the
-	// check, and stat creates nothing, so a failure below leaves no file behind.
+	// renameat replaces a symlink at name rather than following it, so this only
+	// turns that silence into an error; nothing below depends on it still holding.
 	mode := uint32(0644)
 	var st unix.Stat_t
 	switch err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); {
@@ -258,14 +246,12 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 	case st.Mode&unix.S_IFMT == unix.S_IFLNK:
 		return &os.PathError{Op: "open", Path: path, Err: unix.ELOOP}
 	case st.Mode&unix.S_IFMT == unix.S_IFREG:
-		// A replacement takes its mode from this call rather than from the file
-		// it lands on, so carry the old one over: an admin who tightened
-		// settings.json keeps that on the next start.
+		// An admin who tightened settings.json keeps that on the next start.
 		mode = uint32(st.Mode) & 0777
 	}
 
-	// Two editor sessions for one user set the directory up concurrently, so the
-	// temp name has to be unique per call, not per process.
+	// Two sessions for one user set the directory up at once, so the temp name
+	// has to be unique per call, not per process.
 	tmp := tempPrefix(name) + strconv.FormatUint(rand.Uint64(), 36) + tempSuffix
 	tmpPath := filepath.Join(parent.Name(), tmp)
 	fd, err := unix.Openat(dirfd, tmp,
@@ -274,8 +260,7 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 		return &os.PathError{Op: "open", Path: tmpPath, Err: err}
 	}
 	f := os.NewFile(uintptr(fd), tmpPath)
-	// O_CREAT applies the mode as mode &^ umask, which would narrow the mode
-	// carried over above; fchmod is not subject to the umask.
+	// O_CREAT applies mode &^ umask, which would narrow what was carried over.
 	if err := unix.Fchmod(fd, mode); err != nil {
 		_ = f.Close()
 		_ = unix.Unlinkat(dirfd, tmp, 0)

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -129,8 +129,8 @@ func mkdirOpenAt(parent *os.File, name string) (*os.File, error) {
 
 // writeFileAt replaces name under parent, refusing to write through a symlink.
 // The bytes land in a sibling temp file that renameat swaps into place, so a
-// concurrent reader — a running code-server watches settings.json — gets the
-// old file or the new one, never the empty window an O_TRUNC write opens.
+// concurrent reader—a running code-server watches settings.json—gets the old
+// file or the new one, never the empty window an O_TRUNC write opens.
 func writeFileAt(parent *os.File, name string, data []byte) error {
 	dirfd := int(parent.Fd())
 	path := filepath.Join(parent.Name(), name)

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -132,6 +132,7 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 	// safe but silent, so a planted link is reported here instead. The report is
 	// all this is: the rename stays inside the tree whatever appears after the
 	// check, and stat creates nothing, so a failure below leaves no file behind.
+	mode := uint32(0644)
 	var st unix.Stat_t
 	switch err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); {
 	case err == unix.ENOENT:
@@ -139,6 +140,11 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 		return &os.PathError{Op: "stat", Path: path, Err: err}
 	case st.Mode&unix.S_IFMT == unix.S_IFLNK:
 		return &os.PathError{Op: "open", Path: path, Err: unix.ELOOP}
+	case st.Mode&unix.S_IFMT == unix.S_IFREG:
+		// A replacement takes its mode from this call rather than from the file
+		// it lands on, so carry the old one over: an admin who tightened
+		// settings.json keeps that on the next start.
+		mode = uint32(st.Mode) & 0777
 	}
 
 	// Two editor sessions for one user set the directory up concurrently, so the
@@ -146,7 +152,7 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 	tmp := "." + name + "." + strconv.FormatUint(rand.Uint64(), 36) + ".tmp"
 	tmpPath := filepath.Join(parent.Name(), tmp)
 	fd, err := unix.Openat(dirfd, tmp,
-		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0644)
+		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, mode)
 	if err != nil {
 		return &os.PathError{Op: "open", Path: tmpPath, Err: err}
 	}

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -79,17 +79,17 @@ func chownChildren(dir *os.File, uid, gid int) error {
 	}
 	dirfd := int(dir.Fd())
 	for _, name := range names {
-		path := filepath.Join(dir.Name(), name)
 		if err := unix.Fchownat(dirfd, name, uid, gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-			return &os.PathError{Op: "lchown", Path: path, Err: err}
+			return &os.PathError{Op: "lchown", Path: filepath.Join(dir.Name(), name), Err: err}
 		}
 		var st unix.Stat_t
 		if err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-			return &os.PathError{Op: "stat", Path: path, Err: err}
+			return &os.PathError{Op: "stat", Path: filepath.Join(dir.Name(), name), Err: err}
 		}
 		if st.Mode&unix.S_IFMT != unix.S_IFDIR {
 			continue
 		}
+		path := filepath.Join(dir.Name(), name)
 		childFd, err := unix.Openat(dirfd, name, dirFlags, 0)
 		if err != nil {
 			return &os.PathError{Op: "open", Path: path, Err: err}

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -3,8 +3,11 @@
 package runner
 
 import (
+	"cmp"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"golang.org/x/sys/unix"
 )
@@ -117,19 +120,43 @@ func mkdirOpenAt(parent *os.File, name string) (*os.File, error) {
 	return os.NewFile(uintptr(fd), path), nil
 }
 
-// writeFileAt writes data to name under parent, refusing to write through a symlink.
+// writeFileAt replaces name under parent, refusing to write through a symlink.
+// The bytes land in a sibling temp file that renameat swaps into place, so a
+// concurrent reader — a running code-server watches settings.json — gets the
+// old file or the new one, never the empty window an O_TRUNC write opens.
 func writeFileAt(parent *os.File, name string, data []byte) error {
+	dirfd := int(parent.Fd())
 	path := filepath.Join(parent.Name(), name)
-	fd, err := unix.Openat(int(parent.Fd()), name,
-		unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0644)
+
+	// renameat replaces a symlink at name rather than following it, which is
+	// safe but silent. This open refuses one first, so a planted link is an error.
+	probe, err := unix.Openat(dirfd, name,
+		unix.O_WRONLY|unix.O_CREAT|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0644)
 	if err != nil {
 		return &os.PathError{Op: "open", Path: path, Err: err}
 	}
-	f := os.NewFile(uintptr(fd), path)
+	_ = unix.Close(probe)
+
+	// Two editor sessions for one user set the directory up concurrently, so the
+	// temp name has to be unique per call, not per process.
+	tmp := "." + name + "." + strconv.FormatUint(rand.Uint64(), 36) + ".tmp"
+	tmpPath := filepath.Join(parent.Name(), tmp)
+	fd, err := unix.Openat(dirfd, tmp,
+		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0644)
+	if err != nil {
+		return &os.PathError{Op: "open", Path: tmpPath, Err: err}
+	}
+	f := os.NewFile(uintptr(fd), tmpPath)
 	_, writeErr := f.Write(data)
 	closeErr := f.Close()
-	if writeErr != nil {
-		return writeErr
+	if err := cmp.Or(writeErr, closeErr); err != nil {
+		_ = unix.Unlinkat(dirfd, tmp, 0)
+		return err
 	}
-	return closeErr
+
+	if err := unix.Renameat(dirfd, tmp, dirfd, name); err != nil {
+		_ = unix.Unlinkat(dirfd, tmp, 0)
+		return &os.PathError{Op: "rename", Path: path, Err: err}
+	}
+	return nil
 }

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -1,0 +1,135 @@
+//go:build !windows
+
+package runner
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// The user owns the home directory, so any path under it can be swapped for a
+// symlink between a check and the use of the checked path. Every operation
+// below the home directory therefore resolves one path component at a time
+// against a held directory fd with O_NOFOLLOW, which leaves no window to
+// redirect root's writes or chowns elsewhere. The home directory itself is
+// opened by full path, and every name handed to these helpers must be a single
+// component: O_NOFOLLOW guards only the last one, so a separator inside a name
+// would let the components before it be followed.
+
+const dirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
+
+// setupUserDataFiles creates dirName/User under homeDir and writes config.yaml
+// and User/settings.json, refusing to traverse or write through symlinks.
+func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte) error {
+	home, err := openDir(homeDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = home.Close() }()
+
+	dataDir, err := mkdirOpenAt(home, dirName)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dataDir.Close() }()
+
+	userDir, err := mkdirOpenAt(dataDir, userDataUserDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = userDir.Close() }()
+
+	if err := writeFileAt(dataDir, userDataConfigFile, configData); err != nil {
+		return err
+	}
+	return writeFileAt(userDir, userDataSettingsFile, settingsData)
+}
+
+// chownTreeNoFollow recursively changes ownership under root without ever
+// following a symlink: links themselves are re-owned, their targets untouched.
+func chownTreeNoFollow(root string, uid, gid int) error {
+	dir, err := openDir(root)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+
+	if err := dir.Chown(uid, gid); err != nil {
+		return err
+	}
+	return chownChildren(dir, uid, gid)
+}
+
+func chownChildren(dir *os.File, uid, gid int) error {
+	names, err := dir.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+	dirfd := int(dir.Fd())
+	for _, name := range names {
+		path := filepath.Join(dir.Name(), name)
+		if err := unix.Fchownat(dirfd, name, uid, gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return &os.PathError{Op: "lchown", Path: path, Err: err}
+		}
+		var st unix.Stat_t
+		if err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return &os.PathError{Op: "stat", Path: path, Err: err}
+		}
+		if st.Mode&unix.S_IFMT != unix.S_IFDIR {
+			continue
+		}
+		childFd, err := unix.Openat(dirfd, name, dirFlags, 0)
+		if err != nil {
+			return &os.PathError{Op: "open", Path: path, Err: err}
+		}
+		child := os.NewFile(uintptr(childFd), path)
+		err = chownChildren(child, uid, gid)
+		_ = child.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// openDir opens path as a directory fd. The final component must not be a symlink.
+func openDir(path string) (*os.File, error) {
+	fd, err := unix.Open(path, dirFlags, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+// mkdirOpenAt creates name under parent if missing and opens it. A symlink or
+// regular file squatting on the name fails the open (ELOOP or ENOTDIR).
+func mkdirOpenAt(parent *os.File, name string) (*os.File, error) {
+	path := filepath.Join(parent.Name(), name)
+	if err := unix.Mkdirat(int(parent.Fd()), name, 0755); err != nil && err != unix.EEXIST {
+		return nil, &os.PathError{Op: "mkdir", Path: path, Err: err}
+	}
+	fd, err := unix.Openat(int(parent.Fd()), name, dirFlags, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+// writeFileAt writes data to name under parent, refusing to write through a symlink.
+func writeFileAt(parent *os.File, name string, data []byte) error {
+	path := filepath.Join(parent.Name(), name)
+	fd, err := unix.Openat(int(parent.Fd()), name,
+		unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0644)
+	if err != nil {
+		return &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	f := os.NewFile(uintptr(fd), path)
+	_, writeErr := f.Write(data)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
+}

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -10,7 +10,10 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"time"
 
+	"github.com/rs/zerolog/log"
 	"golang.org/x/sys/unix"
 )
 
@@ -38,6 +41,17 @@ const homeDirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC
 // code-server writes comes close to this depth.
 const maxChownDepth = 64
 
+// A temp file only outlives writeFileAt when the process dies between the
+// create and the rename, and the age cut keeps a sweep away from one another
+// session is filling right now.
+const staleTempAge = time.Hour
+
+// A temp file is named for the file it will become, so a sweep can tell one
+// apart from whatever else the user keeps in the directory.
+const tempSuffix = ".tmp"
+
+func tempPrefix(name string) string { return "." + name + "." }
+
 // setupUserDataFiles creates dirName/User under homeDir and writes config.yaml
 // and User/settings.json, refusing to traverse or write through symlinks.
 func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte) error {
@@ -58,6 +72,9 @@ func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte
 		return err
 	}
 	defer func() { _ = userDir.Close() }()
+
+	sweepStaleTemps(dataDir, userDataConfigFile)
+	sweepStaleTemps(userDir, userDataSettingsFile)
 
 	if err := writeFileAt(dataDir, userDataConfigFile, configData); err != nil {
 		return err
@@ -147,6 +164,39 @@ func mkdirOpenAt(parent *os.File, name string) (*os.File, error) {
 	return os.NewFile(uintptr(fd), path), nil
 }
 
+// sweepStaleTemps removes the temp files a writeFileAt of name left behind by
+// dying before its rename. Nothing else collects them, and the directory
+// belongs to the user, so they would sit there for the life of the account.
+// A failure here is not worth refusing to start the editor over.
+func sweepStaleTemps(parent *os.File, name string) {
+	names, err := parent.Readdirnames(-1)
+	if err != nil {
+		log.Debug().Err(err).Msgf("Failed to list %s while sweeping temp files.", parent.Name())
+		return
+	}
+
+	dirfd := int(parent.Fd())
+	prefix, cutoff := tempPrefix(name), time.Now().Add(-staleTempAge)
+	for _, entry := range names {
+		if !strings.HasPrefix(entry, prefix) || !strings.HasSuffix(entry, tempSuffix) {
+			continue
+		}
+		// Stat through an fd rather than the name, so the age that decides the
+		// unlink is read off the very entry the name resolved to.
+		fd, err := unix.Openat(dirfd, entry, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			continue
+		}
+		f := os.NewFile(uintptr(fd), entry)
+		info, err := f.Stat()
+		_ = f.Close()
+		if err != nil || !info.Mode().IsRegular() || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = unix.Unlinkat(dirfd, entry, 0)
+	}
+}
+
 // writeFileAt replaces name under parent, refusing to write through a symlink.
 // The bytes land in a sibling temp file that renameat swaps into place, so a
 // concurrent reader—a running code-server watches settings.json—gets the old
@@ -176,7 +226,7 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 
 	// Two editor sessions for one user set the directory up concurrently, so the
 	// temp name has to be unique per call, not per process.
-	tmp := "." + name + "." + strconv.FormatUint(rand.Uint64(), 36) + ".tmp"
+	tmp := tempPrefix(name) + strconv.FormatUint(rand.Uint64(), 36) + tempSuffix
 	tmpPath := filepath.Join(parent.Name(), tmp)
 	fd, err := unix.Openat(dirfd, tmp,
 		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, mode)

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -182,8 +182,12 @@ func sweepStaleTemps(parent *os.File, name string) {
 			continue
 		}
 		// Stat through an fd rather than the name, so the age that decides the
-		// unlink is read off the very entry the name resolved to.
-		fd, err := unix.Openat(dirfd, entry, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		// unlink is read off the very entry the name resolved to. O_NONBLOCK
+		// because the temp name is predictable and mkfifo needs no privilege:
+		// a FIFO parked here would hold this open until a writer arrived, and
+		// the IsRegular check that rejects it comes after the open.
+		fd, err := unix.Openat(dirfd, entry,
+			unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 		if err != nil {
 			continue
 		}

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -184,6 +184,13 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 		return &os.PathError{Op: "open", Path: tmpPath, Err: err}
 	}
 	f := os.NewFile(uintptr(fd), tmpPath)
+	// O_CREAT applies the mode as mode &^ umask, which would narrow the mode
+	// carried over above; fchmod is not subject to the umask.
+	if err := unix.Fchmod(fd, mode); err != nil {
+		_ = f.Close()
+		_ = unix.Unlinkat(dirfd, tmp, 0)
+		return &os.PathError{Op: "chmod", Path: tmpPath, Err: err}
+	}
 	_, writeErr := f.Write(data)
 	closeErr := f.Close()
 	if err := cmp.Or(writeErr, closeErr); err != nil {

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -209,7 +209,9 @@ func mkdirOpenAt(parent *os.File, name string) (*os.File, error) {
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
 	}
 	// Also for a directory that was already there: mkdir under a umask, or an
-	// earlier alpamon that made it 0755, would otherwise leave it open.
+	// earlier alpamon that made it 0755, would otherwise leave it open. Unlike
+	// writeFileAt, which keeps the mode an admin set on a file, since what
+	// code-server drops into these directories later is nobody else's to read.
 	if err := unix.Fchmod(fd, userDataDirMode); err != nil {
 		_ = unix.Close(fd)
 		return nil, &os.PathError{Op: "chmod", Path: path, Err: err}

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -79,12 +79,19 @@ func chownChildren(dir *os.File, uid, gid int) error {
 	}
 	dirfd := int(dir.Fd())
 	for _, name := range names {
-		if err := unix.Fchownat(dirfd, name, uid, gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-			return &os.PathError{Op: "lchown", Path: filepath.Join(dir.Name(), name), Err: err}
-		}
+		// Stat before the chown, not after: AT_SYMLINK_NOFOLLOW speaks only for
+		// symlinks, and a hard link is not a link to a file but a second name
+		// for the same inode, one the user can plant pointing anywhere they can
+		// read. Handing that inode away is exactly what this walk must not do.
 		var st unix.Stat_t
 		if err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 			return &os.PathError{Op: "stat", Path: filepath.Join(dir.Name(), name), Err: err}
+		}
+		if st.Mode&unix.S_IFMT == unix.S_IFREG && st.Nlink > 1 {
+			continue
+		}
+		if err := unix.Fchownat(dirfd, name, uid, gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return &os.PathError{Op: "lchown", Path: filepath.Join(dir.Name(), name), Err: err}
 		}
 		if st.Mode&unix.S_IFMT != unix.S_IFDIR {
 			continue

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -5,6 +5,7 @@ package runner
 import (
 	"cmp"
 	"errors"
+	"fmt"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -29,6 +30,13 @@ const dirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLO
 // home directories at another filesystem that way, and refusing them would turn
 // a supported layout into an editor that will not start.
 const homeDirFlags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC
+
+// The walk holds one directory fd per level, and the tree below the user data
+// dir is whatever the user puts there. alpamon.service sets no LimitNOFILE, so
+// the systemd default applies to the whole agent: a deep enough chain would
+// starve the WebSocket connection and the FTP sessions of descriptors. Nothing
+// code-server writes comes close to this depth.
+const maxChownDepth = 64
 
 // setupUserDataFiles creates dirName/User under homeDir and writes config.yaml
 // and User/settings.json, refusing to traverse or write through symlinks.
@@ -69,10 +77,14 @@ func chownTreeNoFollow(root string, uid, gid int) error {
 	if err := dir.Chown(uid, gid); err != nil {
 		return err
 	}
-	return chownChildren(dir, uid, gid)
+	return chownChildren(dir, uid, gid, maxChownDepth)
 }
 
-func chownChildren(dir *os.File, uid, gid int) error {
+func chownChildren(dir *os.File, uid, gid, depth int) error {
+	if depth <= 0 {
+		return fmt.Errorf("user data dir nests deeper than %d levels at %s", maxChownDepth, dir.Name())
+	}
+
 	names, err := dir.Readdirnames(-1)
 	if err != nil {
 		return err
@@ -102,7 +114,7 @@ func chownChildren(dir *os.File, uid, gid int) error {
 			return &os.PathError{Op: "open", Path: path, Err: err}
 		}
 		child := os.NewFile(uintptr(childFd), path)
-		err = chownChildren(child, uid, gid)
+		err = chownChildren(child, uid, gid, depth-1)
 		_ = child.Close()
 		if err != nil {
 			return err

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -129,13 +129,17 @@ func writeFileAt(parent *os.File, name string, data []byte) error {
 	path := filepath.Join(parent.Name(), name)
 
 	// renameat replaces a symlink at name rather than following it, which is
-	// safe but silent. This open refuses one first, so a planted link is an error.
-	probe, err := unix.Openat(dirfd, name,
-		unix.O_WRONLY|unix.O_CREAT|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0644)
-	if err != nil {
-		return &os.PathError{Op: "open", Path: path, Err: err}
+	// safe but silent, so a planted link is reported here instead. The report is
+	// all this is: the rename stays inside the tree whatever appears after the
+	// check, and stat creates nothing, so a failure below leaves no file behind.
+	var st unix.Stat_t
+	switch err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); {
+	case err == unix.ENOENT:
+	case err != nil:
+		return &os.PathError{Op: "stat", Path: path, Err: err}
+	case st.Mode&unix.S_IFMT == unix.S_IFLNK:
+		return &os.PathError{Op: "open", Path: path, Err: unix.ELOOP}
 	}
-	_ = unix.Close(probe)
 
 	// Two editor sessions for one user set the directory up concurrently, so the
 	// temp name has to be unique per call, not per process.

--- a/pkg/runner/editor_unix.go
+++ b/pkg/runner/editor_unix.go
@@ -5,7 +5,6 @@ package runner
 import (
 	"cmp"
 	"errors"
-	"fmt"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -104,10 +103,6 @@ func chownTreeNoFollow(root string, uid, gid int) error {
 }
 
 func chownChildren(dir *os.File, uid, gid, depth int) error {
-	if depth <= 0 {
-		return fmt.Errorf("user data dir nests deeper than %d levels at %s", maxChownDepth, dir.Name())
-	}
-
 	names, err := dir.Readdirnames(-1)
 	if err != nil {
 		return err
@@ -139,7 +134,13 @@ func chownChildren(dir *os.File, uid, gid, depth int) error {
 			_ = unix.Close(fd)
 			return &os.PathError{Op: "chown", Path: path, Err: err}
 		}
-		if !isDir {
+		// Skip the subtree, not the walk: the files this run wrote have to change
+		// hands whatever the user parked beside them, and readdir order decides
+		// which the walk meets first.
+		if !isDir || depth <= 0 {
+			if isDir {
+				log.Warn().Msgf("Not descending past %d levels at %s; ownership below it is left as it is.", maxChownDepth, path)
+			}
 			_ = unix.Close(fd)
 			continue
 		}

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -611,3 +611,33 @@ func TestChownUserDataDirRefusesADeepTree(t *testing.T) {
 
 	assert.ErrorContains(t, chownUserDataDir(root, current.Username, ""), "nests deeper than")
 }
+
+// TestSetupUserDataDirSweepsStaleTempFiles: a process killed between the temp
+// create and the rename leaves the temp behind, and nothing else collects it.
+// The sweep is bounded by age and by name so that neither a write in flight in
+// another session nor an unrelated dot file is taken with it.
+func TestSetupUserDataDirSweepsStaleTempFiles(t *testing.T) {
+	homeDir := t.TempDir()
+	userDataDir, err := setupUserDataDir(homeDir, "", "")
+	require.NoError(t, err)
+
+	aged := time.Now().Add(-2 * staleTempAge)
+	abandoned := filepath.Join(userDataDir, tempPrefix(userDataConfigFile)+"abandoned"+tempSuffix)
+	require.NoError(t, os.WriteFile(abandoned, nil, 0600))
+	require.NoError(t, os.Chtimes(abandoned, aged, aged))
+
+	unrelated := filepath.Join(userDataDir, ".editor-state"+tempSuffix)
+	require.NoError(t, os.WriteFile(unrelated, nil, 0600))
+	require.NoError(t, os.Chtimes(unrelated, aged, aged))
+
+	inFlight := filepath.Join(userDataDir, tempPrefix(userDataConfigFile)+"inflight"+tempSuffix)
+	require.NoError(t, os.WriteFile(inFlight, nil, 0600))
+
+	_, err = setupUserDataDir(homeDir, "", "")
+	require.NoError(t, err)
+
+	_, err = os.Stat(abandoned)
+	assert.ErrorIs(t, err, os.ErrNotExist, "an abandoned temp file must not outlive the next setup")
+	assert.FileExists(t, inFlight, "a temp file another session is still filling must be left alone")
+	assert.FileExists(t, unrelated, "the sweep must take only names writeFileAt could have made")
+}

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -281,6 +281,23 @@ func TestSetupUserDataDirRefusesSymlinkedDirs(t *testing.T) {
 	}
 }
 
+// TestSetupUserDataDirFollowsASymlinkedHome covers a home directory an admin
+// pointed at another filesystem. That entry is not the user's to swap, so the
+// link is followed; the refusals below it are what the other tests pin.
+func TestSetupUserDataDirFollowsASymlinkedHome(t *testing.T) {
+	target := t.TempDir()
+	homeDir := filepath.Join(t.TempDir(), "home")
+	require.NoError(t, os.Symlink(target, homeDir))
+
+	userDataDir, err := setupUserDataDir(homeDir, "", "")
+	require.NoError(t, err)
+
+	cfg := GetCodeServerConfig()
+	assert.Equal(t, filepath.Join(homeDir, cfg.UserDataDirName), userDataDir)
+	assert.FileExists(t, filepath.Join(target, cfg.UserDataDirName, "config.yaml"),
+		"the files belong in the directory the link points at")
+}
+
 // TestChownUserDataDirDoesNotFollowSymlinks plants a symlink to a file the
 // target user must not own. As root the file is created in the temp dir and
 // ownership goes to nobody; as a regular user /etc/passwd stands in, where
@@ -336,7 +353,7 @@ func TestWriteFileAtReplacesInPlaceFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "f"), []byte("old"), 0644))
 	require.NoError(t, os.Link(filepath.Join(dir, "f"), filepath.Join(dir, "witness")))
 
-	parent, err := openDir(dir)
+	parent, err := openDir(dir, dirFlags)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = parent.Close() })
 
@@ -368,7 +385,7 @@ func TestWriteFileAtKeepsTheModeItReplaces(t *testing.T) {
 	require.NoError(t, os.WriteFile(target, []byte("old"), 0600))
 	require.NoError(t, os.Chmod(target, 0600))
 
-	parent, err := openDir(dir)
+	parent, err := openDir(dir, dirFlags)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = parent.Close() })
 
@@ -385,7 +402,7 @@ func TestWriteFileAtKeepsTheModeItReplaces(t *testing.T) {
 // temp create and nothing else.
 func TestWriteFileAtLeavesNothingWhenTheTempWriteFails(t *testing.T) {
 	dir := t.TempDir()
-	parent, err := openDir(dir)
+	parent, err := openDir(dir, dirFlags)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = parent.Close() })
 

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -661,6 +661,9 @@ func TestEachNameStopsMidDirectory(t *testing.T) {
 // per level, which the agent shares with the WebSocket connection and the FTP
 // sessions. It stops rather than fails, since readdir order decides whether the
 // deep subtree comes before or after the settings.json that has to change hands.
+// The witness one level down is what tells "stopped at the limit" from "never
+// descended at all": handing User/settings.json to the demoted user is the
+// reason the walk descends, and the deepest entry alone cannot say it happened.
 func TestChownUserDataDirStopsDescendingAtTheLimit(t *testing.T) {
 	root := t.TempDir()
 
@@ -673,14 +676,20 @@ func TestChownUserDataDirStopsDescendingAtTheLimit(t *testing.T) {
 	sibling := filepath.Join(root, userDataSettingsFile)
 	require.NoError(t, os.WriteFile(sibling, nil, 0600))
 
+	nested := filepath.Join(root, "deep", userDataSettingsFile)
+	require.NoError(t, os.WriteFile(nested, nil, 0600))
+
 	username, groupname := movableOwnership(t, sibling)
 	beforeSibling := fileOwner(t, sibling)
+	beforeNested := fileOwner(t, nested)
 	beforeDeepest := fileOwner(t, deepest)
 
 	require.NoError(t, chownUserDataDir(t.Context(), root, username, groupname))
 
 	assert.NotEqual(t, beforeSibling, fileOwner(t, sibling),
 		"a subtree too deep to enter must not cost the files beside it their owner")
+	assert.NotEqual(t, beforeNested, fileOwner(t, nested),
+		"the walk must re-own what it descends into, which is why it descends")
 	assert.Equal(t, beforeDeepest, fileOwner(t, deepest),
 		"the walk must not descend past the descriptor budget")
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -757,11 +757,14 @@ func TestSetupUserDataDirKeepsTheTreeToItsUser(t *testing.T) {
 	userDataDir, err := setupUserDataDir(t.Context(), homeDir, "", "")
 	require.NoError(t, err)
 
+	// Literals, not userDataDirMode and userDataFileMode: an expectation read
+	// from the constants the implementation reads moves with them, and widening
+	// them back to 0755 and 0644 would keep this green.
 	for path, want := range map[string]os.FileMode{
-		userDataDir: userDataDirMode,
-		filepath.Join(userDataDir, userDataUserDir):                       userDataDirMode,
-		filepath.Join(userDataDir, userDataConfigFile):                    userDataFileMode,
-		filepath.Join(userDataDir, userDataUserDir, userDataSettingsFile): userDataFileMode,
+		userDataDir: 0700,
+		filepath.Join(userDataDir, userDataUserDir):                       0700,
+		filepath.Join(userDataDir, userDataConfigFile):                    0600,
+		filepath.Join(userDataDir, userDataUserDir, userDataSettingsFile): 0600,
 	} {
 		info, err := os.Stat(path)
 		require.NoError(t, err)

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -772,6 +772,35 @@ func TestSetupUserDataDirKeepsTheTreeToItsUser(t *testing.T) {
 	}
 }
 
+// TestSetupUserDataDirKeepsAnOlderFileMode covers the other half of the upgrade
+// path: a config.yaml left 0644 by an earlier install keeps that mode, since an
+// admin who tightened the file is the one writeFileAt carries the mode over for.
+// What keeps it out of other accounts is the 0700 directory around it, so the
+// test pins both halves together—the file mode alone would read as an exposure.
+func TestSetupUserDataDirKeepsAnOlderFileMode(t *testing.T) {
+	homeDir := t.TempDir()
+	cfg := GetCodeServerConfig()
+
+	stale := filepath.Join(homeDir, cfg.UserDataDirName)
+	require.NoError(t, os.MkdirAll(stale, 0755))
+	staleConfig := filepath.Join(stale, userDataConfigFile)
+	require.NoError(t, os.WriteFile(staleConfig, nil, 0644))
+	require.NoError(t, os.Chmod(staleConfig, 0644))
+
+	userDataDir, err := setupUserDataDir(t.Context(), homeDir, "", "")
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(userDataDir, userDataConfigFile))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(),
+		"a mode an admin set on the file survives the rewrite")
+
+	dirInfo, err := os.Stat(userDataDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), dirInfo.Mode().Perm(),
+		"the directory is what keeps the carried-over file to its user")
+}
+
 // TestSetupUserDataDirSweepsStaleTempFiles: a process killed between the temp
 // create and the rename leaves the temp behind, and nothing else collects it.
 // The sweep is bounded by age and by name so that neither a write in flight in

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -612,6 +612,21 @@ func TestChownUserDataDirRefusesADeepTree(t *testing.T) {
 	assert.ErrorContains(t, chownUserDataDir(root, current.Username, ""), "nests deeper than")
 }
 
+// TestSetupUserDataDirRefusesAMissingHome pins the behavior for an account
+// whose home directory is listed in passwd but absent from disk (an LDAP user,
+// or useradd -M). The path-based MkdirAll this replaced created it root-owned,
+// which left the user locked out of their own home; resolving one component at
+// a time against a held fd cannot create it, so setup fails instead.
+func TestSetupUserDataDirRefusesAMissingHome(t *testing.T) {
+	homeDir := filepath.Join(t.TempDir(), "absent")
+
+	_, err := setupUserDataDir(homeDir, "", "")
+
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, statErr := os.Stat(homeDir)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "a missing home directory must not be created here")
+}
+
 // TestSetupUserDataDirSweepsStaleTempFiles: a process killed between the temp
 // create and the rename leaves the temp behind, and nothing else collects it.
 // The sweep is bounded by age and by name so that neither a write in flight in

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -358,6 +358,26 @@ func TestWriteFileAtReplacesInPlaceFile(t *testing.T) {
 	assert.ElementsMatch(t, []string{"f", "witness"}, names, "the temp file must not outlive the write")
 }
 
+// TestWriteFileAtKeepsTheModeItReplaces pins the mode across a replacement. The
+// renamed file arrives with the temp file's mode, so the old one has to be
+// carried over or a tightened settings.json widens again on the next start.
+func TestWriteFileAtKeepsTheModeItReplaces(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0600))
+	require.NoError(t, os.Chmod(target, 0600))
+
+	parent, err := openDir(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = parent.Close() })
+
+	require.NoError(t, writeFileAt(parent, "f", []byte("new")))
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "the replacement keeps the mode it replaced")
+}
+
 // TestWriteFileAtLeavesNothingWhenTheTempWriteFails pins the failure path: the
 // call must not create the target it never managed to fill. The name is sized so
 // that it fits but the longer temp name derived from it does not, which fails the

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -8,6 +8,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
@@ -231,4 +234,94 @@ func TestStopKillsGroupIgnoringSIGTERM(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Stop gave up on the process group but left it running")
 	}
+}
+
+func TestSetupUserDataDirRefusesSymlinkedFiles(t *testing.T) {
+	cfg := GetCodeServerConfig()
+	for _, rel := range []string{"config.yaml", filepath.Join("User", "settings.json")} {
+		t.Run(rel, func(t *testing.T) {
+			homeDir := t.TempDir()
+			target := filepath.Join(t.TempDir(), "victim")
+			require.NoError(t, os.WriteFile(target, []byte("keep"), 0600))
+
+			link := filepath.Join(homeDir, cfg.UserDataDirName, rel)
+			require.NoError(t, os.MkdirAll(filepath.Dir(link), 0755))
+			require.NoError(t, os.Symlink(target, link))
+
+			_, err := setupUserDataDir(homeDir, "", "")
+			assert.Error(t, err)
+
+			data, err := os.ReadFile(target)
+			require.NoError(t, err)
+			assert.Equal(t, "keep", string(data))
+		})
+	}
+}
+
+func TestSetupUserDataDirRefusesSymlinkedDirs(t *testing.T) {
+	cfg := GetCodeServerConfig()
+	for _, rel := range []string{".", "User"} {
+		t.Run(rel, func(t *testing.T) {
+			homeDir := t.TempDir()
+			target := t.TempDir()
+
+			link := filepath.Join(homeDir, cfg.UserDataDirName, rel)
+			require.NoError(t, os.MkdirAll(filepath.Dir(link), 0755))
+			require.NoError(t, os.Symlink(target, link))
+
+			_, err := setupUserDataDir(homeDir, "", "")
+			assert.Error(t, err)
+
+			entries, err := os.ReadDir(target)
+			require.NoError(t, err)
+			assert.Empty(t, entries, "nothing may be written through the symlinked directory")
+		})
+	}
+}
+
+// TestChownUserDataDirDoesNotFollowSymlinks plants a symlink to a file the
+// target user must not own. As root the file is created in the temp dir and
+// ownership goes to nobody; as a regular user /etc/passwd stands in, where
+// following the link would fail with EPERM.
+func TestChownUserDataDirDoesNotFollowSymlinks(t *testing.T) {
+	userDataDir := t.TempDir()
+
+	var target, username string
+	if os.Getuid() == 0 {
+		// Not every distro image ships "nobody" (opensuse/leap:15 does not).
+		if _, err := user.Lookup("nobody"); err != nil {
+			t.Skipf("no nobody account on this system: %v", err)
+		}
+		target = filepath.Join(t.TempDir(), "victim")
+		require.NoError(t, os.WriteFile(target, []byte("keep"), 0600))
+		username = "nobody"
+	} else {
+		target = "/etc/passwd"
+		current, err := user.Current()
+		require.NoError(t, err)
+		username = current.Username
+	}
+	before := fileUID(t, target)
+
+	link := filepath.Join(userDataDir, "x")
+	require.NoError(t, os.Symlink(target, link))
+
+	require.NoError(t, chownUserDataDir(userDataDir, username, ""))
+
+	assert.Equal(t, before, fileUID(t, target), "symlink target must keep its owner")
+
+	usr, err := user.Lookup(username)
+	require.NoError(t, err)
+	wantUID, err := strconv.Atoi(usr.Uid)
+	require.NoError(t, err)
+	linkInfo, err := os.Lstat(link)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(wantUID), linkInfo.Sys().(*syscall.Stat_t).Uid, "the link itself is chowned")
+}
+
+func fileUID(t *testing.T, path string) uint32 {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	return info.Sys().(*syscall.Stat_t).Uid
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -615,22 +615,32 @@ func TestChownUserDataDirSkipsHardLinkedNonRegularFiles(t *testing.T) {
 		"the walk must still re-own the files this tree is the only name for")
 }
 
-// TestChownUserDataDirRefusesADeepTree: the walk holds one directory fd per
-// level, and the agent shares its descriptors with the WebSocket connection
-// and the FTP sessions, so a tree the user nested deep enough would take those
-// down with it rather than merely failing the chown.
-func TestChownUserDataDirRefusesADeepTree(t *testing.T) {
+// TestChownUserDataDirStopsDescendingAtTheLimit: the walk holds one directory fd
+// per level, which the agent shares with the WebSocket connection and the FTP
+// sessions. It stops rather than fails, since readdir order decides whether the
+// deep subtree comes before or after the settings.json that has to change hands.
+func TestChownUserDataDirStopsDescendingAtTheLimit(t *testing.T) {
 	root := t.TempDir()
-	deep := root
+
+	deepest := filepath.Join(root, "deep")
 	for range maxChownDepth + 1 {
-		deep = filepath.Join(deep, "d")
+		deepest = filepath.Join(deepest, "d")
 	}
-	require.NoError(t, os.MkdirAll(deep, 0755))
+	require.NoError(t, os.MkdirAll(deepest, 0755))
 
-	current, err := user.Current()
-	require.NoError(t, err)
+	sibling := filepath.Join(root, userDataSettingsFile)
+	require.NoError(t, os.WriteFile(sibling, nil, 0600))
 
-	assert.ErrorContains(t, chownUserDataDir(root, current.Username, ""), "nests deeper than")
+	username, groupname := movableOwnership(t, sibling)
+	beforeSibling := fileOwner(t, sibling)
+	beforeDeepest := fileOwner(t, deepest)
+
+	require.NoError(t, chownUserDataDir(root, username, groupname))
+
+	assert.NotEqual(t, beforeSibling, fileOwner(t, sibling),
+		"a subtree too deep to enter must not cost the files beside it their owner")
+	assert.Equal(t, beforeDeepest, fileOwner(t, deepest),
+		"the walk must not descend past the descriptor budget")
 }
 
 // TestSetupUserDataDirRefusesAMissingHome pins the behavior for an account

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -5,6 +5,7 @@ package runner
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"os/exec"
@@ -398,4 +399,77 @@ func TestWriteFileAtLeavesNothingWhenTheTempWriteFails(t *testing.T) {
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	assert.Empty(t, entries, "the temp file must not survive the failure either")
+}
+
+func TestSetupUserDataDir(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Call setupUserDataDir (empty username/groupname since we're not running as root in tests)
+	userDataDir, err := setupUserDataDir(tempDir, "", "")
+	assert.NoError(t, err, "setupUserDataDir should not error")
+	assert.NotEmpty(t, userDataDir, "userDataDir should not be empty")
+
+	// Verify user data directory was created
+	cfg := GetCodeServerConfig()
+	expectedUserDataDir := filepath.Join(tempDir, cfg.UserDataDirName)
+	assert.Equal(t, expectedUserDataDir, userDataDir)
+	_, err = os.Stat(userDataDir)
+	assert.NoError(t, err, "User data directory should exist")
+
+	// Verify config.yaml was created
+	configPath := filepath.Join(userDataDir, "config.yaml")
+	configData, err := os.ReadFile(configPath)
+	assert.NoError(t, err, "config.yaml should exist and be readable")
+	assert.Contains(t, string(configData), "auth: none", "config.yaml should contain auth: none")
+	assert.Contains(t, string(configData), "disable-telemetry: true", "config.yaml should contain disable-telemetry")
+	assert.Contains(t, string(configData), "disable-update-check: true", "config.yaml should contain disable-update-check")
+
+	// Verify User subdirectory was created
+	userDir := filepath.Join(userDataDir, "User")
+	_, err = os.Stat(userDir)
+	assert.NoError(t, err, "User subdirectory should exist")
+
+	// Verify settings.json was created
+	settingsPath := filepath.Join(userDir, "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	assert.NoError(t, err, "settings.json should exist and be readable")
+
+	// Verify settings.json content
+	var settings map[string]any
+	err = json.Unmarshal(data, &settings)
+	assert.NoError(t, err, "settings.json should be valid JSON")
+
+	assert.Equal(t, cfg.ColorTheme, settings["workbench.colorTheme"], "colorTheme should match config")
+	assert.Equal(t, "none", settings["workbench.startupEditor"], "workbench.startupEditor should be 'none'")
+	assert.Equal(t, false, settings["workbench.welcomePage.walkthroughs.openOnInstall"], "walkthroughs should be disabled")
+	assert.Equal(t, "none", settings["window.restoreWindows"], "window.restoreWindows should be 'none'")
+	assert.Equal(t, "off", settings["telemetry.telemetryLevel"], "telemetry should be off")
+	assert.Equal(t, false, settings["security.workspace.trust.enabled"], "workspace trust should be disabled")
+	assert.Equal(t, "none", settings["update.mode"], "update.mode should be 'none'")
+}
+
+func TestSetupUserDataDirIdempotent(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Call setupUserDataDir twice
+	userDataDir1, err := setupUserDataDir(tempDir, "", "")
+	assert.NoError(t, err)
+
+	userDataDir2, err := setupUserDataDir(tempDir, "", "")
+	assert.NoError(t, err)
+
+	// Both calls should return the same path
+	assert.Equal(t, userDataDir1, userDataDir2)
+
+	// settings.json should still be valid
+	settingsPath := filepath.Join(userDataDir1, "User", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	assert.NoError(t, err)
+
+	var settings map[string]any
+	err = json.Unmarshal(data, &settings)
+	assert.NoError(t, err)
+	assert.Equal(t, "none", settings["workbench.startupEditor"])
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 // killGroupOnCleanup kills the child's group unless the reaper already closed
@@ -415,11 +416,17 @@ func TestWriteFileAtReplacesInPlaceFile(t *testing.T) {
 // TestWriteFileAtKeepsTheModeItReplaces pins the mode across a replacement. The
 // renamed file arrives with the temp file's mode, so the old one has to be
 // carried over or a tightened settings.json widens again on the next start.
+// The mode and the umask are chosen to disagree: O_CREAT applies the mode as
+// mode &^ umask, so a carry-over resting on that call alone narrows the file
+// instead of preserving it, and a mode no common umask touches hides that.
 func TestWriteFileAtKeepsTheModeItReplaces(t *testing.T) {
+	previous := unix.Umask(0077)
+	t.Cleanup(func() { unix.Umask(previous) })
+
 	dir := t.TempDir()
 	target := filepath.Join(dir, "f")
-	require.NoError(t, os.WriteFile(target, []byte("old"), 0600))
-	require.NoError(t, os.Chmod(target, 0600))
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0644))
+	require.NoError(t, os.Chmod(target, 0644))
 
 	parent, err := openDir(dir, dirFlags)
 	require.NoError(t, err)
@@ -429,7 +436,7 @@ func TestWriteFileAtKeepsTheModeItReplaces(t *testing.T) {
 
 	info, err := os.Stat(target)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "the replacement keeps the mode it replaced")
+	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(), "the replacement keeps the mode it replaced")
 }
 
 // nameLimit returns the longest file name dir accepts. NAME_MAX is not portable

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -733,6 +733,33 @@ func TestSetupUserDataDirUnderConcurrentSessions(t *testing.T) {
 		"no session may leave the settings file behind half-written")
 }
 
+// TestSetupUserDataDirKeepsTheTreeToItsUser: code-server fills this directory on
+// the user's behalf, and User/History ends up holding a snapshot of every file
+// they open. Through a 0755 directory any other local account reads all of it.
+func TestSetupUserDataDirKeepsTheTreeToItsUser(t *testing.T) {
+	homeDir := t.TempDir()
+	cfg := GetCodeServerConfig()
+
+	// An install from before this ran left the tree group- and world-readable,
+	// so creating it is not the only case that has to come out right.
+	stale := filepath.Join(homeDir, cfg.UserDataDirName)
+	require.NoError(t, os.MkdirAll(filepath.Join(stale, userDataUserDir), 0755))
+
+	userDataDir, err := setupUserDataDir(t.Context(), homeDir, "", "")
+	require.NoError(t, err)
+
+	for path, want := range map[string]os.FileMode{
+		userDataDir: userDataDirMode,
+		filepath.Join(userDataDir, userDataUserDir):                       userDataDirMode,
+		filepath.Join(userDataDir, userDataConfigFile):                    userDataFileMode,
+		filepath.Join(userDataDir, userDataUserDir, userDataSettingsFile): userDataFileMode,
+	} {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, want, info.Mode().Perm(), path)
+	}
+}
+
 // TestSetupUserDataDirSweepsStaleTempFiles: a process killed between the temp
 // create and the rename leaves the temp behind, and nothing else collects it.
 // The sweep is bounded by age and by name so that neither a write in flight in

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -325,3 +325,34 @@ func fileUID(t *testing.T, path string) uint32 {
 	require.NoError(t, err)
 	return info.Sys().(*syscall.Stat_t).Uid
 }
+
+// TestWriteFileAtReplacesInPlaceFile proves the swap is atomic from the reader's
+// side: a second link to the old inode keeps the old bytes, which an in-place
+// truncate would have destroyed, and no temp file survives the call.
+func TestWriteFileAtReplacesInPlaceFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f"), []byte("old"), 0644))
+	require.NoError(t, os.Link(filepath.Join(dir, "f"), filepath.Join(dir, "witness")))
+
+	parent, err := openDir(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = parent.Close() })
+
+	require.NoError(t, writeFileAt(parent, "f", []byte("new")))
+
+	kept, err := os.ReadFile(filepath.Join(dir, "witness"))
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(kept), "the replaced file must keep the bytes a reader already had open")
+
+	got, err := os.ReadFile(filepath.Join(dir, "f"))
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	assert.ElementsMatch(t, []string{"f", "witness"}, names, "the temp file must not outlive the write")
+}

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -407,12 +407,10 @@ func TestWriteFileAtReplacesInPlaceFile(t *testing.T) {
 	assert.ElementsMatch(t, []string{"f", "witness"}, names, "the temp file must not outlive the write")
 }
 
-// TestWriteFileAtKeepsTheModeItReplaces pins the mode across a replacement. The
-// renamed file arrives with the temp file's mode, so the old one has to be
-// carried over or a tightened settings.json widens again on the next start.
-// The mode and the umask are chosen to disagree: O_CREAT applies the mode as
-// mode &^ umask, so a carry-over resting on that call alone narrows the file
-// instead of preserving it, and a mode no common umask touches hides that.
+// TestWriteFileAtKeepsTheModeItReplaces: the renamed file arrives with the temp
+// file's mode, so a tightened settings.json widens again on the next start
+// unless the old mode is carried over. The mode and the umask are chosen to
+// disagree, since a carry-over resting on O_CREAT alone narrows instead.
 func TestWriteFileAtKeepsTheModeItReplaces(t *testing.T) {
 	previous := unix.Umask(0077)
 	t.Cleanup(func() { unix.Umask(previous) })
@@ -702,9 +700,12 @@ func TestSetupUserDataDirRefusesAMissingHome(t *testing.T) {
 	assert.ErrorIs(t, statErr, os.ErrNotExist, "a missing home directory must not be created here")
 }
 
-// TestSetupUserDataDirUnderConcurrentSessions covers the case the temp+rename
-// replacement exists for: one user opening two editor sessions sets the
-// directory up twice at once, and neither may see a half-written settings.json.
+// TestSetupUserDataDirUnderConcurrentSessions: one user opening two editor
+// sessions sets the directory up twice at once, so every step has to tolerate a
+// peer mid-flight—the mkdir that finds the directory there, the sweep that must
+// leave a peer's temp alone, the rename onto a name someone else just claimed.
+// What a reader sees mid-swap is TestWriteFileAtReplacesInPlaceFile's, since the
+// read below runs only after every session has finished.
 func TestSetupUserDataDirUnderConcurrentSessions(t *testing.T) {
 	homeDir := t.TempDir()
 
@@ -729,7 +730,7 @@ func TestSetupUserDataDirUnderConcurrentSessions(t *testing.T) {
 
 	var settings map[string]any
 	require.NoError(t, json.Unmarshal(data, &settings),
-		"every reader must find one of the two complete files, never a partial one")
+		"no session may leave the settings file behind half-written")
 }
 
 // TestSetupUserDataDirSweepsStaleTempFiles: a process killed between the temp

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -586,3 +586,21 @@ func TestChownUserDataDirSkipsHardLinkedFiles(t *testing.T) {
 	assert.NotEqual(t, beforeOrdinary, fileOwner(t, ordinary),
 		"the walk must still re-own the files this tree is the only name for")
 }
+
+// TestChownUserDataDirRefusesADeepTree: the walk holds one directory fd per
+// level, and the agent shares its descriptors with the WebSocket connection
+// and the FTP sessions, so a tree the user nested deep enough would take those
+// down with it rather than merely failing the chown.
+func TestChownUserDataDirRefusesADeepTree(t *testing.T) {
+	root := t.TempDir()
+	deep := root
+	for range maxChownDepth + 1 {
+		deep = filepath.Join(deep, "d")
+	}
+	require.NoError(t, os.MkdirAll(deep, 0755))
+
+	current, err := user.Current()
+	require.NoError(t, err)
+
+	assert.ErrorContains(t, chownUserDataDir(root, current.Username, ""), "nests deeper than")
+}

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -300,50 +300,40 @@ func TestSetupUserDataDirFollowsASymlinkedHome(t *testing.T) {
 }
 
 // TestChownUserDataDirDoesNotFollowSymlinks plants a symlink to a file the
-// target user must not own. As root the file is created in the temp dir and
-// ownership goes to nobody; as a regular user /etc/passwd stands in, where
-// following the link would fail with EPERM.
+// target user must not own. As root the file is created in the temp dir; as a
+// regular user /etc/passwd stands in, where following the link would fail with
+// EPERM.
 func TestChownUserDataDirDoesNotFollowSymlinks(t *testing.T) {
 	userDataDir := t.TempDir()
 
-	var target, username string
+	target := "/etc/passwd"
 	if os.Getuid() == 0 {
-		// Not every distro image ships "nobody" (opensuse/leap:15 does not).
-		if _, err := user.Lookup("nobody"); err != nil {
-			t.Skipf("no nobody account on this system: %v", err)
-		}
 		target = filepath.Join(t.TempDir(), "victim")
 		require.NoError(t, os.WriteFile(target, []byte("keep"), 0600))
-		username = "nobody"
-	} else {
-		target = "/etc/passwd"
-		current, err := user.Current()
-		require.NoError(t, err)
-		username = current.Username
 	}
-	before := fileOwner(t, target)
+	beforeTarget := fileOwner(t, target)
 
 	link := filepath.Join(userDataDir, "x")
 	require.NoError(t, os.Symlink(target, link))
 
-	require.NoError(t, chownUserDataDir(userDataDir, username, ""))
+	// Ownership the kernel will really move the link to. Asking for the ids the
+	// link already carries would let the assertion below pass with no lchown
+	// having happened at all.
+	username, groupname := movableOwnership(t, link)
+	beforeLink := fileOwner(t, link)
 
-	assert.Equal(t, before, fileOwner(t, target), "symlink target must keep its owner")
+	require.NoError(t, chownUserDataDir(userDataDir, username, groupname))
 
-	usr, err := user.Lookup(username)
-	require.NoError(t, err)
-	wantUID, err := strconv.Atoi(usr.Uid)
-	require.NoError(t, err)
-	linkInfo, err := os.Lstat(link)
-	require.NoError(t, err)
-	assert.Equal(t, uint32(wantUID), linkInfo.Sys().(*syscall.Stat_t).Uid, "the link itself is chowned")
+	assert.Equal(t, beforeTarget, fileOwner(t, target), "symlink target must keep its owner")
+	assert.NotEqual(t, beforeLink, fileOwner(t, link), "the link itself is chowned")
 }
 
 // fileOwner reads both ids, since a non-root process can only ever move the
 // group, and a test that watched the uid alone would pass without chowning.
+// Lstat, not Stat: on a symlink the ownership under test is the link's own.
 func fileOwner(t *testing.T, path string) [2]uint32 {
 	t.Helper()
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	require.NoError(t, err)
 	st := info.Sys().(*syscall.Stat_t)
 	return [2]uint32{st.Uid, st.Gid}

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -320,14 +320,14 @@ func TestChownUserDataDirDoesNotFollowSymlinks(t *testing.T) {
 		require.NoError(t, err)
 		username = current.Username
 	}
-	before := fileUID(t, target)
+	before := fileOwner(t, target)
 
 	link := filepath.Join(userDataDir, "x")
 	require.NoError(t, os.Symlink(target, link))
 
 	require.NoError(t, chownUserDataDir(userDataDir, username, ""))
 
-	assert.Equal(t, before, fileUID(t, target), "symlink target must keep its owner")
+	assert.Equal(t, before, fileOwner(t, target), "symlink target must keep its owner")
 
 	usr, err := user.Lookup(username)
 	require.NoError(t, err)
@@ -338,11 +338,47 @@ func TestChownUserDataDirDoesNotFollowSymlinks(t *testing.T) {
 	assert.Equal(t, uint32(wantUID), linkInfo.Sys().(*syscall.Stat_t).Uid, "the link itself is chowned")
 }
 
-func fileUID(t *testing.T, path string) uint32 {
+// fileOwner reads both ids, since a non-root process can only ever move the
+// group, and a test that watched the uid alone would pass without chowning.
+func fileOwner(t *testing.T, path string) [2]uint32 {
 	t.Helper()
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	return info.Sys().(*syscall.Stat_t).Uid
+	st := info.Sys().(*syscall.Stat_t)
+	return [2]uint32{st.Uid, st.Gid}
+}
+
+// movableOwnership returns a user and group chownUserDataDir can actually move
+// an entry at path to: as root any account, and as a regular user their own
+// name plus a group they belong to that the file is not already in—the only
+// ownership change the kernel lets them make.
+func movableOwnership(t *testing.T, path string) (username, groupname string) {
+	t.Helper()
+
+	if os.Getuid() == 0 {
+		// Not every distro image ships "nobody" (opensuse/leap:15 does not).
+		if _, err := user.Lookup("nobody"); err != nil {
+			t.Skipf("no nobody account on this system: %v", err)
+		}
+		return "nobody", ""
+	}
+
+	current, err := user.Current()
+	require.NoError(t, err)
+	gids, err := current.GroupIds()
+	require.NoError(t, err)
+	own := strconv.FormatUint(uint64(fileOwner(t, path)[1]), 10)
+
+	for _, gid := range gids {
+		if gid == own {
+			continue
+		}
+		if group, err := user.LookupGroupId(gid); err == nil {
+			return current.Username, group.Name
+		}
+	}
+	t.Skip("the current user belongs to no group other than the one already on the file")
+	return "", ""
 }
 
 // TestWriteFileAtReplacesInPlaceFile proves the swap is atomic from the reader's
@@ -521,4 +557,32 @@ func TestSetupUserDataDirIdempotent(t *testing.T) {
 	err = json.Unmarshal(data, &settings)
 	assert.NoError(t, err)
 	assert.Equal(t, "none", settings["workbench.startupEditor"])
+}
+
+// TestChownUserDataDirSkipsHardLinkedFiles: AT_SYMLINK_NOFOLLOW speaks for
+// symlinks only. A hard link is a second name for one inode, and the user can
+// plant one pointing at any file they can read, so chowning it would hand that
+// file's ownership to them.
+func TestChownUserDataDirSkipsHardLinkedFiles(t *testing.T) {
+	userDataDir := t.TempDir()
+
+	outside := filepath.Join(t.TempDir(), "victim")
+	require.NoError(t, os.WriteFile(outside, []byte("keep"), 0600))
+	require.NoError(t, os.Link(outside, filepath.Join(userDataDir, "planted")))
+
+	// A file with only this one name proves the walk re-owned anything at all,
+	// so the assertion below cannot pass by the chown having been a no-op.
+	ordinary := filepath.Join(userDataDir, "ordinary")
+	require.NoError(t, os.WriteFile(ordinary, nil, 0600))
+
+	username, groupname := movableOwnership(t, outside)
+	beforeOutside := fileOwner(t, outside)
+	beforeOrdinary := fileOwner(t, ordinary)
+
+	require.NoError(t, chownUserDataDir(userDataDir, username, groupname))
+
+	assert.Equal(t, beforeOutside, fileOwner(t, outside),
+		"an inode that answers to another name outside the tree must keep its owner")
+	assert.NotEqual(t, beforeOrdinary, fileOwner(t, ordinary),
+		"the walk must still re-own the files this tree is the only name for")
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -355,4 +356,26 @@ func TestWriteFileAtReplacesInPlaceFile(t *testing.T) {
 		names = append(names, entry.Name())
 	}
 	assert.ElementsMatch(t, []string{"f", "witness"}, names, "the temp file must not outlive the write")
+}
+
+// TestWriteFileAtLeavesNothingWhenTheTempWriteFails pins the failure path: the
+// call must not create the target it never managed to fill. The name is sized so
+// that it fits but the longer temp name derived from it does not, which fails the
+// temp create and nothing else.
+func TestWriteFileAtLeavesNothingWhenTheTempWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	parent, err := openDir(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = parent.Close() })
+
+	name := strings.Repeat("n", 250)
+
+	require.Error(t, writeFileAt(parent, name, []byte("x")))
+
+	_, err = os.Stat(filepath.Join(dir, name))
+	assert.ErrorIs(t, err, os.ErrNotExist, "a write that failed must leave no file at the target")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "the temp file must not survive the failure either")
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -627,6 +627,36 @@ func TestSetupUserDataDirRefusesAMissingHome(t *testing.T) {
 	assert.ErrorIs(t, statErr, os.ErrNotExist, "a missing home directory must not be created here")
 }
 
+// TestSetupUserDataDirUnderConcurrentSessions covers the case the temp+rename
+// replacement exists for: one user opening two editor sessions sets the
+// directory up twice at once, and neither may see a half-written settings.json.
+func TestSetupUserDataDirUnderConcurrentSessions(t *testing.T) {
+	homeDir := t.TempDir()
+
+	const sessions = 8
+	start := make(chan struct{})
+	errs := make(chan error, sessions)
+	for range sessions {
+		go func() {
+			<-start
+			_, err := setupUserDataDir(homeDir, "", "")
+			errs <- err
+		}()
+	}
+	close(start)
+	for range sessions {
+		require.NoError(t, <-errs)
+	}
+
+	cfg := GetCodeServerConfig()
+	data, err := os.ReadFile(filepath.Join(homeDir, cfg.UserDataDirName, userDataUserDir, userDataSettingsFile))
+	require.NoError(t, err)
+
+	var settings map[string]any
+	require.NoError(t, json.Unmarshal(data, &settings),
+		"every reader must find one of the two complete files, never a partial one")
+}
+
 // TestSetupUserDataDirSweepsStaleTempFiles: a process killed between the temp
 // create and the rename leaves the temp behind, and nothing else collects it.
 // The sweep is bounded by age and by name so that neither a write in flight in

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -315,17 +315,21 @@ func TestChownUserDataDirDoesNotFollowSymlinks(t *testing.T) {
 
 	link := filepath.Join(userDataDir, "x")
 	require.NoError(t, os.Symlink(target, link))
-
-	// Ownership the kernel will really move the link to. Asking for the ids the
-	// link already carries would let the assertion below pass with no lchown
-	// having happened at all.
-	username, groupname := movableOwnership(t, link)
 	beforeLink := fileOwner(t, link)
+
+	// A witness with one name only, so the assertions above cannot pass by the
+	// walk having re-owned nothing at all.
+	ordinary := filepath.Join(userDataDir, "ordinary")
+	require.NoError(t, os.WriteFile(ordinary, nil, 0600))
+	username, groupname := movableOwnership(t, ordinary)
+	beforeOrdinary := fileOwner(t, ordinary)
 
 	require.NoError(t, chownUserDataDir(userDataDir, username, groupname))
 
-	assert.Equal(t, beforeTarget, fileOwner(t, target), "symlink target must keep its owner")
-	assert.NotEqual(t, beforeLink, fileOwner(t, link), "the link itself is chowned")
+	assert.Equal(t, beforeTarget, fileOwner(t, target), "a symlink target must keep its owner")
+	assert.Equal(t, beforeLink, fileOwner(t, link), "the link itself is not the walk's to re-own either")
+	assert.NotEqual(t, beforeOrdinary, fileOwner(t, ordinary),
+		"the walk must still re-own the files this tree is the only name for")
 }
 
 // fileOwner reads both ids, since a non-root process can only ever move the
@@ -580,6 +584,33 @@ func TestChownUserDataDirSkipsHardLinkedFiles(t *testing.T) {
 
 	assert.Equal(t, beforeOutside, fileOwner(t, outside),
 		"an inode that answers to another name outside the tree must keep its owner")
+	assert.NotEqual(t, beforeOrdinary, fileOwner(t, ordinary),
+		"the walk must still re-own the files this tree is the only name for")
+}
+
+// TestChownUserDataDirSkipsHardLinkedNonRegularFiles: link() does not care what
+// type the inode is, and the kernel only refuses a source the caller does not
+// own once fs.protected_hardlinks is set, which is not its own default. A
+// socket or FIFO reached that way is the one worth planting, since handing it
+// over lets the user chmod it and talk to whatever listens.
+func TestChownUserDataDirSkipsHardLinkedNonRegularFiles(t *testing.T) {
+	userDataDir := t.TempDir()
+
+	outside := filepath.Join(t.TempDir(), "victim.fifo")
+	require.NoError(t, unix.Mkfifo(outside, 0600))
+	require.NoError(t, os.Link(outside, filepath.Join(userDataDir, "planted")))
+
+	ordinary := filepath.Join(userDataDir, "ordinary")
+	require.NoError(t, os.WriteFile(ordinary, nil, 0600))
+
+	username, groupname := movableOwnership(t, outside)
+	beforeOutside := fileOwner(t, outside)
+	beforeOrdinary := fileOwner(t, ordinary)
+
+	require.NoError(t, chownUserDataDir(userDataDir, username, groupname))
+
+	assert.Equal(t, beforeOutside, fileOwner(t, outside),
+		"a non-regular inode that answers to another name outside the tree must keep its owner")
 	assert.NotEqual(t, beforeOrdinary, fileOwner(t, ordinary),
 		"the walk must still re-own the files this tree is the only name for")
 }

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -251,7 +251,7 @@ func TestSetupUserDataDirRefusesSymlinkedFiles(t *testing.T) {
 			require.NoError(t, os.MkdirAll(filepath.Dir(link), 0755))
 			require.NoError(t, os.Symlink(target, link))
 
-			_, err := setupUserDataDir(homeDir, "", "")
+			_, err := setupUserDataDir(t.Context(), homeDir, "", "")
 			assert.Error(t, err)
 
 			data, err := os.ReadFile(target)
@@ -272,7 +272,7 @@ func TestSetupUserDataDirRefusesSymlinkedDirs(t *testing.T) {
 			require.NoError(t, os.MkdirAll(filepath.Dir(link), 0755))
 			require.NoError(t, os.Symlink(target, link))
 
-			_, err := setupUserDataDir(homeDir, "", "")
+			_, err := setupUserDataDir(t.Context(), homeDir, "", "")
 			assert.Error(t, err)
 
 			entries, err := os.ReadDir(target)
@@ -290,7 +290,7 @@ func TestSetupUserDataDirFollowsASymlinkedHome(t *testing.T) {
 	homeDir := filepath.Join(t.TempDir(), "home")
 	require.NoError(t, os.Symlink(target, homeDir))
 
-	userDataDir, err := setupUserDataDir(homeDir, "", "")
+	userDataDir, err := setupUserDataDir(t.Context(), homeDir, "", "")
 	require.NoError(t, err)
 
 	cfg := GetCodeServerConfig()
@@ -324,7 +324,7 @@ func TestChownUserDataDirDoesNotFollowSymlinks(t *testing.T) {
 	username, groupname := movableOwnership(t, ordinary)
 	beforeOrdinary := fileOwner(t, ordinary)
 
-	require.NoError(t, chownUserDataDir(userDataDir, username, groupname))
+	require.NoError(t, chownUserDataDir(t.Context(), userDataDir, username, groupname))
 
 	assert.Equal(t, beforeTarget, fileOwner(t, target), "a symlink target must keep its owner")
 	assert.Equal(t, beforeLink, fileOwner(t, link), "the link itself is not the walk's to re-own either")
@@ -492,7 +492,7 @@ func TestSetupUserDataDir(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Call setupUserDataDir (empty username/groupname since we're not running as root in tests)
-	userDataDir, err := setupUserDataDir(tempDir, "", "")
+	userDataDir, err := setupUserDataDir(t.Context(), tempDir, "", "")
 	assert.NoError(t, err, "setupUserDataDir should not error")
 	assert.NotEmpty(t, userDataDir, "userDataDir should not be empty")
 
@@ -540,10 +540,10 @@ func TestSetupUserDataDirIdempotent(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Call setupUserDataDir twice
-	userDataDir1, err := setupUserDataDir(tempDir, "", "")
+	userDataDir1, err := setupUserDataDir(t.Context(), tempDir, "", "")
 	assert.NoError(t, err)
 
-	userDataDir2, err := setupUserDataDir(tempDir, "", "")
+	userDataDir2, err := setupUserDataDir(t.Context(), tempDir, "", "")
 	assert.NoError(t, err)
 
 	// Both calls should return the same path
@@ -580,7 +580,7 @@ func TestChownUserDataDirSkipsHardLinkedFiles(t *testing.T) {
 	beforeOutside := fileOwner(t, outside)
 	beforeOrdinary := fileOwner(t, ordinary)
 
-	require.NoError(t, chownUserDataDir(userDataDir, username, groupname))
+	require.NoError(t, chownUserDataDir(t.Context(), userDataDir, username, groupname))
 
 	assert.Equal(t, beforeOutside, fileOwner(t, outside),
 		"an inode that answers to another name outside the tree must keep its owner")
@@ -607,12 +607,56 @@ func TestChownUserDataDirSkipsHardLinkedNonRegularFiles(t *testing.T) {
 	beforeOutside := fileOwner(t, outside)
 	beforeOrdinary := fileOwner(t, ordinary)
 
-	require.NoError(t, chownUserDataDir(userDataDir, username, groupname))
+	require.NoError(t, chownUserDataDir(t.Context(), userDataDir, username, groupname))
 
 	assert.Equal(t, beforeOutside, fileOwner(t, outside),
 		"a non-regular inode that answers to another name outside the tree must keep its owner")
 	assert.NotEqual(t, beforeOrdinary, fileOwner(t, ordinary),
 		"the walk must still re-own the files this tree is the only name for")
+}
+
+// TestChownUserDataDirStopsOnACancelledContext pins the narrow half: a walk
+// handed a context that is already done re-owns nothing and says why. That the
+// walk also stops once it is under way is TestEachNameStopsMidDirectory.
+func TestChownUserDataDirStopsOnACancelledContext(t *testing.T) {
+	userDataDir := t.TempDir()
+	entry := filepath.Join(userDataDir, "f")
+	require.NoError(t, os.WriteFile(entry, nil, 0600))
+
+	username, groupname := movableOwnership(t, entry)
+	beforeDir, beforeEntry := fileOwner(t, userDataDir), fileOwner(t, entry)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	assert.ErrorIs(t, chownUserDataDir(ctx, userDataDir, username, groupname), context.Canceled)
+	assert.Equal(t, beforeDir, fileOwner(t, userDataDir), "the root of the tree is re-owned before any entry is")
+	assert.Equal(t, beforeEntry, fileOwner(t, entry), "a cancelled walk must re-own nothing at all")
+}
+
+// TestEachNameStopsMidDirectory: a cancel that registered only before the first
+// read would still let one closed session chown its way through a directory of
+// any width, leaving another such walk behind on every open and close.
+func TestEachNameStopsMidDirectory(t *testing.T) {
+	dir := t.TempDir()
+	for i := range readdirBatch + 1 {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, strconv.Itoa(i)), nil, 0600))
+	}
+
+	parent, err := openDir(dir, dirFlags)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = parent.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	seen := 0
+	err = eachName(ctx, parent, func(string) error {
+		seen++
+		cancel()
+		return nil
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, seen, "the cancel must land before the next entry, not at the next batch")
 }
 
 // TestChownUserDataDirStopsDescendingAtTheLimit: the walk holds one directory fd
@@ -635,7 +679,7 @@ func TestChownUserDataDirStopsDescendingAtTheLimit(t *testing.T) {
 	beforeSibling := fileOwner(t, sibling)
 	beforeDeepest := fileOwner(t, deepest)
 
-	require.NoError(t, chownUserDataDir(root, username, groupname))
+	require.NoError(t, chownUserDataDir(t.Context(), root, username, groupname))
 
 	assert.NotEqual(t, beforeSibling, fileOwner(t, sibling),
 		"a subtree too deep to enter must not cost the files beside it their owner")
@@ -651,7 +695,7 @@ func TestChownUserDataDirStopsDescendingAtTheLimit(t *testing.T) {
 func TestSetupUserDataDirRefusesAMissingHome(t *testing.T) {
 	homeDir := filepath.Join(t.TempDir(), "absent")
 
-	_, err := setupUserDataDir(homeDir, "", "")
+	_, err := setupUserDataDir(t.Context(), homeDir, "", "")
 
 	assert.ErrorIs(t, err, os.ErrNotExist)
 	_, statErr := os.Stat(homeDir)
@@ -670,7 +714,7 @@ func TestSetupUserDataDirUnderConcurrentSessions(t *testing.T) {
 	for range sessions {
 		go func() {
 			<-start
-			_, err := setupUserDataDir(homeDir, "", "")
+			_, err := setupUserDataDir(t.Context(), homeDir, "", "")
 			errs <- err
 		}()
 	}
@@ -694,7 +738,7 @@ func TestSetupUserDataDirUnderConcurrentSessions(t *testing.T) {
 // another session nor an unrelated dot file is taken with it.
 func TestSetupUserDataDirSweepsStaleTempFiles(t *testing.T) {
 	homeDir := t.TempDir()
-	userDataDir, err := setupUserDataDir(homeDir, "", "")
+	userDataDir, err := setupUserDataDir(t.Context(), homeDir, "", "")
 	require.NoError(t, err)
 
 	aged := time.Now().Add(-2 * staleTempAge)
@@ -709,7 +753,7 @@ func TestSetupUserDataDirSweepsStaleTempFiles(t *testing.T) {
 	inFlight := filepath.Join(userDataDir, tempPrefix(userDataConfigFile)+"inflight"+tempSuffix)
 	require.NoError(t, os.WriteFile(inFlight, nil, 0600))
 
-	_, err = setupUserDataDir(homeDir, "", "")
+	_, err = setupUserDataDir(t.Context(), homeDir, "", "")
 	require.NoError(t, err)
 
 	_, err = os.Stat(abandoned)
@@ -725,7 +769,7 @@ func TestSetupUserDataDirSweepsStaleTempFiles(t *testing.T) {
 // the root agent on every editor start for that user.
 func TestSetupUserDataDirSurvivesAFifoNamedLikeATemp(t *testing.T) {
 	homeDir := t.TempDir()
-	userDataDir, err := setupUserDataDir(homeDir, "", "")
+	userDataDir, err := setupUserDataDir(t.Context(), homeDir, "", "")
 	require.NoError(t, err)
 
 	fifo := filepath.Join(userDataDir, tempPrefix(userDataConfigFile)+"fifo"+tempSuffix)
@@ -735,7 +779,7 @@ func TestSetupUserDataDirSurvivesAFifoNamedLikeATemp(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := setupUserDataDir(homeDir, "", "")
+		_, err := setupUserDataDir(t.Context(), homeDir, "", "")
 		done <- err
 	}()
 

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -676,3 +676,36 @@ func TestSetupUserDataDirSweepsStaleTempFiles(t *testing.T) {
 	assert.FileExists(t, inFlight, "a temp file another session is still filling must be left alone")
 	assert.FileExists(t, unrelated, "the sweep must take only names writeFileAt could have made")
 }
+
+// TestSetupUserDataDirSurvivesAFifoNamedLikeATemp: the temp name is predictable
+// and mkfifo needs no privilege, so the user can park a FIFO where the sweep
+// will open it. An O_RDONLY open of a FIFO waits for a writer, and no signal
+// reaches that wait, so a setup without O_NONBLOCK strands a goroutine inside
+// the root agent on every editor start for that user.
+func TestSetupUserDataDirSurvivesAFifoNamedLikeATemp(t *testing.T) {
+	homeDir := t.TempDir()
+	userDataDir, err := setupUserDataDir(homeDir, "", "")
+	require.NoError(t, err)
+
+	fifo := filepath.Join(userDataDir, tempPrefix(userDataConfigFile)+"fifo"+tempSuffix)
+	require.NoError(t, unix.Mkfifo(fifo, 0600))
+	aged := time.Now().Add(-2 * staleTempAge)
+	require.NoError(t, os.Chtimes(fifo, aged, aged))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := setupUserDataDir(homeDir, "", "")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("setupUserDataDir blocked opening the FIFO")
+	}
+
+	info, err := os.Lstat(fifo)
+	require.NoError(t, err)
+	assert.Equal(t, os.ModeNamedPipe, info.Mode()&os.ModeType, "the sweep must unlink only regular files")
+}

--- a/pkg/runner/editor_unix_test.go
+++ b/pkg/runner/editor_unix_test.go
@@ -396,17 +396,49 @@ func TestWriteFileAtKeepsTheModeItReplaces(t *testing.T) {
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "the replacement keeps the mode it replaced")
 }
 
+// nameLimit returns the longest file name dir accepts. NAME_MAX is not portable
+// to query from Go here—unix.Pathconf exists on darwin and not on linux—so the
+// limit is found by bisecting between one character and a length no filesystem
+// in use accepts. The upper bound is asserted rather than assumed.
+func nameLimit(t *testing.T, dir string) int {
+	t.Helper()
+
+	fits := func(n int) bool {
+		path := filepath.Join(dir, strings.Repeat("n", n))
+		if err := os.WriteFile(path, nil, 0600); err != nil {
+			return false
+		}
+		require.NoError(t, os.Remove(path))
+		return true
+	}
+
+	lo, hi := 1, 4097
+	require.True(t, fits(lo))
+	require.False(t, fits(hi), "no name length is rejected, so this test cannot fail the temp create")
+	for hi-lo > 1 {
+		mid := (lo + hi) / 2
+		if fits(mid) {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return lo
+}
+
 // TestWriteFileAtLeavesNothingWhenTheTempWriteFails pins the failure path: the
-// call must not create the target it never managed to fill. The name is sized so
-// that it fits but the longer temp name derived from it does not, which fails the
-// temp create and nothing else.
+// call must not create the target it never managed to fill. The name sits just
+// under what the filesystem accepts, so it fits while the longer temp name
+// derived from it does not, which fails the temp create and nothing else.
 func TestWriteFileAtLeavesNothingWhenTheTempWriteFails(t *testing.T) {
 	dir := t.TempDir()
 	parent, err := openDir(dir, dirFlags)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = parent.Close() })
 
-	name := strings.Repeat("n", 250)
+	// The temp name adds a leading dot, a separating dot, at least one base36
+	// digit and ".tmp", so three under the limit is enough to push it over.
+	name := strings.Repeat("n", nameLimit(t, dir)-3)
 
 	require.Error(t, writeFileAt(parent, name, []byte("x")))
 

--- a/pkg/runner/editor_windows.go
+++ b/pkg/runner/editor_windows.go
@@ -10,7 +10,7 @@ import "errors"
 // path-based MkdirAll and WriteFile, which nothing here would protect: the
 // agent runs as LocalSystem, and a directory junction, which any user can
 // create without the privilege a symlink requires, redirects a path-based
-// write the same way a symlink does on unix. Whoever enables editor tunnels on
+// write the same way a symlink does on Unix. Whoever enables editor tunnels on
 // Windows (#379) writes the junction-safe counterpart to editor_unix.go first,
 // and the tests below are what says so.
 

--- a/pkg/runner/editor_windows.go
+++ b/pkg/runner/editor_windows.go
@@ -2,41 +2,24 @@
 
 package runner
 
-import (
-	"os"
-	"path/filepath"
-)
+import "errors"
 
 // Editor tunnels are rejected on Windows before they reach this code
-// (editorTunnelSupported, pkg/executor/handlers/tunnel/tunnel.go), which is the
-// only reason neither function below is exploitable today.
-//
-// chownTreeNoFollow is inert: os.Lchown always fails with EWINDOWS here.
-// setupUserDataFiles is not — it really creates and writes the files, with no
-// defense matching the openat/O_NOFOLLOW walk in editor_unix.go. Before
-// code-server support lands (#379) it needs one: the agent runs as LocalSystem,
-// and a directory junction, which any user can create without the privilege a
-// symlink requires, redirects MkdirAll and WriteFile the same way a symlink
-// does on unix.
+// (editorTunnelSupported, pkg/executor/handlers/tunnel/tunnel.go), so neither
+// function below is reachable today. Both refuse rather than fall back to
+// path-based MkdirAll and WriteFile, which nothing here would protect: the
+// agent runs as LocalSystem, and a directory junction, which any user can
+// create without the privilege a symlink requires, redirects a path-based
+// write the same way a symlink does on unix. Whoever enables editor tunnels on
+// Windows (#379) writes the junction-safe counterpart to editor_unix.go first,
+// and the tests below are what says so.
+
+var errUserDataDirUnsupported = errors.New("code-server user data dir is not implemented on Windows")
 
 func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte) error {
-	userDataDir := filepath.Join(homeDir, dirName)
-	userDir := filepath.Join(userDataDir, userDataUserDir)
-
-	if err := os.MkdirAll(userDir, 0755); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(userDataDir, userDataConfigFile), configData, 0644); err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(userDir, userDataSettingsFile), settingsData, 0644)
+	return errUserDataDirUnsupported
 }
 
 func chownTreeNoFollow(root string, uid, gid int) error {
-	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		return os.Lchown(path, uid, gid)
-	})
+	return errUserDataDirUnsupported
 }

--- a/pkg/runner/editor_windows.go
+++ b/pkg/runner/editor_windows.go
@@ -11,8 +11,8 @@ import "errors"
 // agent runs as LocalSystem, and a directory junction, which any user can
 // create without the privilege a symlink requires, redirects a path-based
 // write the same way a symlink does on Unix. Whoever enables editor tunnels on
-// Windows (#379) writes the junction-safe counterpart to editor_unix.go first,
-// and the tests below are what says so.
+// Windows (#379) writes the junction-safe counterpart of editor_unix.go here
+// first, and editor_windows_test.go is what says so.
 
 var errUserDataDirUnsupported = errors.New("code-server user data dir is not implemented on Windows")
 

--- a/pkg/runner/editor_windows.go
+++ b/pkg/runner/editor_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package runner
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Editor tunnels are rejected on Windows before they reach this code
+// (editorTunnelSupported, pkg/executor/handlers/tunnel/tunnel.go), which is the
+// only reason neither function below is exploitable today.
+//
+// chownTreeNoFollow is inert: os.Lchown always fails with EWINDOWS here.
+// setupUserDataFiles is not — it really creates and writes the files, with no
+// defense matching the openat/O_NOFOLLOW walk in editor_unix.go. Before
+// code-server support lands (#379) it needs one: the agent runs as LocalSystem,
+// and a directory junction, which any user can create without the privilege a
+// symlink requires, redirects MkdirAll and WriteFile the same way a symlink
+// does on unix.
+
+func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte) error {
+	userDataDir := filepath.Join(homeDir, dirName)
+	userDir := filepath.Join(userDataDir, userDataUserDir)
+
+	if err := os.MkdirAll(userDir, 0755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(userDataDir, userDataConfigFile), configData, 0644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(userDir, userDataSettingsFile), settingsData, 0644)
+}
+
+func chownTreeNoFollow(root string, uid, gid int) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Lchown(path, uid, gid)
+	})
+}

--- a/pkg/runner/editor_windows.go
+++ b/pkg/runner/editor_windows.go
@@ -2,7 +2,10 @@
 
 package runner
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 // Editor tunnels are rejected on Windows before they reach this code
 // (editorTunnelSupported, pkg/executor/handlers/tunnel/tunnel.go), so neither
@@ -16,10 +19,10 @@ import "errors"
 
 var errUserDataDirUnsupported = errors.New("code-server user data dir is not implemented on Windows")
 
-func setupUserDataFiles(homeDir, dirName string, configData, settingsData []byte) error {
+func setupUserDataFiles(ctx context.Context, homeDir, dirName string, configData, settingsData []byte) error {
 	return errUserDataDirUnsupported
 }
 
-func chownTreeNoFollow(root string, uid, gid int) error {
+func chownTreeNoFollow(ctx context.Context, root string, uid, gid int) error {
 	return errUserDataDirUnsupported
 }

--- a/pkg/runner/editor_windows_test.go
+++ b/pkg/runner/editor_windows_test.go
@@ -13,9 +13,9 @@ import (
 // a junction-safe implementation goes red here rather than quietly writing
 // through whatever the path resolves to.
 func TestUserDataDirIsUnsupportedOnWindows(t *testing.T) {
-	assert.ErrorIs(t, setupUserDataFiles(t.TempDir(), "d", nil, nil), errUserDataDirUnsupported)
-	assert.ErrorIs(t, chownTreeNoFollow(t.TempDir(), 0, 0), errUserDataDirUnsupported)
+	assert.ErrorIs(t, setupUserDataFiles(t.Context(), t.TempDir(), "d", nil, nil), errUserDataDirUnsupported)
+	assert.ErrorIs(t, chownTreeNoFollow(t.Context(), t.TempDir(), 0, 0), errUserDataDirUnsupported)
 
-	_, err := setupUserDataDir(t.TempDir(), "", "")
+	_, err := setupUserDataDir(t.Context(), t.TempDir(), "", "")
 	assert.ErrorIs(t, err, errUserDataDirUnsupported)
 }

--- a/pkg/runner/editor_windows_test.go
+++ b/pkg/runner/editor_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUserDataDirIsUnsupportedOnWindows turns the header comment in
+// editor_windows.go into behavior: enabling editor tunnels on Windows without
+// a junction-safe implementation goes red here rather than quietly writing
+// through whatever the path resolves to.
+func TestUserDataDirIsUnsupportedOnWindows(t *testing.T) {
+	assert.ErrorIs(t, setupUserDataFiles(t.TempDir(), "d", nil, nil), errUserDataDirUnsupported)
+	assert.ErrorIs(t, chownTreeNoFollow(t.TempDir(), 0, 0), errUserDataDirUnsupported)
+
+	_, err := setupUserDataDir(t.TempDir(), "", "")
+	assert.ErrorIs(t, err, errUserDataDirUnsupported)
+}


### PR DESCRIPTION
## Background

`setupUserDataDir` builds `$HOME/.alpamon-editor` for code-server: `config.yaml`, `User/settings.json`, and, when alpamon runs as root, an ownership pass so the demoted user can edit them afterwards. It did all three with `os.MkdirAll`, `os.WriteFile`, and a `filepath.Walk` of `os.Chown`.

Every one of those resolves a whole path, and resolving a path follows the symbolic links in it. The home directory belongs to the user rather than to alpamon, so its contents are not something this function gets to assume: a link at `.alpamon-editor/User/settings.json` sends the write to wherever the link points, and the `Walk` hands the chown to the link target instead of the link. The function manages one directory tree and should act on nothing outside it, whatever the tree happens to contain when it runs.

Two smaller things came out of the same reading. `UserDataDirName` reaches the join from `CodeServerConfig` with nothing checking its shape, and the writes used `O_TRUNC`, which empties the file before it refills it.

## Changes

### One component at a time

`setupUserDataFiles` and `chownTreeNoFollow` replace the path-based calls (`pkg/runner/editor_unix.go`). Both hold a directory file descriptor and resolve a single name against it at each step, with `O_NOFOLLOW` on the open, so a link is refused rather than followed. Nothing is resolved by name twice.

The home directory's own entry is the one exception. It lives in a directory the user does not own, so it is not theirs to swap, and admins do point home directories at another filesystem with a symlink. That open gets its own flag set without `O_NOFOLLOW`; every step under it keeps the guard.

`O_NOFOLLOW` covers only the last component of the name it is handed, so every name these helpers take has to be one plain component. Three of them are literals, now named in `editor.go`; `ToArgs` reads `config.yaml` back for the `--config` flag. The fourth, `UserDataDirName`, is configuration, so `validateUserDataDirName` rejects it up front when it is not a single usable component. `.` needs its own clause: `filepath.IsLocal` accepts it, and joining it gives back the home directory.

### Nothing outside the tree

The walk re-owns what the tree is the only name for, and nothing else. Each entry is opened once and the stat, the chown and the descent all go through that descriptor, so the inode a check clears is the inode the chown reaches. Resolving the name a second time to act on it is what would let the user rename something else onto it in between, and `rename` inside their own directory is atomic, needs no privilege, and can be retried against every editor start.

A hard link is not a link to a file: it is a second name for the same inode. A user who plants `.alpamon-editor/x` as a hard link to a file they can read would have had root hand them its ownership, so an entry whose link count is above one is skipped. Directories are exempt, since `.` always gives them a second link. Every other type is not: `link` does not care what the inode is, and `fs.protected_hardlinks` is 0 unless something sets it, so a root-owned socket or FIFO is reachable the same way as a regular file.

Two kinds of entry drop out of being opened before being acted on. A symlink cannot be opened under `O_NOFOLLOW`, so it is skipped rather than re-owned; its own ownership decides nothing inside a directory the user already controls, and the target is what mattered. A socket cannot be opened at all, which is the safe direction. Those two and an entry a live code-server has just removed are the three the walk skips on—`ELOOP`, `ENXIO`, `ENOENT`—because abandoning the walk leaves whatever it had not reached root-owned, and `setupUserDataDir` only logs a chown failure. Every other errno fails the walk instead. `EMFILE` and `ENFILE` say nothing about the entry, so skipping on them skips every entry in turn and reports success over a tree that is still root-owned end to end, and the agent shares one descriptor table with the WebSocket connection and the FTP sessions.

The recursion holds one directory file descriptor per level, and what lives under `.alpamon-editor` is whatever the user puts there. `configs/alpamon.service` sets no `LimitNOFILE`, so the systemd default governs the whole agent, and a deep enough chain would not merely fail the chown but starve the WebSocket connection and the FTP sessions of descriptors. `filepath.Walk` held no descriptors, so this cost is new here. `maxChownDepth` bounds it at 64, checked immediately before the child open so the descriptor the budget protects is never the one that overruns it, and an over-deep subtree is skipped with a warning rather than failing the walk: readdir order on ext4 is hash order, so a subtree nested deep enough could otherwise be met before `User/` and leave it root-owned.

The tree is also the user's to fill sideways, so reading a directory whole would put a slice of however many entries they chose inside the root agent. `eachName` reads names a batch at a time and checks the context between them, and the context comes from the `CodeServerManager`, so closing an editor session ends the walk instead of leaving one running per open and close.

The directory and the two files are created `0700` and `0600` rather than `0755` and `0644`. code-server fills this tree as the user, and what it puts there is not neutral: `User/History` holds VS Code's local history, a snapshot of every file opened in the editor, and `User/globalStorage` holds extension state and token stores. `mkdirOpenAt` also `fchmod`s a directory that was already there, so a tree left over from an earlier alpamon is tightened on the next editor start rather than staying open. A file that exists keeps the mode it had, which is what lets an admin tighten `settings.json` further; only the mode a new file is created with moves. A `config.yaml` an older install left `0644` therefore stays `0644`, and what keeps it out of other accounts is the `0700` directory around it rather than its own mode. The two policies are opposite on purpose: a directory here holds only what code-server writes on the user's behalf, so there is no admin intent in its mode to preserve.

### Atomic replacement

`RegisterTunnel` deduplicates tunnels by session ID, not by user (`pkg/runner/tunnel_client.go`), so one user can hold two editor tunnels at once. Each gets its own `CodeServerManager` and each runs `setupUserDataDir`, which puts two writers on the same `settings.json` while a running code-server watches that file. The `O_TRUNC` write left a window in which a reader saw an empty file.

The bytes now go to a sibling temp file that `renameat` swaps into place, so a reader gets the old file or the new one. The temp name carries a random suffix rather than a pid, since the two writers share a process.

`renameat` replaces a symlink sitting at the target instead of following it, so the swap alone would already stay inside the tree, but it does so silently. A stat with `AT_SYMLINK_NOFOLLOW` runs first so a planted link is reported rather than replaced. It only reports: the rename stays inside the tree whatever appears after the check, which is why a stat is enough here and would not be enough anywhere else in the file. It also creates nothing, so a failure in any later step leaves the target absent rather than empty.

A replaced file arrives with the mode its temp file was created with, where truncating in place left the old mode alone. The same stat reports it, so a regular file passes its own mode to the temp create. `O_CREAT` applies that mode as `mode &^ umask`, which would narrow it rather than preserve it, so an `fchmod` follows the create; `fchmod` is not subject to the umask. Ownership is left alone: it cannot widen access the way a mode can, `chownUserDataDir` resets it on the path where it matters, and elsewhere the process already runs as the user who owns the tree.

What the temp file costs is a leftover. A process that dies between the create and the rename leaves one behind, where an in-place truncate left no residue, and the directory belongs to the user, so nothing else would ever collect it. `setupUserDataFiles` sweeps each directory before it writes, taking only entries whose name a `writeFileAt` of that file could have produced and whose age is over an hour, so a temp another session is filling right now is left alone. The age is read through a descriptor rather than off the name, so the entry that is measured is the entry that is unlinked. That open carries `O_NONBLOCK` as well as `O_NOFOLLOW`: the temp name is predictable and `mkfifo` needs no privilege, and `O_RDONLY` on a FIFO waits for a writer that never comes, which would hang the setup inside the root agent with no signal reaching it. A sweep that fails is logged and ignored.

### Windows

`setupUserDataFiles` and `chownTreeNoFollow` return an error on Windows rather than keeping the path-based implementation the unix side replaced. Nothing reachable changes: `editorTunnelSupported` rejects editor tunnels there before any of this runs (`pkg/executor/handlers/tunnel/tunnel.go`), and `chownTreeNoFollow` sat behind `os.Getuid() == 0`, which Windows never satisfies. What changes is the day someone lifts that rejection. The agent runs as LocalSystem, and a directory junction, which any user can create without the privilege a symlink requires, redirects a path-based write the way a symlink does on unix, so `editor_windows.go` needs a junction-safe implementation of its own before that (#379). `editor_windows_test.go` says so as a test instead of a comment.

`TestSetupUserDataDir` and `TestSetupUserDataDirIdempotent` move to `editor_unix_test.go` with that, since they assert files landing on disk and `editor_test.go` carries no build tag. The name check runs before either platform implementation, so its tests stay in `editor_test.go`.

## Testing

`go test ./... -p 1 -count=1` passes:

```
ok  	github.com/alpacax/alpamon/v2/pkg/runner	35.539s
```

`go vet ./...`, `GOOS=windows go vet ./pkg/runner/` and `gofmt -l` are all clean. `golangci-lint run ./pkg/runner/...` reports one issue, `commit_types.go:162: field expireDate is unused`, in a file this branch does not touch.

Every target in `.goreleaser.yaml` compiles: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64` and `windows/amd64`.

Each new test was seen fail first, by putting back the code it covers:

| Reverted to | Fails |
| --- | --- |
| `os.MkdirAll` / `os.WriteFile` / `filepath.Walk`, name check dropped | `TestSetupUserDataDirRefusesSymlinkedFiles`, `TestSetupUserDataDirRefusesSymlinkedDirs`, `TestChownUserDataDirDoesNotFollowSymlinks`, all five cases of `TestValidateUserDataDirNameRejectsUnsafeNames` |
| `O_TRUNC` in `writeFileAt` | `TestWriteFileAtReplacesInPlaceFile` |
| the symlink check as an `O_CREAT` open | `TestWriteFileAtLeavesNothingWhenTheTempWriteFails` |
| a fixed 0644 on the temp create, or the `fchmod` dropped | `TestWriteFileAtKeepsTheModeItReplaces` |
| `O_NOFOLLOW` on the home directory open | `TestSetupUserDataDirFollowsASymlinkedHome` |
| the hard link skip dropped | `TestChownUserDataDirSkipsHardLinkedFiles` |
| that skip narrowed back to `S_IFREG` | `TestChownUserDataDirSkipsHardLinkedNonRegularFiles` |
| a name-based `lchown` for entries that fail to open | `TestChownUserDataDirDoesNotFollowSymlinks` |
| the over-deep subtree failing the walk instead of being skipped, or the recursion in `chownChildren` removed | `TestChownUserDataDirStopsDescendingAtTheLimit` |
| the per-entry context check in `eachName` dropped | `TestEachNameStopsMidDirectory` |
| the context check before the root chown dropped | `TestChownUserDataDirStopsOnACancelledContext` |
| `userDataDirMode` and `userDataFileMode` widened back to `0755` and `0644`, or the `fchmod` on an existing directory dropped | `TestSetupUserDataDirKeepsTheTreeToItsUser` |
| the mode carry-over in `writeFileAt` dropped | `TestSetupUserDataDirKeepsAnOlderFileMode` |
| the temp sweep dropped | `TestSetupUserDataDirSweepsStaleTempFiles` |
| `O_NONBLOCK` dropped from the sweep's open | `TestSetupUserDataDirSurvivesAFifoNamedLikeATemp` |
| `os.MkdirAll` creating an absent home | `TestSetupUserDataDirRefusesAMissingHome` |
| a fixed temp name, so two sessions collide | `TestSetupUserDataDirUnderConcurrentSessions` |
| the name check widened | `TestValidateUserDataDirNameAcceptsAPlainComponent` |

`TestWriteFileAtReplacesInPlaceFile` holds a second hard link to the old inode and asserts it still reads `old` afterwards, which an in-place truncate would have destroyed, plus that no temp file outlives the call. It is where atomicity from a reader's side is pinned; `TestSetupUserDataDirUnderConcurrentSessions` reads only after all eight sessions have finished, so it covers that none of them fails and the file they leave is whole, and says so rather than claiming more.

`TestWriteFileAtLeavesNothingWhenTheTempWriteFails` picks a name long enough that the derived temp name exceeds `NAME_MAX`, which fails the temp create and nothing else, and asserts `os.ErrNotExist` at the target.

`TestWriteFileAtKeepsTheModeItReplaces` runs under an explicit `umask` of `0077` against a `0644` file, so the mode and the umask disagree by construction. The earlier version used `0600`, which neither `022` nor `077` takes a bit off, and so passed with the umask bug present.

`TestChownUserDataDirDoesNotFollowSymlinks` runs on both sides of the root check: as root it plants the target in a temp directory, and as a regular user it points the link at `/etc/passwd`, where following it would fail with `EPERM`. Both the link and its target must keep their owner, and an ordinary file beside them must not, so the case cannot pass by the chown having done nothing at all. The hard-link cases carry the same witness.

`TestChownUserDataDirStopsDescendingAtTheLimit` pins both sides of the budget. A tree nested exactly `maxChownDepth` deep is still descended, the level past that is not, and the `settings.json` sitting beside the deep subtree changes hands whichever of the two readdir returns first. A witness one level inside the tree carries the descent itself: without it, an unchanged owner on the deepest entry reads the same whether the walk stopped at the limit or never entered, and turning the descent condition into `if true` left the whole package green.

`TestEachNameStopsMidDirectory` fills a directory past `readdirBatch` and cancels from inside the callback on its first call, requiring an exact count of one. Checking the context only per batch, or only before the first read, gives 512.

The `EMFILE` and `ENFILE` branch added in this round is deliberately uncovered. Reaching it means lowering `RLIMIT_NOFILE` for the whole test binary, which every other case in the package shares under `-p 1`.

`TestUserDataDirIsUnsupportedOnWindows` was not run here—it is `//go:build windows`, so the Windows CI job is the first place it executes.

Each of the six commits in this round was checked out on its own and builds and passes `go test ./pkg/runner/` there, and the rounds before it were checked the same way when they landed.

