### PR TITLE
fix(runner): add jitter to the reconnect backoff

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -42,10 +42,10 @@ type ExponentialBackoff struct {
 // MaxInterval].
 //
 // The doubling sequence itself is unaffected by the random draw, so it
-// keeps climbing to MaxInterval call over call regardless of how any single
-// draw landed. Without jitter, every agent reconnecting after the same
-// event (e.g. a shared backhaul server restart) retries on the exact same
-// schedule; the random factor spreads that out.
+// keeps climbing to MaxInterval from call to call regardless of how any
+// single draw landed. Without jitter, every agent reconnecting after the
+// same event (e.g. a shared backhaul server restart) retries on the exact
+// same schedule; the random factor spreads that out.
 func (b *ExponentialBackoff) NextBackOff() time.Duration {
 	if b.currentInterval == 0 {
 		b.currentInterval = b.InitialInterval

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"math/rand/v2"
 	"time"
 )
 
@@ -25,20 +26,56 @@ type ExponentialBackoff struct {
 	InitialInterval time.Duration
 	MaxInterval     time.Duration
 	MaxElapsedTime  time.Duration // 0 means no limit
+
+	// Rand returns a value in [0, 1), used to compute the jitter factor
+	// applied to each backoff. Nil uses the package-level math/rand/v2
+	// source. Tests set this to a deterministic function for reproducible
+	// assertions.
+	Rand func() float64
+
 	currentInterval time.Duration
 }
 
-// NextBackOff returns the next wait interval, capped at MaxInterval.
+// NextBackOff returns the next wait interval: the unjittered doubling
+// sequence (InitialInterval, 2x, 4x, ... capped at MaxInterval) multiplied
+// by a random factor in [0.5, 1.5) and clamped to [InitialInterval,
+// MaxInterval].
+//
+// The doubling sequence itself is unaffected by the random draw, so it
+// keeps climbing to MaxInterval call over call regardless of how any single
+// draw landed. Without jitter, every agent reconnecting after the same
+// event (e.g. a shared backhaul server restart) retries on the exact same
+// schedule; the random factor spreads that out.
 func (b *ExponentialBackoff) NextBackOff() time.Duration {
 	if b.currentInterval == 0 {
 		b.currentInterval = b.InitialInterval
-		return b.currentInterval
+	} else {
+		b.currentInterval = time.Duration(math.Min(
+			float64(b.currentInterval)*2,
+			float64(b.MaxInterval),
+		))
 	}
-	b.currentInterval = time.Duration(math.Min(
-		float64(b.currentInterval)*2,
-		float64(b.MaxInterval),
-	))
-	return b.currentInterval
+
+	return b.jitter(b.currentInterval)
+}
+
+func (b *ExponentialBackoff) jitter(interval time.Duration) time.Duration {
+	randFn := b.Rand
+	if randFn == nil {
+		randFn = rand.Float64
+	}
+
+	factor := 0.5 + randFn()
+	jittered := time.Duration(float64(interval) * factor)
+
+	if jittered < b.InitialInterval {
+		jittered = b.InitialInterval
+	}
+	if jittered > b.MaxInterval {
+		jittered = b.MaxInterval
+	}
+
+	return jittered
 }
 
 // Reset resets the backoff interval to initial state.

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -26,12 +26,8 @@ func TestRetry_Success(t *testing.T) {
 		return nil
 	})
 
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
-	}
-	if calls != 3 {
-		t.Fatalf("expected 3 calls, got %d", calls)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
 }
 
 func TestRetry_PermanentError(t *testing.T) {
@@ -47,12 +43,8 @@ func TestRetry_PermanentError(t *testing.T) {
 		return Permanent(fatal)
 	})
 
-	if !errors.Is(err, fatal) {
-		t.Fatalf("expected fatal error, got %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("expected 1 call (no retry after permanent), got %d", calls)
-	}
+	require.ErrorIs(t, err, fatal)
+	assert.Equal(t, 1, calls, "no retry after a permanent error")
 }
 
 func TestRetry_ContextCancellation(t *testing.T) {
@@ -101,10 +93,17 @@ func TestRetry_MaxElapsedTime(t *testing.T) {
 	})
 }
 
-func TestNextBackOff_CappedAtMax(t *testing.T) {
+// TestNextBackOff_BaseDoublingReachesCeiling pins Rand to always return 0.5,
+// which yields a jitter factor of exactly 1.0 (no-op), so the underlying
+// doubling sequence is observable directly: 100ms, 200ms, 400ms, capped at
+// 500ms from there on. This is what "the doubling of the base interval is
+// unaffected by the random draw" buys: the ceiling is still reached exactly
+// on schedule even though real draws jitter the returned value.
+func TestNextBackOff_BaseDoublingReachesCeiling(t *testing.T) {
 	b := &ExponentialBackoff{
 		InitialInterval: 100 * time.Millisecond,
 		MaxInterval:     500 * time.Millisecond,
+		Rand:            func() float64 { return 0.5 },
 	}
 
 	intervals := make([]time.Duration, 6)
@@ -112,19 +111,95 @@ func TestNextBackOff_CappedAtMax(t *testing.T) {
 		intervals[i] = b.NextBackOff()
 	}
 
-	if intervals[0] != 100*time.Millisecond {
-		t.Fatalf("first interval = %v, want 100ms", intervals[0])
-	}
+	assert.Equal(t, 100*time.Millisecond, intervals[0])
+	assert.Equal(t, 200*time.Millisecond, intervals[1])
+	assert.Equal(t, 400*time.Millisecond, intervals[2])
+	assert.Equal(t, 500*time.Millisecond, intervals[3], "capped at max from here on")
+	assert.Equal(t, 500*time.Millisecond, intervals[4])
+	assert.Equal(t, 500*time.Millisecond, intervals[5])
+}
 
-	for i, d := range intervals {
-		if d > 500*time.Millisecond {
-			t.Fatalf("interval[%d] = %v exceeds max 500ms", i, d)
+// TestNextBackOff_JitterBounds draws many samples across the whole
+// InitialInterval..MaxInterval doubling sequence (using the real default
+// Rand, not a stub) and checks every one lands in [InitialInterval,
+// MaxInterval] — the clamp that keeps a 0.5x draw from undercutting the
+// configured floor and a 1.49x draw from overshooting the ceiling.
+func TestNextBackOff_JitterBounds(t *testing.T) {
+	const (
+		initial = 100 * time.Millisecond
+		maxIvl  = 500 * time.Millisecond
+	)
+
+	for range 500 {
+		b := &ExponentialBackoff{InitialInterval: initial, MaxInterval: maxIvl}
+
+		for range 10 {
+			d := b.NextBackOff()
+			assert.GreaterOrEqual(t, d, initial)
+			assert.LessOrEqual(t, d, maxIvl)
 		}
 	}
+}
 
-	if intervals[5] != 500*time.Millisecond {
-		t.Fatalf("interval[5] = %v, want 500ms (capped)", intervals[5])
+// TestNextBackOff_JitterVariesTheReturnedValue guards against a jitter
+// implementation that silently no-ops (e.g. a Rand call whose result is
+// discarded): repeated draws at a fixed base interval must not all come back
+// identical.
+func TestNextBackOff_JitterVariesTheReturnedValue(t *testing.T) {
+	seen := map[time.Duration]bool{}
+	for range 200 {
+		b := &ExponentialBackoff{
+			InitialInterval: 100 * time.Millisecond,
+			MaxInterval:     10 * time.Second, // high enough that the clamp doesn't hide the spread
+		}
+		seen[b.NextBackOff()] = true
 	}
+
+	assert.Greater(t, len(seen), 1, "200 draws at the same base interval should not all collapse to one value")
+}
+
+// TestNextBackOff_ExtremeDraws checks the two edges of the jitter factor
+// directly: a draw of 0 (factor 0.5) must clamp up to InitialInterval when
+// the base is at InitialInterval, and a draw just under 1 (factor just under
+// 1.5) must clamp down to MaxInterval when the base is at MaxInterval.
+func TestNextBackOff_ExtremeDraws(t *testing.T) {
+	low := &ExponentialBackoff{
+		InitialInterval: 100 * time.Millisecond,
+		MaxInterval:     500 * time.Millisecond,
+		Rand:            func() float64 { return 0 },
+	}
+	assert.Equal(t, 100*time.Millisecond, low.NextBackOff(), "0.5x of the initial interval clamps up to the floor")
+
+	high := &ExponentialBackoff{
+		InitialInterval: 100 * time.Millisecond,
+		MaxInterval:     500 * time.Millisecond,
+		Rand:            func() float64 { return 0.999999 },
+	}
+	// Drive the base up to the ceiling first.
+	for range 5 {
+		high.NextBackOff()
+	}
+	assert.Equal(t, 500*time.Millisecond, high.NextBackOff(), "~1.5x of the max interval clamps down to the ceiling")
+}
+
+// TestNextBackOff_ResetRestartsTheSequence confirms Reset drops the internal
+// base back to zero so the next call starts the doubling sequence over,
+// exactly as it did before jitter was added.
+func TestNextBackOff_ResetRestartsTheSequence(t *testing.T) {
+	b := &ExponentialBackoff{
+		InitialInterval: 100 * time.Millisecond,
+		MaxInterval:     500 * time.Millisecond,
+		Rand:            func() float64 { return 0.5 }, // factor 1.0, isolates the reset behavior from jitter
+	}
+
+	for range 4 {
+		b.NextBackOff()
+	}
+	require.Equal(t, 500*time.Millisecond, b.currentInterval, "sequence should have reached the ceiling")
+
+	b.Reset()
+	assert.Equal(t, time.Duration(0), b.currentInterval)
+	assert.Equal(t, 100*time.Millisecond, b.NextBackOff(), "first call after Reset restarts at InitialInterval")
 }
 
 func TestRetry_ImmediateSuccess(t *testing.T) {

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -93,30 +93,51 @@ func TestRetry_MaxElapsedTime(t *testing.T) {
 	})
 }
 
-// TestNextBackOff_BaseDoublingReachesCeiling pins Rand to always return 0.5,
-// which yields a jitter factor of exactly 1.0 (no-op), so the underlying
-// doubling sequence is observable directly: 100ms, 200ms, 400ms, capped at
-// 500ms from there on. This is what "the doubling of the base interval is
-// unaffected by the random draw" buys: the ceiling is still reached exactly
-// on schedule even though real draws jitter the returned value.
+// TestNextBackOff_BaseDoublingReachesCeiling pins Rand to a non-neutral
+// factor (0.5x, the low edge) and asserts on the internal base
+// (b.currentInterval) directly, not just the jittered return value. That
+// distinction matters: at the neutral factor (1.0x) a broken implementation
+// that feeds the *returned*, jittered value back into the base as next
+// call's starting point would produce the same sequence as a correct one
+// that keeps the base pure, so a neutral-factor test cannot tell them apart.
+// At 0.5x the two diverge starting at the second call (200ms base vs. 100ms
+// jittered return), which is what actually exercises "the doubling of the
+// base interval is unaffected by the random draw".
 func TestNextBackOff_BaseDoublingReachesCeiling(t *testing.T) {
 	b := &ExponentialBackoff{
 		InitialInterval: 100 * time.Millisecond,
 		MaxInterval:     500 * time.Millisecond,
-		Rand:            func() float64 { return 0.5 },
+		Rand:            func() float64 { return 0 }, // factor 0.5, the low edge
 	}
 
-	intervals := make([]time.Duration, 6)
-	for i := range intervals {
-		intervals[i] = b.NextBackOff()
+	returned := make([]time.Duration, 6)
+	base := make([]time.Duration, 6)
+	for i := range returned {
+		returned[i] = b.NextBackOff()
+		base[i] = b.currentInterval
 	}
 
-	assert.Equal(t, 100*time.Millisecond, intervals[0])
-	assert.Equal(t, 200*time.Millisecond, intervals[1])
-	assert.Equal(t, 400*time.Millisecond, intervals[2])
-	assert.Equal(t, 500*time.Millisecond, intervals[3], "capped at max from here on")
-	assert.Equal(t, 500*time.Millisecond, intervals[4])
-	assert.Equal(t, 500*time.Millisecond, intervals[5])
+	// The base doubles on its own schedule regardless of the 0.5x factor
+	// applied to what's returned.
+	assert.Equal(t, []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		500 * time.Millisecond, // capped at max from here on
+		500 * time.Millisecond,
+		500 * time.Millisecond,
+	}, base, "base interval must keep doubling to the ceiling independent of jitter")
+
+	// The returned value is base * 0.5, clamped up to InitialInterval where
+	// that would otherwise undercut it.
+	assert.Equal(t, []time.Duration{
+		100 * time.Millisecond, // 50ms raw, clamped up to the 100ms floor
+		100 * time.Millisecond, // 100ms raw, at the floor
+		200 * time.Millisecond,
+		250 * time.Millisecond,
+		250 * time.Millisecond,
+		250 * time.Millisecond,
+	}, returned)
 }
 
 // TestNextBackOff_JitterBounds draws many samples across the whole


### PR DESCRIPTION
## Summary

`ExponentialBackoff.NextBackOff` doubled its interval from `InitialInterval` to `MaxInterval` with no randomness. Every caller on the same schedule (the WebSocket reconnect backoff in `pkg/runner/client.go` uses 5s/60s) retries in lockstep after a shared event, so a backhaul server restart turns into a synchronized reconnect burst from every connected agent at once.

## Changes

- `internal/retry/retry.go`: `NextBackOff` now multiplies its computed interval by a random factor in `[0.5, 1.5)` and clamps the result to `[InitialInterval, MaxInterval]`. The underlying doubling sequence that produces the computed interval is unaffected by the random draw, so it still reaches `MaxInterval` on the same schedule as before; only the value returned to the caller is jittered. Added a `Rand func() float64` field (returning a value in `[0, 1)`) so the randomness is injectable; it defaults to `math/rand/v2`'s package-level source when nil.
- `internal/retry/retry_test.go`: replaced the old exact-value assertions (which no longer hold once the result is jittered) with tests that pin `Rand` to isolate the doubling sequence from jitter, draw many samples to check bounds hold, check the returned value actually varies across draws (so a no-op jitter bug would be caught), check both jitter-factor extremes clamp correctly, and check `Reset` still restarts the sequence. Also converted two of the tests directly adjacent to this change from `t.Fatalf` to `require`/`assert`, per this repo's testing convention.

## Testing

- `go build ./...`
- `go vet ./...`
- `go test ./... -p 1` (full suite, including `pkg/runner` which is the heaviest user of `ExponentialBackoff`)
- `go test ./internal/retry/... -p 1 -v -count=5` (multiple runs to catch flakiness from the new randomized assertions)
- `golangci-lint run --timeout=5m ./...` (only pre-existing, unrelated findings in untouched files)
- `go mod tidy` (no diff)

Grepped every `ExponentialBackoff` caller (`pkg/runner/client.go`, `control_client.go`, `pty.go`, `auth_manager.go`, `auth_session_event.go`): none read `NextBackOff`'s return value for anything besides scheduling the retry timer, so no call site changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162DGnJkJYRrpPJQnwTCcUG