### PR TITLE
fix(pty): give the WebSocket recovery loop five minutes before ending the shell

### DIFF
--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -52,7 +52,11 @@ type PtyClient struct {
 }
 
 const (
-	maxRecoveryTimeout       = 1 * time.Minute
+	// maxRecoveryTimeout bounds how long a single recovery attempt is allowed to keep
+	// retrying before the session gives up and ends the shell. Short network
+	// interruptions and upstream restarts commonly last longer than a minute, so the
+	// budget is generous enough to outlive them.
+	maxRecoveryTimeout       = 5 * time.Minute
 	reconnectPtyWebsocketURL = "/api/websh/pty-channels/"
 	bufferSize               = 8192
 


### PR DESCRIPTION
## Summary

Extends the Websh PTY WebSocket recovery budget from 1 minute to 5 minutes so that short network interruptions and upstream restarts, which commonly last longer than a minute, don't end an otherwise-healthy shell session.

## Change

- `pkg/runner/pty.go`: `maxRecoveryTimeout` raised from `1 * time.Minute` to `5 * time.Minute`, with a comment on the constant explaining the rationale.
- Backoff schedule (`retry.ExponentialBackoff`, `InitialInterval: 1s`, `MaxInterval: 30s`, doubling each attempt) is unchanged. With a 5-minute budget the retry sequence is roughly 1, 2, 4, 8, 16, 30, 30, 30, 30, 30, 30, 30, 30s (~13 attempts) before the budget is exhausted, which still gives a reasonable ramp-up followed by many retries at the 30s cap. No change to the cap looked necessary.
- No Windows-specific constant to update: `pkg/runner/pty_windows.go` has its own `bufferSize`/`sessionCloseCode` block but no recovery timeout, because Windows skips WebSocket recovery entirely (see the comment at `pkg/runner/pty_windows.go:225`).
- No other comment, doc, or test hardcodes the old 1-minute value.

## Behavior while disconnected

While the WebSocket is down and recovery is in progress, PTY output is **bounded in memory, then backpressure blocks the read loop (and eventually the child process)**—it is not discarded and not unbounded.

- `ptyToWs` is a buffered channel of capacity `bufferSize` (8192 slots): `pkg/runner/pty.go:79-80`, `pkg/runner/pty.go:57`.
- `readFromPty` (`pkg/runner/pty.go:285-304`) reads from the PTY master and sends each chunk into `ptyToWs`. The send is behind a `select` with `ctx.Done()`, so once the channel is full it blocks there rather than dropping data.
- `writeToWebsocket` (`pkg/runner/pty.go:306-330`) is the only consumer of `ptyToWs`. On a write error it calls `waitForRecovery` (`pkg/runner/pty.go:216-236`), which blocks until `recoveryDone` closes or the context is cancelled—so during recovery this goroutine stops draining `ptyToWs` entirely.
- With the consumer stalled, `ptyToWs` fills to its 8192-slot capacity, after which `readFromPty`'s send blocks, which stops further `ptmx.Read` calls. That leaves the kernel PTY buffer to fill, and standard PTY flow control then blocks the child process's own writes until the buffer drains—so a long recovery pauses the child process rather than silently losing its output or growing memory without bound.

## Testing

```
$ gofmt -l .
(no output)

$ go vet ./...
(no output)

$ go build -v ./cmd/alpamon && go build ./...
github.com/alpacax/alpamon/v2/cmd/alpamon
(both succeeded, no output)

$ go test ./... -p 1
...
ok  	github.com/alpacax/alpamon/v2/pkg/runner	0.952s
ok  	github.com/alpacax/alpamon/v2/pkg/scheduler	0.010s
ok  	github.com/alpacax/alpamon/v2/pkg/signing	0.046s
...
ok  	github.com/alpacax/alpamon/v2/pkg/updater	0.169s
ok  	github.com/alpacax/alpamon/v2/pkg/utils	0.242s
(all packages passed, no FAIL lines)

$ go test -race -v ./pkg/runner/...
=== RUN   TestPtyRecovery_ReadSideOnly
--- PASS: TestPtyRecovery_ReadSideOnly (0.02s)
=== RUN   TestPtyRecovery_WriteSideOnly
--- PASS: TestPtyRecovery_WriteSideOnly (0.02s)
=== RUN   TestPtyRecovery_StormNoGoroutineLeak
--- PASS: TestPtyRecovery_StormNoGoroutineLeak (0.02s)
...
PASS
ok  	github.com/alpacax/alpamon/v2/pkg/runner	2.330s
```

(Ent codegen was regenerated per the repo's CLAUDE.md before building/testing; `go.mod`/`go.sum` were unchanged by `go mod tidy`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132tX6w2ET78zpfYowjWkKk
