### PR TITLE
fix(utils): use the default file mode when a zip entry carries none

### DIFF
--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -30,8 +30,8 @@ const (
 
 	// zipCreatorUnix and zipCreatorMacOSX are the creator halves of a zip
 	// header's CreatorVersion under which archive/zip reads a Unix mode out of
-	// ExternalAttrs; SetMode writes the first. Every other creator gets a mode
-	// derived from FAT attributes instead.
+	// ExternalAttrs; SetMode writes the first. FAT, NTFS and VFAT creators get a
+	// mode derived from FAT attributes instead; every other creator gets none.
 	zipCreatorUnix   = 3
 	zipCreatorMacOSX = 19
 
@@ -756,9 +756,10 @@ func extractFile(f *zip.File, fpath string) error {
 	// or sticky off an entry would land on a root-owned file. newZipEntry drops
 	// the same bits on the way in.
 	mode := f.Mode().Perm()
-	if creator := f.CreatorVersion >> 8; mode == 0 && (creator == zipCreatorUnix || creator == zipCreatorMacOSX) {
-		// As with directories, zero means no mode was carried. Use the same
-		// default archive/zip gives files without Unix modes; umask still applies.
+	if mode == 0 {
+		// Zero is an entry that carried no mode: a Unix header left empty, or
+		// a creator archive/zip does not decode. Use the 0666 it gives a FAT
+		// entry; umask still applies.
 		mode = 0666
 	}
 	outFile, err := createFile(fpath, mode)

--- a/pkg/utils/archive.go
+++ b/pkg/utils/archive.go
@@ -755,7 +755,13 @@ func extractFile(f *zip.File, fpath string) error {
 	// Perm only: extraction runs as root on a normal install, so setuid, setgid
 	// or sticky off an entry would land on a root-owned file. newZipEntry drops
 	// the same bits on the way in.
-	outFile, err := createFile(fpath, f.Mode().Perm())
+	mode := f.Mode().Perm()
+	if creator := f.CreatorVersion >> 8; mode == 0 && (creator == zipCreatorUnix || creator == zipCreatorMacOSX) {
+		// As with directories, zero means no mode was carried. Use the same
+		// default archive/zip gives files without Unix modes; umask still applies.
+		mode = 0666
+	}
+	outFile, err := createFile(fpath, mode)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -1171,11 +1171,13 @@ func TestUnzip_FileEntryWithoutModeKeepsTheDefault(t *testing.T) {
 	}{
 		{"Unix", zipCreatorUnix},
 		{"MacOSX", zipCreatorMacOSX},
+		{"OpenVMS", 2},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			w := zip.NewWriter(&buf)
-			// No SetMode: preserve zero external attributes from a Unix creator.
+			// No SetMode: preserve the zero external attributes archive/zip
+			// leaves for a creator it does not decode a mode from.
 			zw, err := w.CreateHeader(&zip.FileHeader{
 				Name:           "file.txt",
 				CreatorVersion: tc.creator << 8,

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -1176,8 +1176,8 @@ func TestUnzip_FileEntryWithoutModeKeepsTheDefault(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			w := zip.NewWriter(&buf)
-			// No SetMode: preserve the zero external attributes archive/zip
-			// leaves for a creator it does not decode a mode from.
+			// No SetMode: zero external attributes read back as mode 0 whether
+			// archive/zip reads a Unix mode for the creator or decodes nothing.
 			zw, err := w.CreateHeader(&zip.FileHeader{
 				Name:           "file.txt",
 				CreatorVersion: tc.creator << 8,

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -1194,12 +1194,11 @@ func TestUnzip_FileEntryWithoutModeKeepsTheDefault(t *testing.T) {
 			out := filepath.Join(dir, "out")
 			require.NoError(t, UnzipReader(r, out))
 
-			// os.Create uses 0666, subject to the process's umask, just like
-			// extraction of a file from an archive with no Unix mode.
-			ref, err := os.Create(filepath.Join(dir, "ref"))
-			require.NoError(t, err)
-			want, err := ref.Stat()
-			require.NoError(t, ref.Close())
+			// A file written at 0666 goes through the same umask as extraction,
+			// so it is the reference, not a literal 0644.
+			ref := filepath.Join(dir, "ref")
+			require.NoError(t, os.WriteFile(ref, nil, 0666))
+			want, err := os.Stat(ref)
 			require.NoError(t, err)
 			path := filepath.Join(out, "file.txt")
 			fi, err := os.Stat(path)

--- a/pkg/utils/archive_test.go
+++ b/pkg/utils/archive_test.go
@@ -1160,6 +1160,56 @@ func TestUnzip_DirectoryEntryWithoutModeKeepsTheDefault(t *testing.T) {
 	assert.Equal(t, "hi", string(content))
 }
 
+func TestUnzip_FileEntryWithoutModeKeepsTheDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	for _, tc := range []struct {
+		name    string
+		creator uint16
+	}{
+		{"Unix", zipCreatorUnix},
+		{"MacOSX", zipCreatorMacOSX},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := zip.NewWriter(&buf)
+			// No SetMode: preserve zero external attributes from a Unix creator.
+			zw, err := w.CreateHeader(&zip.FileHeader{
+				Name:           "file.txt",
+				CreatorVersion: tc.creator << 8,
+			})
+			require.NoError(t, err)
+			_, err = zw.Write([]byte("hi"))
+			require.NoError(t, err)
+			require.NoError(t, w.Close())
+			r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+			require.NoError(t, err)
+			require.Zero(t, r.File[0].Mode().Perm())
+
+			dir := t.TempDir()
+			out := filepath.Join(dir, "out")
+			require.NoError(t, UnzipReader(r, out))
+
+			// os.Create uses 0666, subject to the process's umask, just like
+			// extraction of a file from an archive with no Unix mode.
+			ref, err := os.Create(filepath.Join(dir, "ref"))
+			require.NoError(t, err)
+			want, err := ref.Stat()
+			require.NoError(t, ref.Close())
+			require.NoError(t, err)
+			path := filepath.Join(out, "file.txt")
+			fi, err := os.Stat(path)
+			require.NoError(t, err)
+			assert.Equal(t, want.Mode().Perm(), fi.Mode().Perm())
+			content, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, "hi", string(content))
+		})
+	}
+}
+
 func TestUnzipReader_ExtractsAnInMemoryArchive(t *testing.T) {
 	var buf bytes.Buffer
 	w := zip.NewWriter(&buf)


### PR DESCRIPTION
## Background
Directory entries already fell back to a default mode when none was carried, but file entries had no equivalent handling. A Unix or macOS zip entry with a zero mode in its external attributes has no mode set at all, and `extractFile` passed that 0 straight through as the file's permissions, producing a file nobody could read or write.

## Changes
In `extractFile`, fall back to 0666 whenever the decoded mode is 0—the same default `archive/zip` gives files with no Unix mode. This value still goes through the process's umask.

The initial fix gated the fallback on the creator being `zipCreatorUnix` or `zipCreatorMacOSX`, which left the same bug in place for any creator `archive/zip` does not decode a mode from (OpenVMS and others): those entries carry a zero mode too and were never covered by the gate. FAT, NTFS and VFAT creators never need a gate, since their branch of `FileHeader.Mode()` never returns a zero permission for a file—checking `mode == 0` alone already excludes them. The gate is gone, and the `zipCreatorUnix`/`zipCreatorMacOSX` doc comment is corrected: only FAT, NTFS and VFAT creators derive a mode from FAT attributes; every other creator gets none, which is what made the gate look safe.

## Testing
`TestUnzip_FileEntryWithoutModeKeepsTheDefault` now covers the Unix, MacOSX and OpenVMS creators. Against the pre-review code the OpenVMS case fails with `expected: 0x1a4, actual: 0x0`. The reference file is now built with `os.WriteFile` plus `os.Stat`, matching the `os.Mkdir` plus `os.Stat` reference `TestUnzip_DirectoryEntryWithoutModeKeepsTheDefault` already uses.

Confirmed `go test -race -v -shuffle=on ./pkg/utils/... -run TestUnzip` passes.

Closes #440
