### PR TITLE
fix(executor): create missing parent directories under privilege demotion

### DIFF
--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -121,14 +121,17 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	createdRoot := firstMissingAncestor(parentDir)
 	// Only a target this call creates may be removed on failure: mkdir -p exits 0 on an
 	// existing parent, so a tee that fails to open a pre-existing file leaves it untouched,
-	// and removing it would delete something the caller never created.
-	_, targetStatErr := os.Lstat(path)
-	createdTarget := os.IsNotExist(targetStatErr)
+	// and removing it would delete something the caller never created. When we do remove it,
+	// the removal runs inside this same demoted shell, under the requester's real permissions,
+	// not later in Go as the agent (root)--which would otherwise let a symlink swapped into a
+	// path component redirect a root-privileged unlink.
+	script := fmt.Sprintf("mkdir -p %s && tee %s > /dev/null", utils.Quote(parentDir), utils.Quote(path))
+	if _, err := os.Lstat(path); os.IsNotExist(err) {
+		script = fmt.Sprintf("mkdir -p %s && { tee %s > /dev/null || { rm -f %s; exit 1; }; }",
+			utils.Quote(parentDir), utils.Quote(path), utils.Quote(path))
+	}
 	// Create parents as the requesting user to preserve filesystem permissions.
-	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf(
-		"mkdir -p %s && tee %s > /dev/null",
-		utils.Quote(parentDir), utils.Quote(path),
-	))
+	cmd := exec.CommandContext(ctx, "sh", "-c", script)
 	cmd.SysProcAttr = sysProcAttr
 	// Wrap src to preserve its read error even if a subsequent broken-pipe write
 	// overwrites it before cmd.Wait collects the goroutine result.
@@ -142,7 +145,10 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	// erc.err is only ever non-nil alongside a non-nil runErr: cmd.Wait returns the stdin-copy
 	// goroutine's error on a clean exit, and the process's own exit error otherwise.
 	if runErr != nil {
-		if createdTarget {
+		if erc.err != nil {
+			// tee already opened (and truncated) path before the source read failed, so the
+			// original content is already gone; a target tee never reached is instead
+			// protected by omitting the rm -f clause above.
 			if fi, statErr := os.Lstat(path); statErr == nil && !fi.IsDir() {
 				_ = os.Remove(path)
 			}

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -77,6 +77,18 @@ func firstMissingAncestor(dir string) string {
 	}
 }
 
+// removeAsRequester unlinks path under the requesting user's own permissions instead of the
+// agent's (root), so a symlink swapped into a path component after the caller's Lstat check
+// cannot redirect a root-privileged unlink. Run errors are swallowed: rm -f already reports
+// success on a missing target, and there is no recovery available from a demoted rm failing.
+// context.WithoutCancel is deliberate--context cancellation is one of the ways this cleanup
+// path is reached, and the removal must still run even after ctx is done.
+func removeAsRequester(ctx context.Context, path string, sysProcAttr *syscall.SysProcAttr) {
+	cmd := exec.CommandContext(context.WithoutCancel(ctx), "rm", "-f", path)
+	cmd.SysProcAttr = sysProcAttr
+	_ = cmd.Run()
+}
+
 // dirTreeIsAllDirs reports whether root and everything under it are plain directories,
 // so removing it cannot discard a file a concurrent writer placed there.
 func dirTreeIsAllDirs(root string) bool {
@@ -150,11 +162,11 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	if runErr != nil {
 		// erc.err alone does not prove tee opened path: a tee that cannot open a pre-existing
 		// file still drains stdin to EOF and exits nonzero, so a source read failure can arrive
-		// with the target untouched. Only remove it when this call created it--the same target
-		// the demoted rm -f in the script above would have covered had tee itself failed.
+		// with the target untouched. Only remove it when this call created it, and--same as the
+		// rm -f in the script above--under the requester's own permissions, not root's.
 		if erc.err != nil && createdTarget {
 			if fi, statErr := os.Lstat(path); statErr == nil && !fi.IsDir() {
-				_ = os.Remove(path)
+				removeAsRequester(ctx, path, sysProcAttr)
 			}
 		}
 		if createdRoot != "" && dirTreeIsAllDirs(createdRoot) {

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -125,8 +125,10 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	// the removal runs inside this same demoted shell, under the requester's real permissions,
 	// not later in Go as the agent (root)--which would otherwise let a symlink swapped into a
 	// path component redirect a root-privileged unlink.
+	_, targetStatErr := os.Lstat(path)
+	createdTarget := os.IsNotExist(targetStatErr)
 	script := fmt.Sprintf("mkdir -p %s && tee %s > /dev/null", utils.Quote(parentDir), utils.Quote(path))
-	if _, err := os.Lstat(path); os.IsNotExist(err) {
+	if createdTarget {
 		script = fmt.Sprintf("mkdir -p %s && { tee %s > /dev/null || { rm -f %s; exit 1; }; }",
 			utils.Quote(parentDir), utils.Quote(path), utils.Quote(path))
 	}
@@ -146,10 +148,11 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	// goroutine's error on a clean exit, and the process's own exit error otherwise. The
 	// fallback after this block guards that invariant instead of relying on it silently.
 	if runErr != nil {
-		if erc.err != nil {
-			// tee already opened (and truncated) path before the source read failed, so the
-			// original content is already gone; a target tee never reached is instead
-			// protected by omitting the rm -f clause above.
+		// erc.err alone does not prove tee opened path: a tee that cannot open a pre-existing
+		// file still drains stdin to EOF and exits nonzero, so a source read failure can arrive
+		// with the target untouched. Only remove it when this call created it--the same target
+		// the demoted rm -f in the script above would have covered had tee itself failed.
+		if erc.err != nil && createdTarget {
 			if fi, statErr := os.Lstat(path); statErr == nil && !fi.IsDir() {
 				_ = os.Remove(path)
 			}

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -80,7 +81,7 @@ func firstMissingAncestor(dir string) string {
 // so removing it cannot discard a file a concurrent writer placed there.
 func dirTreeIsAllDirs(root string) bool {
 	safe := true
-	_ = filepath.WalkDir(root, func(_ string, d os.DirEntry, err error) error {
+	_ = filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
 		if err != nil || !d.IsDir() {
 			safe = false
 			return filepath.SkipAll

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -88,25 +88,24 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	cmd.Stderr = errW
 	runErr := cmd.Run()
 
-	if runErr != nil || erc.err != nil {
+	// erc.err is only ever non-nil alongside a non-nil runErr: cmd.Wait returns the stdin-copy
+	// goroutine's error on a clean exit, and the process's own exit error otherwise.
+	if runErr != nil {
 		// lgtm[go/path-injection]: path sanitized via SanitizePath, which
 		// rejects null bytes, UNC/device prefixes, and literal ".." after
 		// cleaning. Wire input is admin-authenticated.
 		_ = os.Remove(path) // lgtm[go/path-injection]
-		if runErr != nil {
-			var details []string
-			if msg := strings.TrimSpace(errW.buf.String()); msg != "" {
-				details = append(details, msg)
-			}
-			if erc.err != nil && erc.err != runErr {
-				details = append(details, erc.err.Error())
-			}
-			if len(details) > 0 {
-				return fmt.Errorf("%w: %s", runErr, strings.Join(details, "; "))
-			}
-			return runErr
+		var details []string
+		if msg := strings.TrimSpace(errW.buf.String()); msg != "" {
+			details = append(details, msg)
 		}
-		return fmt.Errorf("failed to read source: %w", erc.err)
+		if erc.err != nil && erc.err != runErr {
+			details = append(details, erc.err.Error())
+		}
+		if len(details) > 0 {
+			return fmt.Errorf("%w: %s", runErr, strings.Join(details, "; "))
+		}
+		return runErr
 	}
 	return nil
 }

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -119,7 +119,9 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 		// lgtm[go/path-injection]: path sanitized via SanitizePath, which
 		// rejects null bytes, UNC/device prefixes, and literal ".." after
 		// cleaning. Wire input is admin-authenticated.
-		_ = os.Remove(path) // lgtm[go/path-injection]
+		if fi, statErr := os.Lstat(path); statErr == nil && !fi.IsDir() {
+			_ = os.Remove(path) // lgtm[go/path-injection]
+		}
 		if tracksCreation {
 			_ = os.RemoveAll(createdRoot) // lgtm[go/path-injection]
 		}

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -56,20 +56,21 @@ func readFileAs(ctx context.Context, path string, sysProcAttr *syscall.SysProcAt
 	return rc, st.Size(), nil
 }
 
-// firstMissingAncestor returns the highest ancestor of dir that mkdir -p would create.
-// ok is false when dir exists or its state is unknown, so callers never remove a directory they didn't create.
-func firstMissingAncestor(dir string) (missing string, ok bool) {
+// firstMissingAncestor returns the highest ancestor of dir that mkdir -p would create,
+// or "" when dir exists or its state is unknown, so callers never remove a directory they didn't create.
+func firstMissingAncestor(dir string) string {
+	missing := ""
 	cur := dir
 	for {
 		if _, err := os.Lstat(cur); err == nil {
-			return missing, missing != ""
+			return missing
 		} else if !os.IsNotExist(err) {
-			return "", false
+			return ""
 		}
 		missing = cur
 		parent := filepath.Dir(cur)
 		if parent == cur {
-			return missing, true
+			return missing
 		}
 		cur = parent
 	}
@@ -113,7 +114,7 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 		return err
 	}
 	parentDir := filepath.Dir(path)
-	createdRoot, tracksCreation := firstMissingAncestor(parentDir)
+	createdRoot := firstMissingAncestor(parentDir)
 	// Create parents as the requesting user to preserve filesystem permissions.
 	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf(
 		"mkdir -p %s && tee %s > /dev/null",
@@ -135,7 +136,7 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 		if fi, statErr := os.Lstat(path); statErr == nil && !fi.IsDir() {
 			_ = os.Remove(path)
 		}
-		if tracksCreation && dirTreeIsAllDirs(createdRoot) {
+		if createdRoot != "" && dirTreeIsAllDirs(createdRoot) {
 			_ = os.RemoveAll(createdRoot)
 		}
 		var details []string

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -92,9 +92,12 @@ func dirTreeIsAllDirs(root string) bool {
 }
 
 // writeFileAs streams src to a file, demoting via tee when sysProcAttr is set. Caller owns src.
-// path is sanitized by callers via utils.SanitizePath, which rejects null bytes,
-// UNC/device prefixes, and literal ".." after cleaning.
+// path must already be absolute: callers sanitize it via utils.SanitizePath, which rejects
+// null bytes, UNC/device prefixes, and literal ".." after cleaning.
 func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *syscall.SysProcAttr) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("invalid argument: path must be absolute: %s", path)
+	}
 	// No-op for the absolute path SanitizePath produces; it is the sanitizer shape CodeQL recognizes.
 	path = filepath.Clean("/" + path)
 	if sysProcAttr == nil {

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -61,7 +61,7 @@ func readFileAs(ctx context.Context, path string, sysProcAttr *syscall.SysProcAt
 func firstMissingAncestor(dir string) (missing string, ok bool) {
 	cur := dir
 	for {
-		if _, err := os.Stat(cur); err == nil {
+		if _, err := os.Lstat(cur); err == nil {
 			return missing, missing != ""
 		} else if !os.IsNotExist(err) {
 			return "", false

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -119,6 +119,11 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	}
 	parentDir := filepath.Dir(path)
 	createdRoot := firstMissingAncestor(parentDir)
+	// Only a target this call creates may be removed on failure: mkdir -p exits 0 on an
+	// existing parent, so a tee that fails to open a pre-existing file leaves it untouched,
+	// and removing it would delete something the caller never created.
+	_, targetStatErr := os.Lstat(path)
+	createdTarget := os.IsNotExist(targetStatErr)
 	// Create parents as the requesting user to preserve filesystem permissions.
 	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf(
 		"mkdir -p %s && tee %s > /dev/null",
@@ -137,8 +142,10 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	// erc.err is only ever non-nil alongside a non-nil runErr: cmd.Wait returns the stdin-copy
 	// goroutine's error on a clean exit, and the process's own exit error otherwise.
 	if runErr != nil {
-		if fi, statErr := os.Lstat(path); statErr == nil && !fi.IsDir() {
-			_ = os.Remove(path)
+		if createdTarget {
+			if fi, statErr := os.Lstat(path); statErr == nil && !fi.IsDir() {
+				_ = os.Remove(path)
+			}
 		}
 		if createdRoot != "" && dirTreeIsAllDirs(createdRoot) {
 			_ = os.RemoveAll(createdRoot)

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -131,12 +131,8 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	}
 	parentDir := filepath.Dir(path)
 	createdRoot := firstMissingAncestor(parentDir)
-	// Only a target this call creates may be removed on failure: mkdir -p exits 0 on an
-	// existing parent, so a tee that fails to open a pre-existing file leaves it untouched,
-	// and removing it would delete something the caller never created. When we do remove it,
-	// the removal runs inside this same demoted shell, under the requester's real permissions,
-	// not later in Go as the agent (root)--which would otherwise let a symlink swapped into a
-	// path component redirect a root-privileged unlink.
+	// Only a target this call created may be removed on failure, and only under the
+	// requester's own permissions, never as root--see removeAsRequester and the script's own rm -f.
 	_, targetStatErr := os.Lstat(path)
 	createdTarget := os.IsNotExist(targetStatErr)
 	script := fmt.Sprintf("mkdir -p %s && tee %s > /dev/null", utils.Quote(parentDir), utils.Quote(path))

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -56,6 +56,25 @@ func readFileAs(ctx context.Context, path string, sysProcAttr *syscall.SysProcAt
 	return rc, st.Size(), nil
 }
 
+// firstMissingAncestor returns the highest ancestor of dir that mkdir -p would create.
+// ok is false when dir exists or its state is unknown, so callers never remove a directory they didn't create.
+func firstMissingAncestor(dir string) (missing string, ok bool) {
+	cur := dir
+	for {
+		if _, err := os.Stat(cur); err == nil {
+			return missing, missing != ""
+		} else if !os.IsNotExist(err) {
+			return "", false
+		}
+		missing = cur
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return missing, true
+		}
+		cur = parent
+	}
+}
+
 // writeFileAs streams src to a file, demoting via tee when sysProcAttr is set. Caller owns src.
 // path is sanitized by callers via utils.SanitizePath, which rejects null bytes,
 // UNC/device prefixes, and literal ".." after cleaning.
@@ -77,7 +96,13 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 		}
 		return err
 	}
-	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("tee %s > /dev/null", utils.Quote(path)))
+	parentDir := filepath.Dir(path)
+	createdRoot, tracksCreation := firstMissingAncestor(parentDir)
+	// Create parents as the requesting user to preserve filesystem permissions.
+	cmd := exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf(
+		"mkdir -p %s && tee %s > /dev/null",
+		utils.Quote(parentDir), utils.Quote(path),
+	))
 	cmd.SysProcAttr = sysProcAttr
 	// Wrap src to preserve its read error even if a subsequent broken-pipe write
 	// overwrites it before cmd.Wait collects the goroutine result.
@@ -95,6 +120,9 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 		// rejects null bytes, UNC/device prefixes, and literal ".." after
 		// cleaning. Wire input is admin-authenticated.
 		_ = os.Remove(path) // lgtm[go/path-injection]
+		if tracksCreation {
+			_ = os.RemoveAll(createdRoot) // lgtm[go/path-injection]
+		}
 		var details []string
 		if msg := strings.TrimSpace(errW.buf.String()); msg != "" {
 			details = append(details, msg)

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -143,7 +143,8 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	runErr := cmd.Run()
 
 	// erc.err is only ever non-nil alongside a non-nil runErr: cmd.Wait returns the stdin-copy
-	// goroutine's error on a clean exit, and the process's own exit error otherwise.
+	// goroutine's error on a clean exit, and the process's own exit error otherwise. The
+	// fallback after this block guards that invariant instead of relying on it silently.
 	if runErr != nil {
 		if erc.err != nil {
 			// tee already opened (and truncated) path before the source read failed, so the
@@ -167,6 +168,9 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 			return fmt.Errorf("%w: %s", runErr, strings.Join(details, "; "))
 		}
 		return runErr
+	}
+	if erc.err != nil {
+		return fmt.Errorf("failed to read source: %w", erc.err)
 	}
 	return nil
 }

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -75,6 +75,20 @@ func firstMissingAncestor(dir string) (missing string, ok bool) {
 	}
 }
 
+// dirTreeIsAllDirs reports whether root and everything under it are plain directories,
+// so removing it cannot discard a file a concurrent writer placed there.
+func dirTreeIsAllDirs(root string) bool {
+	safe := true
+	_ = filepath.WalkDir(root, func(_ string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			safe = false
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return safe
+}
+
 // writeFileAs streams src to a file, demoting via tee when sysProcAttr is set. Caller owns src.
 // path is sanitized by callers via utils.SanitizePath, which rejects null bytes,
 // UNC/device prefixes, and literal ".." after cleaning.
@@ -122,7 +136,7 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 		if fi, statErr := os.Lstat(path); statErr == nil && !fi.IsDir() {
 			_ = os.Remove(path) // lgtm[go/path-injection]
 		}
-		if tracksCreation {
+		if tracksCreation && dirTreeIsAllDirs(createdRoot) {
 			_ = os.RemoveAll(createdRoot) // lgtm[go/path-injection]
 		}
 		var details []string

--- a/pkg/executor/handlers/file/file_io_unix.go
+++ b/pkg/executor/handlers/file/file_io_unix.go
@@ -93,11 +93,13 @@ func dirTreeIsAllDirs(root string) bool {
 // path is sanitized by callers via utils.SanitizePath, which rejects null bytes,
 // UNC/device prefixes, and literal ".." after cleaning.
 func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *syscall.SysProcAttr) error {
+	// No-op for the absolute path SanitizePath produces; it is the sanitizer shape CodeQL recognizes.
+	path = filepath.Clean("/" + path)
 	if sysProcAttr == nil {
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err
 		}
-		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // lgtm[go/path-injection]
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}
@@ -106,7 +108,7 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 			err = cerr
 		}
 		if err != nil {
-			_ = os.Remove(path) // lgtm[go/path-injection] drop partial write so retry isn't blocked by AllowOverwrite=false
+			_ = os.Remove(path) // drop partial write so retry isn't blocked by AllowOverwrite=false
 		}
 		return err
 	}
@@ -130,14 +132,11 @@ func writeFileAs(ctx context.Context, path string, src io.Reader, sysProcAttr *s
 	// erc.err is only ever non-nil alongside a non-nil runErr: cmd.Wait returns the stdin-copy
 	// goroutine's error on a clean exit, and the process's own exit error otherwise.
 	if runErr != nil {
-		// lgtm[go/path-injection]: path sanitized via SanitizePath, which
-		// rejects null bytes, UNC/device prefixes, and literal ".." after
-		// cleaning. Wire input is admin-authenticated.
 		if fi, statErr := os.Lstat(path); statErr == nil && !fi.IsDir() {
-			_ = os.Remove(path) // lgtm[go/path-injection]
+			_ = os.Remove(path)
 		}
 		if tracksCreation && dirTreeIsAllDirs(createdRoot) {
-			_ = os.RemoveAll(createdRoot) // lgtm[go/path-injection]
+			_ = os.RemoveAll(createdRoot)
 		}
 		var details []string
 		if msg := strings.TrimSpace(errW.buf.String()); msg != "" {

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -66,7 +66,8 @@ func TestWriteFileAs_TeePath_SurfacesTeeFailureAfterMkdirSucceeds(t *testing.T) 
 
 	err := writeFileAs(t.Context(), path, strings.NewReader("payload"), &syscall.SysProcAttr{})
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "directory")
+	// tee's "Is a directory" message is locale-dependent; the path it names is not.
+	assert.ErrorContains(t, err, path)
 	assert.DirExists(t, path)
 }
 

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -36,6 +36,12 @@ func TestWriteFileAs_TeePath_CreatesParentDir(t *testing.T) {
 	}
 }
 
+func TestWriteFileAs_RejectsNonAbsolutePath(t *testing.T) {
+	err := writeFileAs(t.Context(), "relative/x", strings.NewReader("payload"), nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "absolute")
+}
+
 func TestWriteFileAs_TeePath_RejectsUnwritableParent(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("root can write through directory mode restrictions")

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestWriteFileAs_TeePath_CreatesParentDir(t *testing.T) {
 	for _, dir := range []string{"nested/deep", "space and 'quote'/$literal;name"} {
-		t.Run(dir, func(t *testing.T) {
+		t.Run(strings.ReplaceAll(dir, "/", "_"), func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), dir, "out 'file'.bin")
 			// Select the subprocess branch without changing credentials or requiring root.
 			err := writeFileAs(t.Context(), path, strings.NewReader("payload"), &syscall.SysProcAttr{})

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -61,6 +61,7 @@ func TestWriteFileAs_TeePath_SurfacesTeeFailureAfterMkdirSucceeds(t *testing.T) 
 	err := writeFileAs(t.Context(), path, strings.NewReader("payload"), &syscall.SysProcAttr{})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "directory")
+	assert.DirExists(t, path)
 }
 
 func TestWriteFileAs_TeePath_RemovesDirsItCreatedOnFailure(t *testing.T) {

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -1,0 +1,113 @@
+//go:build !windows
+
+package file
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteFileAs_TeePath_CreatesParentDir(t *testing.T) {
+	for _, dir := range []string{"nested/deep", "space and 'quote'/$literal;name"} {
+		t.Run(dir, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), dir, "out 'file'.bin")
+			// Select the subprocess branch without changing credentials or requiring root.
+			err := writeFileAs(t.Context(), path, strings.NewReader("payload"), &syscall.SysProcAttr{})
+			require.NoError(t, err)
+			assert.DirExists(t, filepath.Dir(path))
+			got, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, "payload", string(got))
+
+			err = writeFileAs(t.Context(), path, strings.NewReader("next"), &syscall.SysProcAttr{})
+			require.NoError(t, err)
+			got, err = os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, "next", string(got))
+		})
+	}
+}
+
+func TestWriteFileAs_TeePath_RejectsUnwritableParent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write through directory mode restrictions")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0555))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(dir, 0700)) })
+	path := filepath.Join(dir, "missing", "out.bin")
+
+	err := writeFileAs(t.Context(), path, strings.NewReader("payload"), &syscall.SysProcAttr{})
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Dir(path))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestWriteFileAs_TeePath_SurfacesTeeFailureAfterMkdirSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	// mkdir -p is a no-op here since the parent already exists, so this exercises
+	// "mkdir succeeds, tee fails" rather than the mkdir-failure branch above.
+	path := filepath.Join(dir, "target")
+	require.NoError(t, os.Mkdir(path, 0755))
+
+	err := writeFileAs(t.Context(), path, strings.NewReader("payload"), &syscall.SysProcAttr{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "directory")
+}
+
+func TestWriteFileAs_TeePath_RemovesDirsItCreatedOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new", "nested", "out.bin")
+
+	err := writeFileAs(t.Context(), path, iotest.ErrReader(errors.New("boom")), &syscall.SysProcAttr{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "boom")
+	_, statErr := os.Stat(filepath.Join(dir, "new"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestWriteFileAs_TeePath_KeepsPreexistingParentOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(sub, 0755))
+	path := filepath.Join(sub, "out.bin")
+
+	err := writeFileAs(t.Context(), path, iotest.ErrReader(errors.New("boom")), &syscall.SysProcAttr{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "boom")
+	assert.DirExists(t, sub)
+}
+
+func TestWriteFileAs_DemotedPath_CreatesParentsAsUser(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("credential demotion requires root")
+	}
+	// Only the demoted user should own the newly created parents.
+	const uid, gid = 65534, 65534
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(filepath.Dir(dir), 0755))
+	require.NoError(t, os.Chown(dir, uid, gid))
+	attr := &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uid, Gid: gid}}
+	path := filepath.Join(dir, "nested", "deep", "out.bin")
+
+	require.NoError(t, writeFileAs(t.Context(), path, strings.NewReader("payload"), attr))
+	for _, created := range []string{filepath.Join(dir, "nested"), filepath.Dir(path), path} {
+		st, err := os.Stat(created)
+		require.NoError(t, err)
+		stat, ok := st.Sys().(*syscall.Stat_t)
+		require.True(t, ok)
+		assert.EqualValues(t, uid, stat.Uid)
+		assert.EqualValues(t, gid, stat.Gid)
+	}
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(got))
+}

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -70,6 +70,20 @@ func TestWriteFileAs_TeePath_SurfacesTeeFailureAfterMkdirSucceeds(t *testing.T) 
 	assert.DirExists(t, path)
 }
 
+func TestWriteFileAs_TeePath_KeepsUnwritableTargetOnTeeFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write through file mode restrictions")
+	}
+	path := filepath.Join(t.TempDir(), "precious.conf")
+	require.NoError(t, os.WriteFile(path, []byte("ORIGINAL"), 0444))
+
+	err := writeFileAs(t.Context(), path, strings.NewReader("payload"), &syscall.SysProcAttr{})
+	require.Error(t, err)
+	got, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, "ORIGINAL", string(got))
+}
+
 func TestDirTreeIsAllDirs(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0755))

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -85,6 +85,20 @@ func TestWriteFileAs_TeePath_KeepsUnwritableTargetOnTeeFailure(t *testing.T) {
 	assert.Equal(t, "ORIGINAL", string(got))
 }
 
+func TestWriteFileAs_TeePath_KeepsUnwritableTargetOnSourceReadFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write through file mode restrictions")
+	}
+	path := filepath.Join(t.TempDir(), "precious.conf")
+	require.NoError(t, os.WriteFile(path, []byte("ORIGINAL"), 0444))
+
+	err := writeFileAs(t.Context(), path, iotest.ErrReader(errors.New("connection reset")), &syscall.SysProcAttr{})
+	require.Error(t, err)
+	got, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, "ORIGINAL", string(got))
+}
+
 func TestFirstMissingAncestor(t *testing.T) {
 	dir := t.TempDir()
 	existing := filepath.Join(dir, "existing")

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -84,6 +84,46 @@ func TestWriteFileAs_TeePath_KeepsUnwritableTargetOnTeeFailure(t *testing.T) {
 	assert.Equal(t, "ORIGINAL", string(got))
 }
 
+func TestFirstMissingAncestor(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing")
+	require.NoError(t, os.Mkdir(existing, 0755))
+
+	danglingParent := filepath.Join(dir, "dangling")
+	require.NoError(t, os.Symlink(filepath.Join(dir, "nonexistent-target"), danglingParent))
+
+	nonDirParent := filepath.Join(dir, "not-a-dir")
+	require.NoError(t, os.WriteFile(nonDirParent, []byte("x"), 0644))
+
+	tests := []struct {
+		name string
+		dir  string
+		want string
+	}{
+		{"existing directory", existing, ""},
+		{"missing chain", filepath.Join(dir, "a", "b", "c"), filepath.Join(dir, "a")},
+		{"dangling symlink parent", filepath.Join(danglingParent, "child"), filepath.Join(danglingParent, "child")},
+		// Lstat through a non-directory component fails with ENOTDIR, not ENOENT--the same
+		// "state is unknown" branch a permission-denied stat takes, so this reports "" too.
+		{"non-directory parent", filepath.Join(nonDirParent, "child"), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, firstMissingAncestor(tt.dir))
+		})
+	}
+
+	t.Run("stat error", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses permission checks")
+		}
+		blocked := filepath.Join(dir, "blocked")
+		require.NoError(t, os.Mkdir(blocked, 0000))
+		t.Cleanup(func() { require.NoError(t, os.Chmod(blocked, 0700)) })
+		assert.Equal(t, "", firstMissingAncestor(filepath.Join(blocked, "child")))
+	})
+}
+
 func TestDirTreeIsAllDirs(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0755))

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -64,6 +64,15 @@ func TestWriteFileAs_TeePath_SurfacesTeeFailureAfterMkdirSucceeds(t *testing.T) 
 	assert.DirExists(t, path)
 }
 
+func TestDirTreeIsAllDirs(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0755))
+	assert.True(t, dirTreeIsAllDirs(dir))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "nested", "out.bin"), []byte("x"), 0644))
+	assert.False(t, dirTreeIsAllDirs(dir))
+}
+
 func TestWriteFileAs_TeePath_RemovesDirsItCreatedOnFailure(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "new", "nested", "out.bin")

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -103,7 +103,11 @@ func TestWriteFileAs_DemotedPath_CreatesParentsAsUser(t *testing.T) {
 	// Only the demoted user should own the newly created parents.
 	const uid, gid = 65534, 65534
 	dir := t.TempDir()
-	require.NoError(t, os.Chmod(filepath.Dir(dir), 0755))
+	parent := filepath.Dir(dir)
+	parentInfo, err := os.Stat(parent)
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(parent, 0755))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(parent, parentInfo.Mode().Perm())) })
 	require.NoError(t, os.Chown(dir, uid, gid))
 	attr := &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uid, Gid: gid}}
 	path := filepath.Join(dir, "nested", "deep", "out.bin")

--- a/pkg/executor/handlers/file/file_io_unix_test.go
+++ b/pkg/executor/handlers/file/file_io_unix_test.go
@@ -99,6 +99,17 @@ func TestWriteFileAs_TeePath_KeepsUnwritableTargetOnSourceReadFailure(t *testing
 	assert.Equal(t, "ORIGINAL", string(got))
 }
 
+func TestWriteFileAs_TeePath_RemovesFreshTargetOnSourceReadFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.bin")
+
+	err := writeFileAs(t.Context(), path, iotest.ErrReader(errors.New("boom")), &syscall.SysProcAttr{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "boom")
+	_, statErr := os.Stat(path)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
 func TestFirstMissingAncestor(t *testing.T) {
 	dir := t.TempDir()
 	existing := filepath.Join(dir, "existing")


### PR DESCRIPTION
## Background

writeFileAs in pkg/executor/handlers/file/file_io_unix.go ran the demoted (privilege-lowered) write through `sh -c "tee <path> > /dev/null"` and never created the destination's parent directory. The non-demoted branch and the Windows implementation both call os.MkdirAll first. Every transfer coming through the server carries a username, so the demoted branch is the normal path, not the edge case—so any transfer into a directory that didn't exist yet failed outright. Issue #463 has the full repro and root-cause analysis.

## Changes

- The demoted branch's shell command is now `mkdir -p <parentDir> && tee <path> > /dev/null`, so the parent directory is created as the requesting user rather than as the agent (root), which keeps ownership correct.
- Added firstMissingAncestor, which walks up from the parent directory to find the highest ancestor mkdir -p would actually create. If tee subsequently fails, writeFileAs removes only that ancestor, leaving directories that already existed before the call untouched. Unconditionally removing the parent directory was rejected because it could delete a directory the caller never created.
- firstMissingAncestor now walks ancestors with os.Lstat instead of os.Stat, so an existing symlink in the parent chain (dangling or not) is treated as present rather than as something this call created. firstMissingAncestor's second return value was later dropped: every return path already satisfied `ok == (missing != "")`, so it carried no information the string didn't already carry.
- The failure-path cleanup no longer removes path with os.Remove when path is itself a directory (an empty one, for example, that already existed before the call), and no longer runs os.RemoveAll(createdRoot) unless the whole created tree still contains only plain directories.
- writeFileAs never removes a target this call didn't create. mkdir -p exits 0 on an existing parent regardless of permissions, so a tee that fails to open a pre-existing file used to leave it untouched on disk but still get deleted by an unconditional `os.Remove(path)` on the failure path—as the agent, i.e. root, so it succeeded against files the requester had no permission to write. writeFileAs now checks with os.Lstat before running the command and only includes a removal for a target that doesn't exist yet.
- That removal, when it does run, now happens inside the same demoted shell command instead of later in Go: the script becomes `mkdir -p P && { tee F > /dev/null || { rm -f F; exit 1; }; }` for a target this call is about to create. Doing it there, rather than as a later `os.Remove` running as root, closes a symlink-redirection window: `os.Remove` resolves every intermediate path component at unlink time, so a requester who controls a directory in the chain could otherwise swap it for a symlink between the check and the removal and have root unlink through it.
- The one removal path that still runs on the Go side—the source read failing, rather than tee itself failing—turned out to share both problems the shell-side fix above closed, and both are fixed now:
  - `erc.err != nil` does not prove tee ever opened path. A tee that can't open a pre-existing file still drains stdin to EOF and exits nonzero, so a source read failure can arrive with the target completely untouched. This removal used to run whenever erc.err was non-nil, with no check at all, so it deleted a pre-existing file the requester had no permission to write—the same class of bug fixed above for the tee-failure path. It's now gated on the same pre-existence check (createdTarget) that already decides which script to run, so it only ever removes a target this call created.
  - That removal also ran as root. It's now routed through a new removeAsRequester helper, which execs `rm -f path` with the caller's own SysProcAttr—the same permission boundary the script's own rm -f already runs under—using context.WithoutCancel since context cancellation is one of the ways this cleanup path is reached and the removal still has to run after ctx is done.
- writeFileAs now rejects a non-absolute path outright instead of silently anchoring it. It previously relied on `filepath.Clean("/" + path)` to always produce an absolute path, so `""` became `"/"` and `"relative/x"` became `"/relative/x"` instead of surfacing an error. No current caller hits this—fileDownload sanitizes first—but the doc comment claimed path always arrived sanitized, which wasn't actually enforced.
- dirTreeIsAllDirs's WalkDir callback is now typed `fs.DirEntry`, the type the `fs.WalkDirFunc` contract actually names (`os.DirEntry` is a type alias for it, so this was never a compile error, only a misleading signature).
- writeFileAs now starts with `path = filepath.Clean("/" + path)`, the exact shape CodeQL's go/path-injection query treats as a sanitizer. For the absolute path SanitizePath always produces this is a no-op. CodeQL was flagging every filesystem call in the function because fileDownload writes the sanitized value back into args.Path and CodeQL's field-based taint model does not treat that store as clearing the original wire taint. The `// lgtm[go/path-injection]` markers in the function never suppressed anything (alerts fired on lines carrying them) and are removed.
- The failure-handling collapse from `runErr != nil || erc.err != nil` to `runErr != nil` rested on cmd.Wait always returning the stdin-copy goroutine's error on a clean process exit and the process's own exit error otherwise. That invariant depends on two os/exec internals, not one—Cmd.Wait's own ordering, and `skipStdinCopyError` discarding EPIPE from the same copy—so writeFileAs now falls back to reporting `erc.err` explicitly after the `runErr != nil` block instead of silently returning nil if the invariant is ever violated.
- The `os.RemoveAll(createdRoot)` call now carries a comment stating why it still runs as root instead of through removeAsRequester: `dirTreeIsAllDirs` already limits what it can remove to a tree of plain directories, so the worst case is deleting empty directories, not a file. That reasoning previously lived only in the review thread.

## Safety

The directories mkdir -p creates get their mode from **alpamon's own inherited umask**, not the requesting user's. `sh -c` runs a non-login, non-interactive shell that never reads the requesting user's profile, so the mode is whatever alpamon itself inherited (typically 0755, matching the direct-write branch's `os.MkdirAll(dir, 0755)`, but not user-controlled and not deterministic across deployments—a systemd `UMask=` setting changes it). An earlier version of this section attributed the umask to the requesting user; that was wrong.

One race window remains open; a second one, thought closed earlier, wasn't and is now:

- `os.RemoveAll(createdRoot)`, the directory-tree cleanup on failure, still runs in Go as the agent (root) and still resolves intermediate path components at unlink time, the same symlink-redirection shape closed below for file removal. `dirTreeIsAllDirs` narrows the window (a write landing in the instant between its check and the RemoveAll call is still possible) but doesn't close it. Closing it fully needs a symlink-safe walk in the style of `pkg/utils/archive.go`'s `mkdirAllInside`/`createFile`, which is a bigger change than this cleanup path warrants right now—now noted inline at the call site so the reasoning doesn't depend on finding this section.
- The Go-side `os.Remove(path)` reached on a source-read failure was previously assumed safe on the premise that tee had already opened and truncated the target by the time that code ran. That premise was wrong—a tee that can't open a pre-existing file still drains stdin and exits nonzero, so this path could delete a file the requester has no permission to write, the exact bug already fixed for the tee-failure path. It's now gated on createdTarget and routed through removeAsRequester, so it only ever removes a target this call created, and only under the requester's own permissions.

## Testing

Coverage in pkg/executor/handlers/file/file_io_unix_test.go for the demoted tee path:
- creating a missing parent directory, and reusing it on a later write
- rejecting an unwritable parent directory, and a non-absolute path
- mkdir -p succeeding but tee failing on a path that is itself a pre-existing directory, and that directory surviving the failure (asserted via the path tee names, not its locale-dependent message text)
- a pre-existing, unwritable file surviving a tee failure that never opened it
- a pre-existing, unwritable file surviving a source read failure that arrives before tee ever gets a chance to fail on its own
- removing only the directory this call created, on failure
- removing a target this call freshly created when the source read fails mid-copy
- leaving a pre-existing parent directory untouched, on that same failure
- leaving a pre-existing target that tee already opened and truncated in its truncated state, rather than removing it, when the source read then fails
- firstMissingAncestor directly, over an existing directory, a missing chain, a dangling symlink parent, a non-directory parent, and a permission-denied stat
- dirTreeIsAllDirs directly, over a tree of plain directories and one containing a file
- the demoted user owning newly created parents (requires root, skipped otherwise)

Every new test and every extended assertion was seen failing once before being trusted: disabling cleanup entirely, forcing cleanup to always treat the immediate parent as newly created, reverting the os.Lstat directory guard on os.Remove, making dirTreeIsAllDirs always return true, removing the createdTarget/absolute-path guards, reverting firstMissingAncestor's os.Lstat to os.Stat, no-opping removeAsRequester, dropping the createdTarget gate on the source-read-failure removal, and—for the truncated-target test added this round—dropping that same gate again and watching the file disappear with "no such file or directory" instead of coming back empty.

The demoted-owner test's chmod on the temp directory's parent is restored via t.Cleanup; this environment isn't root, so that specific test still only SKIPs here rather than exercising red/green.

```
$ go build ./pkg/executor/...
$ go vet ./pkg/executor/handlers/file/...
$ go test ./pkg/executor/handlers/file/... -p 1
ok  	github.com/alpacax/alpamon/v2/pkg/executor/handlers/file	0.556s
```

Run against the pushed head (`9b1f70e8`). GitHub's own checks (Build and Test across all platforms, golangci-lint, govulncheck, CodeQL) were still queued/pending on this head at the time of writing—see the PR's Checks tab for their result.

CodeQL, run locally with the CodeQL CLI 2.27.0 and codeql/go-queries 1.6.10 against Security/CWE-022/TaintedPath.ql: a database built from the tree before the sanitizer wrapper reports 7 go/path-injection findings in pkg/executor/handlers/file/file_io_unix.go (the 4 the PR check raised on lines 64, 136, 137, 140, plus 3 in the non-demoted branch that predate this branch); a database built from the current head reports none in the file. The PR's CodeQL check on the pushed head is what confirms this on GitHub's side.

Closes #463

