### PR TITLE
docs: add Raspberry Pi OS to the supported platforms table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installed on each managed server, Alpamon establishes an outbound-only connectio
 
 | Platform | Minimum version | Arch |
 | --- | --- | --- |
-| Linux | Ubuntu 18.04+, Debian 11+, RHEL / Rocky / AlmaLinux 8+, Oracle Linux 8+, Amazon Linux 2 / 2023, Fedora (current or previous) | amd64, arm64 |
+| Linux | Ubuntu 18.04+, Debian 11+, RHEL / Rocky / AlmaLinux 8+, Oracle Linux 8+, Amazon Linux 2 / 2023, Fedora (current or previous), Raspberry Pi OS (64-bit) | amd64, arm64 |
 | Linux (best-effort) | openSUSE Leap 15+, SLES 15+ | amd64, arm64 |
 | macOS | 11 (Big Sur) or later | amd64, arm64 (Apple Silicon) |
 | Windows | Windows 10 (1803+) / Windows 11, Windows Server 2019 or later | amd64 |


### PR DESCRIPTION
Raspberry Pi OS (64-bit) is a supported platform—Debian-based, covered by the existing arm64 release builds—but the README's platform table omitted it. This adds it to the Linux row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)