### PR TITLE
feat(wsclient): add a leaf WebSocket transport package

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -157,6 +157,35 @@ jobs:
             printf '%s\n' "$deps" | sed 's/^/  /'
           done
 
+  # pkg/wsclient holds one connection open across reconnects with a read
+  # loop, callers writing from their own goroutines, and a watcher that
+  # interrupts a parked read. That ownership model is the whole point of the
+  # package, and getting it wrong is what issue #452 is about in pkg/runner.
+  # The suite below runs without the race detector on every platform, so a
+  # race reintroduced here would pass it.
+  #
+  # Cheap enough to be worth its own job: no cgo of its own, no database and
+  # no generated code, so it needs neither a distro container nor the ent
+  # codegen step. `cache: false` for the same reason as leaf-guard, so this
+  # job cannot claim the shared setup-go cache key for a near-empty cache.
+  race-wsclient:
+    name: Race detector (pkg/wsclient)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      # Twice over: a race that needs an unlucky interleaving does not always
+      # show up on the first scheduling.
+      - name: Run tests under the race detector
+        run: go test -race -count=2 ./pkg/wsclient
+
   # Renamed from `build-and-test` so the flat aggregator at the bottom of this
   # file can take that id: a job id and the aggregate check name cannot be the
   # same string, and the aggregate is the one that has to be `build-and-test`.
@@ -414,6 +443,7 @@ jobs:
     needs:
       - verify-tidy
       - leaf-guard
+      - race-wsclient
       - build-and-test-linux
       - build-and-test-windows
       - build-and-test-macos

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,6 +29,134 @@ jobs:
           go mod tidy
           git diff --exit-code go.mod go.sum
 
+  # pkg/wsclient is imported by alpacax/alpamon-kube, a separate module that
+  # pins an alpamon tag, and its whole value is that it is a leaf: WebSocket
+  # transport and nothing else. The day it imports pkg/config, pkg/utils,
+  # internal/* or anything that drags in creack/pty or the systemd probes,
+  # every importer has to compile the host agent just to open a socket, which
+  # is how alpamon-dhcp-plugin ended up pinned to v1.3.0 for over a year. No
+  # linter here enforces an import boundary (there is no .golangci.yml, so no
+  # depguard), so this job is the only thing holding the line.
+  #
+  # It deliberately skips ./.github/actions/setup-go-generate. The ent package
+  # is gitignored and loading pkg/wsclient must not need it; if this job ever
+  # fails for want of generated code, the package has grown a dependency it
+  # should not have, and red is the right answer.
+  #
+  # To run it yourself, save the step's script to a file and run it with
+  # `PKG=... ALLOWED='...' bash that-file`. It needs nothing but Go. Do not
+  # paste it into an interactive shell: `set -e` and `exit 1` would take the
+  # shell down with it.
+  leaf-guard:
+    name: Verify pkg/wsclient stays a leaf
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          # This job downloads almost nothing, and setup-go's cache key is the
+          # same one the ubuntu jobs using setup-go-generate compute. Saving
+          # from here would claim that key for a near-empty cache and leave the
+          # jobs that need it with nothing to restore.
+          cache: false
+
+      - name: Check the dependency graph
+        env:
+          PKG: github.com/alpacax/alpamon/v2/pkg/wsclient
+          # The only packages pkg/wsclient may reach outside the standard
+          # library. pkg/tunnel and pkg/version are leaves themselves.
+          ALLOWED: >-
+            github.com/alpacax/alpamon/v2/pkg/wsclient
+            github.com/alpacax/alpamon/v2/pkg/tunnel
+            github.com/alpacax/alpamon/v2/pkg/version
+            github.com/gorilla/websocket
+        run: |
+          set -euo pipefail
+
+          # Plain string comparison rather than a regex. `if unexpected=$(grep
+          # -vE "$ALLOWED" ...)` would read grep's exit 2, which is what a
+          # mistyped pattern gives, the same as exit 1, and let the guard pass
+          # on a package that had already drifted.
+          allowed() {
+            local candidate="$1" entry
+            for entry in $ALLOWED; do
+              if [ "$entry" = "$candidate" ]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          # go list resolves build constraints for one target at a time, so a
+          # file tagged //go:build windows could import anything and a Linux
+          # runner would never see it. Cover every target .goreleaser.yaml
+          # ships, which build with CGO off, plus the cgo-on pass that matches
+          # how this repo's own Linux jobs build.
+          for target in linux/amd64/1 linux/amd64/0 linux/arm64/0 darwin/amd64/0 darwin/arm64/0 windows/amd64/0; do
+            IFS=/ read -r goos goarch cgo <<<"$target"
+
+            # {{if .Module}} prints only packages that come from a module,
+            # which leaves out the standard library, including the
+            # GOROOT-vendored vendor/golang.org/x/... packages crypto/tls and
+            # net/http pull in. Those print as empty lines, which sed drops.
+            # -deps skips test-only imports on purpose: tests may use testify,
+            # and no importer compiles them, so do not add -test.
+            deps="$(GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="$cgo" \
+              go list -deps -f '{{if .Module}}{{.ImportPath}}{{end}}' "$PKG" | sed '/^$/d')"
+
+            # Unquoted on purpose: one dependency per word.
+            # shellcheck disable=SC2086
+            set -- $deps
+
+            # A package that no longer resolves would leave nothing to check,
+            # and every test below would pass on an empty list.
+            self=no
+            for dep in "$@"; do
+              if [ "$dep" = "$PKG" ]; then
+                self=yes
+              fi
+            done
+            if [ "$self" = no ]; then
+              echo "::error::$PKG is missing from its own dependency list on $target, so this guard would have passed without checking anything"
+              printf '%s\n' "$deps"
+              exit 1
+            fi
+
+            coupling=
+            unexpected=
+            for dep in "$@"; do
+              case "$dep" in
+                *pty*|*systemd*) coupling="$coupling  $dep"$'\n' ;;
+              esac
+              if ! allowed "$dep"; then
+                unexpected="$unexpected  $dep"$'\n'
+              fi
+            done
+
+            # Checked before the allowlist, which would refuse these too:
+            # naming the two couplings that made a separate alpamon-kube
+            # necessary says more than a generic message about whichever
+            # transitive import happened to bring them in.
+            if [ -n "$coupling" ]; then
+              echo "::error file=pkg/wsclient/doc.go::on $target, pkg/wsclient's dependency graph reaches pty or systemd code:"
+              printf '%s' "$coupling"
+              exit 1
+            fi
+            if [ -n "$unexpected" ]; then
+              echo "::error file=pkg/wsclient/doc.go::pkg/wsclient must stay a leaf, but on $target its dependency graph reaches:"
+              printf '%s' "$unexpected"
+              echo "Allowed: $ALLOWED, and the standard library."
+              exit 1
+            fi
+
+            echo "pkg/wsclient on $target:"
+            printf '%s\n' "$deps" | sed 's/^/  /'
+          done
+
   # Renamed from `build-and-test` so the flat aggregator at the bottom of this
   # file can take that id: a job id and the aggregate check name cannot be the
   # same string, and the aggregate is the one that has to be `build-and-test`.
@@ -285,6 +413,7 @@ jobs:
   build-and-test:
     needs:
       - verify-tidy
+      - leaf-guard
       - build-and-test-linux
       - build-and-test-windows
       - build-and-test-macos

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
   # transport and nothing else. The day it imports pkg/config, pkg/utils,
   # internal/* or anything that drags in creack/pty or the systemd probes,
   # every importer has to compile the host agent just to open a socket, which
-  # is how alpamon-dhcp-plugin ended up pinned to v1.3.0 for over a year. No
+  # is what keeps alpamon-dhcp-plugin on a pre-/v2 alpamon today. No
   # linter here enforces an import boundary (there is no .golangci.yml, so no
   # depguard), so this job is the only thing holding the line.
   #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Commands from the Alpacon console flow through:
 
 **WebSocket transport (`pkg/wsclient/`)**
 - Leaf package for modules outside this repo (alpamon-kube): dial with the `id`/`key` header, jittered reconnect backoff, read timeout, reconnect
-- May import only the standard library, gorilla/websocket, `pkg/tunnel` and `pkg/version`; the `leaf-guard` job in `build-and-test.yml` enforces this
+- May import only the standard library, gorilla/websocket, `pkg/tunnel` and `pkg/version`; the `leaf-guard` job in `.github/workflows/build-and-test.yml` enforces this
 - Nothing in alpamon calls it yet; `pkg/runner` keeps its own client
 
 **Configuration (`pkg/config/`)**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,11 @@ Commands from the Alpacon console flow through:
 - `protocol/`: Command and message protocol definitions
 - `pool/`: Worker pool for concurrent task execution
 
+**WebSocket transport (`pkg/wsclient/`)**
+- Leaf package for modules outside this repo (alpamon-kube): dial with the `id`/`key` header, jittered reconnect backoff, read timeout, reconnect
+- May import only the standard library, gorilla/websocket, `pkg/tunnel` and `pkg/version`; the `leaf-guard` job in `build-and-test.yml` enforces this
+- Nothing in alpamon calls it yet; `pkg/runner` keeps its own client
+
 **Configuration (`pkg/config/`)**
 - INI-based configuration parsing
 - Environment variable support

--- a/pkg/wsclient/backoff.go
+++ b/pkg/wsclient/backoff.go
@@ -1,0 +1,59 @@
+package wsclient
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// backoff is the reconnect schedule: exponential with jitter. It mirrors
+// internal/retry.ExponentialBackoff rather than importing it, because Go's
+// internal rule keeps internal/ out of reach of the modules this package
+// exists for.
+//
+// The base doubles from initial up to max, and only the value handed back is
+// jittered. Keeping the base pure means an unlucky draw never drags the
+// sequence down, so it reaches max on the same schedule every time.
+type backoff struct {
+	initial time.Duration
+	max     time.Duration
+	rand    func() float64 // returns [0, 1); nil means math/rand/v2
+
+	current time.Duration
+}
+
+// next returns the next wait: the doubling base multiplied by a factor in
+// [0.5, 1.5), clamped to [initial, max]. Without the random factor every
+// agent reconnecting after the same event, such as a backhaul restart,
+// would retry in lockstep.
+func (b *backoff) next() time.Duration {
+	switch {
+	case b.current == 0:
+		b.current = b.initial
+	case b.current > b.max/2: // doubling would pass max, or overflow
+		b.current = b.max
+	default:
+		b.current *= 2
+	}
+
+	randFn := b.rand
+	if randFn == nil {
+		randFn = rand.Float64
+	}
+
+	// Clamp in float64 before converting: a factor near 1.5 on a large max
+	// would overflow time.Duration, and !(x < max) also catches a NaN from
+	// a caller-supplied source.
+	jittered := float64(b.current) * (0.5 + randFn())
+	if !(jittered < float64(b.max)) {
+		return b.max
+	}
+	if d := time.Duration(jittered); d > b.initial {
+		return d
+	}
+	return b.initial
+}
+
+// reset restarts the schedule at initial, after a connection succeeds.
+func (b *backoff) reset() {
+	b.current = 0
+}

--- a/pkg/wsclient/backoff.go
+++ b/pkg/wsclient/backoff.go
@@ -22,9 +22,15 @@ type backoff struct {
 }
 
 // next returns the next wait: the doubling base multiplied by a factor in
-// [0.5, 1.5), clamped to [initial, max]. Without the random factor every
-// agent reconnecting after the same event, such as a backhaul restart,
-// would retry in lockstep.
+// [1.0, 1.5), clamped to [initial, max]. Without the random factor every
+// agent reconnecting after the same event, such as a backhaul restart, would
+// retry in lockstep.
+//
+// The factor starts at 1.0 rather than 0.5, which is where internal/retry
+// starts it, because the clamp to initial would otherwise swallow the whole
+// lower half: at the first attempt the base is initial, so every draw below
+// 1.0 returns exactly initial and half of a fleet retries on the same tick.
+// Spreading upward keeps initial a real floor and the distribution intact.
 func (b *backoff) next() time.Duration {
 	switch {
 	case b.current == 0:
@@ -43,7 +49,7 @@ func (b *backoff) next() time.Duration {
 	// Clamp in float64 before converting: a factor near 1.5 on a large max
 	// would overflow time.Duration, and !(x < max) also catches a NaN from
 	// a caller-supplied source.
-	jittered := float64(b.current) * (0.5 + randFn())
+	jittered := float64(b.current) * (1.0 + 0.5*randFn())
 	if !(jittered < float64(b.max)) {
 		return b.max
 	}

--- a/pkg/wsclient/backoff_test.go
+++ b/pkg/wsclient/backoff_test.go
@@ -1,0 +1,158 @@
+package wsclient
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The cases below mirror internal/retry/retry_test.go, which pins the same
+// schedule. Keep the two in step.
+
+// TestBackoff_BaseDoublingReachesCeiling pins the draw to a non-neutral
+// factor (0.5x) and asserts on the internal base apart from the returned
+// value. At the neutral factor (1.0x) an implementation that feeds the
+// jittered value back into the base produces the same numbers as a correct
+// one, so only a non-neutral factor tells them apart.
+func TestBackoff_BaseDoublingReachesCeiling(t *testing.T) {
+	b := &backoff{
+		initial: 100 * time.Millisecond,
+		max:     500 * time.Millisecond,
+		rand:    func() float64 { return 0 }, // factor 0.5, the low edge
+	}
+
+	returned := make([]time.Duration, 6)
+	base := make([]time.Duration, 6)
+	for i := range returned {
+		returned[i] = b.next()
+		base[i] = b.current
+	}
+
+	assert.Equal(t, []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		500 * time.Millisecond, // capped at max from here on
+		500 * time.Millisecond,
+		500 * time.Millisecond,
+	}, base, "the base must keep doubling to the ceiling whatever the jitter draws")
+
+	assert.Equal(t, []time.Duration{
+		100 * time.Millisecond, // 50ms raw, clamped up to the floor
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		250 * time.Millisecond,
+		250 * time.Millisecond,
+		250 * time.Millisecond,
+	}, returned)
+}
+
+// TestBackoff_JitterStaysInBounds draws from the real source across the whole
+// doubling sequence and checks every wait lands in [initial, max].
+func TestBackoff_JitterStaysInBounds(t *testing.T) {
+	const (
+		initial = 100 * time.Millisecond
+		maxWait = 500 * time.Millisecond
+	)
+
+	for range 500 {
+		b := &backoff{initial: initial, max: maxWait}
+		for range 10 {
+			d := b.next()
+			assert.GreaterOrEqual(t, d, initial)
+			assert.LessOrEqual(t, d, maxWait)
+		}
+	}
+}
+
+// TestBackoff_JitterVariesTheWait guards against a jitter that silently does
+// nothing, such as a draw whose result is discarded.
+func TestBackoff_JitterVariesTheWait(t *testing.T) {
+	seen := map[time.Duration]bool{}
+	for range 200 {
+		b := &backoff{initial: 100 * time.Millisecond, max: 10 * time.Second}
+		seen[b.next()] = true
+	}
+
+	assert.Greater(t, len(seen), 1, "200 first draws should not all land on one value")
+}
+
+func TestBackoff_ExtremeDrawsClamp(t *testing.T) {
+	low := &backoff{
+		initial: 100 * time.Millisecond,
+		max:     500 * time.Millisecond,
+		rand:    func() float64 { return 0 },
+	}
+	assert.Equal(t, 100*time.Millisecond, low.next(), "0.5x of the initial wait clamps up to the floor")
+
+	high := &backoff{
+		initial: 100 * time.Millisecond,
+		max:     500 * time.Millisecond,
+		rand:    func() float64 { return 0.999999 },
+	}
+	for range 5 {
+		high.next()
+	}
+	assert.Equal(t, 500*time.Millisecond, high.next(), "~1.5x of the ceiling clamps down to it")
+}
+
+// TestBackoff_HostileDrawsClamp covers a caller-supplied source that breaks
+// its [0, 1) contract. The clamp has to hold for these too, since a wait of
+// zero or less would turn the reconnect loop into a busy loop.
+func TestBackoff_HostileDrawsClamp(t *testing.T) {
+	for name, draw := range map[string]float64{
+		"negative": -5,
+		"too big":  7,
+		"NaN":      math.NaN(),
+		"infinity": math.Inf(1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			b := &backoff{
+				initial: 100 * time.Millisecond,
+				max:     500 * time.Millisecond,
+				rand:    func() float64 { return draw },
+			}
+			for range 6 {
+				d := b.next()
+				assert.GreaterOrEqual(t, d, 100*time.Millisecond)
+				assert.LessOrEqual(t, d, 500*time.Millisecond)
+			}
+		})
+	}
+}
+
+// TestBackoff_LargeMaxDoesNotOverflow drives the base against a ceiling near
+// the top of time.Duration, where a naive doubling or a 1.5x factor would wrap
+// negative.
+func TestBackoff_LargeMaxDoesNotOverflow(t *testing.T) {
+	b := &backoff{
+		initial: time.Second,
+		max:     time.Duration(math.MaxInt64),
+		rand:    func() float64 { return 0.999999 },
+	}
+	for range 80 {
+		d := b.next()
+		require.Positive(t, d)
+		require.Positive(t, b.current)
+	}
+	assert.Equal(t, time.Duration(math.MaxInt64), b.current, "the base must settle on the ceiling, not wrap")
+}
+
+func TestBackoff_ResetRestartsTheSequence(t *testing.T) {
+	b := &backoff{
+		initial: 100 * time.Millisecond,
+		max:     500 * time.Millisecond,
+		rand:    func() float64 { return 0.5 }, // factor 1.0, isolates reset from jitter
+	}
+
+	for range 4 {
+		b.next()
+	}
+	require.Equal(t, 500*time.Millisecond, b.current, "the sequence should have reached the ceiling")
+
+	b.reset()
+	assert.Equal(t, 100*time.Millisecond, b.next(), "the first wait after reset starts over at the floor")
+}

--- a/pkg/wsclient/backoff_test.go
+++ b/pkg/wsclient/backoff_test.go
@@ -13,7 +13,7 @@ import (
 // schedule. Keep the two in step.
 
 // TestBackoff_BaseDoublingReachesCeiling pins the draw to a non-neutral
-// factor (0.5x) and asserts on the internal base apart from the returned
+// factor (1.25x) and asserts on the internal base apart from the returned
 // value. At the neutral factor (1.0x) an implementation that feeds the
 // jittered value back into the base produces the same numbers as a correct
 // one, so only a non-neutral factor tells them apart.
@@ -21,7 +21,7 @@ func TestBackoff_BaseDoublingReachesCeiling(t *testing.T) {
 	b := &backoff{
 		initial: 100 * time.Millisecond,
 		max:     500 * time.Millisecond,
-		rand:    func() float64 { return 0 }, // factor 0.5, the low edge
+		rand:    func() float64 { return 0.5 }, // factor 1.25
 	}
 
 	returned := make([]time.Duration, 6)
@@ -41,12 +41,12 @@ func TestBackoff_BaseDoublingReachesCeiling(t *testing.T) {
 	}, base, "the base must keep doubling to the ceiling whatever the jitter draws")
 
 	assert.Equal(t, []time.Duration{
-		100 * time.Millisecond, // 50ms raw, clamped up to the floor
-		100 * time.Millisecond,
-		200 * time.Millisecond,
+		125 * time.Millisecond,
 		250 * time.Millisecond,
-		250 * time.Millisecond,
-		250 * time.Millisecond,
+		500 * time.Millisecond, // 1.25x of 400ms, clamped down to the ceiling
+		500 * time.Millisecond,
+		500 * time.Millisecond,
+		500 * time.Millisecond,
 	}, returned)
 }
 
@@ -86,7 +86,7 @@ func TestBackoff_ExtremeDrawsClamp(t *testing.T) {
 		max:     500 * time.Millisecond,
 		rand:    func() float64 { return 0 },
 	}
-	assert.Equal(t, 100*time.Millisecond, low.next(), "0.5x of the initial wait clamps up to the floor")
+	assert.Equal(t, 100*time.Millisecond, low.next(), "the lowest draw returns the base itself, the floor")
 
 	high := &backoff{
 		initial: 100 * time.Millisecond,
@@ -145,7 +145,7 @@ func TestBackoff_ResetRestartsTheSequence(t *testing.T) {
 	b := &backoff{
 		initial: 100 * time.Millisecond,
 		max:     500 * time.Millisecond,
-		rand:    func() float64 { return 0.5 }, // factor 1.0, isolates reset from jitter
+		rand:    func() float64 { return 0 }, // factor 1.0, isolates reset from jitter
 	}
 
 	for range 4 {

--- a/pkg/wsclient/client.go
+++ b/pkg/wsclient/client.go
@@ -319,11 +319,12 @@ func (c *Client) serve(ctx context.Context, conn *websocket.Conn, h Handler) (di
 		messageType, payload, err := conn.ReadMessage()
 		if err != nil {
 			cause, ending := c.closeRequest(ctx)
-			// Freeing a read produces a timeout and nothing else, so any
-			// other error is the connection's own ending, even if a request
-			// happened to be pending: report that rather than the request.
-			var timeout net.Error
-			if ending && errors.As(err, &timeout) && timeout.Timeout() {
+			// Freeing a read produces a timeout, or net.ErrClosed when the
+			// socket refused the deadline and freeRead closed it instead. Any
+			// other error is the connection's own ending, a peer's close
+			// frame among them, even if a request happened to be pending:
+			// report that rather than the request.
+			if ending && wokenOnPurpose(err) {
 				err = cause
 			}
 			c.release(conn, err)
@@ -376,14 +377,25 @@ func (c *Client) rearm(ctx context.Context, conn *websocket.Conn) {
 	_ = conn.SetReadDeadline(time.Now().Add(c.s.readTimeout))
 }
 
-// freeRead unblocks a read parked on conn. Pushing the deadline into the
-// past is the ordinary way, but a caller-supplied net.Conn may refuse a
-// deadline, and then closing the socket is the only thing left that ends the
-// read. Both are safe to call while another goroutine is reading.
+// freeRead unblocks a read parked on conn from a goroutine other than the
+// reader. It works on the underlying net.Conn: gorilla/websocket counts its
+// own SetReadDeadline among the read methods that only one goroutine may
+// call, while net.Conn promises that any of its methods may be called
+// concurrently. Pushing the deadline into the past is the ordinary way, but a
+// caller-supplied net.Conn may refuse a deadline, and then closing the socket
+// is the only thing left that ends the read; gorilla's Close is safe to call
+// concurrently too.
 func freeRead(conn *websocket.Conn) {
-	if err := conn.SetReadDeadline(aLongTimeAgo); err != nil {
+	if err := conn.UnderlyingConn().SetReadDeadline(aLongTimeAgo); err != nil {
 		_ = conn.Close()
 	}
+}
+
+// wokenOnPurpose reports whether a failed read is one this package caused
+// to free it, as opposed to one the connection failed on by itself.
+func wokenOnPurpose(err error) bool {
+	var timeout net.Error
+	return (errors.As(err, &timeout) && timeout.Timeout()) || errors.Is(err, net.ErrClosed)
 }
 
 // closeRequest reports whether the live connection is ending, and the cause
@@ -468,8 +480,10 @@ func closeConn(conn *websocket.Conn) {
 	err := conn.WriteControl(websocket.CloseMessage,
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 		time.Now().Add(closeTimeout))
-	if err == nil {
-		_ = conn.SetReadDeadline(time.Now().Add(drainTimeout))
+	// Only drain when the drain can be bounded: a conn that refuses the
+	// deadline would leave NextReader waiting on a silent peer forever, and
+	// Close, which is what actually matters, would never be reached.
+	if err == nil && conn.SetReadDeadline(time.Now().Add(drainTimeout)) == nil {
 		for {
 			if _, _, err := conn.NextReader(); err != nil {
 				break

--- a/pkg/wsclient/client.go
+++ b/pkg/wsclient/client.go
@@ -1,0 +1,427 @@
+package wsclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// closeTimeout bounds each step of closing a connection: sending the close
+// frame, and waiting for the peer's reply to it.
+const closeTimeout = 5 * time.Second
+
+// aLongTimeAgo is a read deadline already in the past. Setting it frees a
+// parked read at once, whatever the clock says.
+var aLongTimeAgo = time.Unix(1, 0)
+
+var (
+	// ErrNotConnected is returned by a write made while no connection is up,
+	// for example between a drop and the reconnect that follows it.
+	ErrNotConnected = errors.New("wsclient: not connected")
+
+	// ErrAlreadyRunning is returned by Run on a Client whose Run has already
+	// been called. A Client is single-use.
+	ErrAlreadyRunning = errors.New("wsclient: Run has already been called")
+)
+
+// Handler receives each inbound frame. It runs on the Run goroutine, so the
+// next frame is not read until it returns: hand long work to another
+// goroutine. ctx is done once Run starts stopping. A non-nil error stops Run,
+// which returns it; call Shutdown for an ordinary stop.
+type Handler func(ctx context.Context, messageType int, payload []byte) error
+
+// Client keeps one WebSocket connection up: it dials, reconnects with
+// jittered backoff whenever the connection drops, and hands every inbound
+// frame to a Handler.
+//
+// The Client owns its connection. Run is the only goroutine that reads it,
+// writes are serialized, and Reconnect and Shutdown only signal the read
+// loop, so gorilla/websocket's one-reader, one-writer rule holds without the
+// caller's help. All methods are safe for concurrent use.
+type Client struct {
+	s settings
+
+	// mu guards conn and the pending-reconnect pair. Nothing slower than
+	// SetReadDeadline happens while it is held.
+	mu   sync.Mutex
+	conn *websocket.Conn
+	// reconnectPending asks Run to replace conn; reconnectCause is what
+	// OnDisconnect then reports: nil for Reconnect, the write error for a
+	// connection a failed write abandoned. Both reset whenever conn changes.
+	reconnectPending bool
+	reconnectCause   error
+
+	// writeMu serializes data frames. Lock order is writeMu, then mu.
+	writeMu sync.Mutex
+
+	started      atomic.Bool
+	shutdownOnce sync.Once
+	shutdown     chan struct{}
+	done         chan struct{}
+}
+
+// New validates cfg and returns a Client ready to Run. It does not dial.
+func New(cfg Config) (*Client, error) {
+	s, err := cfg.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		s:        s,
+		shutdown: make(chan struct{}),
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// Run dials, then feeds every inbound frame to h until Shutdown is called,
+// ctx is done, or h returns an error, reconnecting whenever the connection
+// drops. It keeps trying for as long as it runs; OnRetry reports every wait,
+// so a caller that wants to give up can call Shutdown.
+//
+// The backoff paces attempts, not just failed dials. A connection that ends
+// before it proved itself is followed by the same jittered wait a failed dial
+// gets. A connection proves itself by carrying an inbound frame or by staying
+// up for MinBackoff, and one that does restarts the schedule, as does a
+// reconnect the caller asked for. Without that, a peer that accepts the
+// handshake and closes at once would be redialed in a tight loop.
+//
+// Run returns nil after Shutdown, ctx.Err() once ctx is done, and h's error
+// when h stopped it. The connection is closed before Run returns. A Client
+// runs once: a second call returns ErrAlreadyRunning.
+func (c *Client) Run(ctx context.Context, h Handler) error {
+	if !c.started.CompareAndSwap(false, true) {
+		return ErrAlreadyRunning
+	}
+	defer close(c.done)
+	if h == nil {
+		return errors.New("wsclient: Run needs a non-nil Handler")
+	}
+
+	// runCtx also ends on Shutdown, so one context aborts a dial in flight,
+	// a backoff wait and the handler alike. A parked read ignores contexts,
+	// which is why the watcher also interrupts it.
+	runCtx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		select {
+		case <-c.shutdown:
+			cancel()
+		case <-runCtx.Done():
+		}
+		c.interrupt()
+	})
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	b := &backoff{initial: c.s.minBackoff, max: c.s.maxBackoff, rand: c.s.rand}
+	var (
+		attempt int   // attempts since the last connection that worked
+		wait    bool  // whether the next attempt waits out a backoff first
+		cause   error // what made it wait
+	)
+	for {
+		// Checked before the wait as well as before the dial, so a Shutdown
+		// neither dials again nor reports a retry that will never happen.
+		if c.stopping(runCtx) {
+			return ctx.Err()
+		}
+		if wait {
+			attempt++
+			delay := b.next()
+			c.s.onRetry(attempt, delay, cause)
+			if !c.sleep(runCtx, delay) {
+				return ctx.Err()
+			}
+		}
+
+		conn, _, err := c.s.dial(runCtx)
+		if err != nil {
+			wait, cause = true, err
+			continue
+		}
+		if !c.install(runCtx, conn) {
+			closeConn(conn)
+			return ctx.Err()
+		}
+		c.s.onConnect()
+
+		ended, handlerErr := c.serve(runCtx, conn, h)
+		if handlerErr != nil {
+			return handlerErr
+		}
+		if ended.requested || ended.proven {
+			b.reset()
+			attempt, wait, cause = 0, false, nil
+			continue
+		}
+		wait, cause = true, ended.cause
+	}
+}
+
+// sleep waits out d, and reports false if Run should stop instead.
+func (c *Client) sleep(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-c.shutdown:
+		return false
+	}
+}
+
+// WriteMessage sends one data frame on the live connection. messageType must
+// be websocket.TextMessage or websocket.BinaryMessage: control frames belong
+// to the Client. It returns ErrNotConnected while no connection is up, and
+// never queues a frame for a later connection. A failed write leaves the
+// connection unable to send, so it also makes Run replace the connection.
+func (c *Client) WriteMessage(messageType int, data []byte) error {
+	if messageType != websocket.TextMessage && messageType != websocket.BinaryMessage {
+		// gorilla/websocket would send a close frame given here, and every
+		// later write would then fail behind the read loop's back.
+		return fmt.Errorf("wsclient: WriteMessage sends data frames only, got message type %d", messageType)
+	}
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	c.mu.Lock()
+	conn := c.conn
+	c.mu.Unlock()
+	if conn == nil {
+		return ErrNotConnected
+	}
+	// gorilla/websocket keeps the write deadline in a plain field that the
+	// next write reads, so setting it is only safe under writeMu.
+	if err := conn.SetWriteDeadline(time.Now().Add(c.s.writeTimeout)); err != nil {
+		return err
+	}
+	if err := conn.WriteMessage(messageType, data); err != nil {
+		// gorilla/websocket fails every later write once one has failed, so
+		// this connection can no longer send. Replace it now rather than
+		// wait for the read side to notice.
+		c.abandon(conn, err)
+		return err
+	}
+	return nil
+}
+
+// WriteJSON sends v, encoded as JSON, as one text frame.
+func (c *Client) WriteJSON(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return c.WriteMessage(websocket.TextMessage, data)
+}
+
+// Reconnect drops the live connection so that Run dials a fresh one, as when
+// the server asks the agent to reconnect. While no connection is up it does
+// nothing, since Run is already dialing. It does not block.
+func (c *Client) Reconnect() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn == nil || c.reconnectPending {
+		return
+	}
+	c.reconnectPending = true
+	c.reconnectCause = nil
+	_ = c.conn.SetReadDeadline(aLongTimeAgo)
+}
+
+// Shutdown makes Run close the connection and return. It does not wait; Done
+// does. Calling it more than once, before Run, or after Run returned is safe.
+func (c *Client) Shutdown() {
+	c.shutdownOnce.Do(func() { close(c.shutdown) })
+}
+
+// Done is closed once Run has returned. It never closes if Run is never called.
+func (c *Client) Done() <-chan struct{} {
+	return c.done
+}
+
+// Connected reports whether a connection is up. It is a snapshot: the
+// connection may drop the moment after it returns true.
+func (c *Client) Connected() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conn != nil
+}
+
+// install makes conn the live connection, unless Run started stopping while
+// conn was being dialed.
+func (c *Client) install(ctx context.Context, conn *websocket.Conn) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stopping(ctx) {
+		return false
+	}
+	c.conn = conn
+	c.reconnectPending, c.reconnectCause = false, nil
+	return true
+}
+
+// disconnect says how a connection ended, which is what decides whether Run
+// redials at once or waits out a backoff first.
+type disconnect struct {
+	requested bool  // Shutdown, Reconnect or the Run context asked for it
+	proven    bool  // it carried a frame, or stayed up for MinBackoff
+	cause     error // what ended it; nil when the client closed a healthy connection
+}
+
+// serve reads conn into h until the connection ends, and releases it. It
+// returns h's error when h stopped it, and nil otherwise.
+func (c *Client) serve(ctx context.Context, conn *websocket.Conn, h Handler) (disconnect, error) {
+	opened := time.Now()
+	frames := 0
+	// A connection that carried traffic, or lasted as long as the shortest
+	// backoff, has shown the endpoint is worth redialing at once.
+	proven := func() bool { return frames > 0 || time.Since(opened) >= c.s.minBackoff }
+
+	for {
+		if cause, requested := c.armRead(ctx, conn); requested {
+			c.release(conn, cause)
+			return disconnect{requested: true, proven: proven(), cause: cause}, nil
+		}
+		messageType, payload, err := conn.ReadMessage()
+		if err != nil {
+			cause, requested := c.closeRequest(ctx)
+			// Freeing a read produces a timeout and nothing else, so any
+			// other error is the connection's own ending, even if a request
+			// happened to be pending: report that rather than the request.
+			var timeout net.Error
+			if requested && errors.As(err, &timeout) && timeout.Timeout() {
+				err = cause
+			} else {
+				requested = false
+			}
+			c.release(conn, err)
+			return disconnect{requested: requested, proven: proven(), cause: err}, nil
+		}
+		frames++
+		if err := h(ctx, messageType, payload); err != nil {
+			// A handler that honors its context reports the cancellation that
+			// is already stopping Run. That is not a failure of its own, and
+			// Run must still return nil for a Shutdown.
+			if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, ctxErr) {
+				c.release(conn, nil)
+				return disconnect{requested: true, proven: proven()}, nil
+			}
+			c.release(conn, err)
+			return disconnect{proven: proven(), cause: err}, err
+		}
+	}
+}
+
+// armRead re-arms conn's read deadline, unless a close has been requested,
+// in which case it reports that and the cause instead. Checking and arming
+// under one lock is what keeps a request from landing between the two and
+// being overwritten by a fresh ReadTimeout.
+func (c *Client) armRead(ctx context.Context, conn *websocket.Conn) (cause error, requested bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cause, requested := c.closeRequestLocked(ctx); requested {
+		return cause, true
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(c.s.readTimeout))
+	return nil, false
+}
+
+// closeRequest reports whether the live connection is ending on request
+// rather than on a failed read, and the cause OnDisconnect should report.
+func (c *Client) closeRequest(ctx context.Context) (cause error, requested bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closeRequestLocked(ctx)
+}
+
+func (c *Client) closeRequestLocked(ctx context.Context) (cause error, requested bool) {
+	if c.reconnectPending {
+		return c.reconnectCause, true
+	}
+	return nil, c.stopping(ctx)
+}
+
+// stopping reports whether Run should wind down. It reads the shutdown
+// channel itself instead of waiting for the watcher to cancel ctx, so no
+// dial can start in the gap between the two.
+func (c *Client) stopping(ctx context.Context) bool {
+	select {
+	case <-c.shutdown:
+		return true
+	default:
+		return ctx.Err() != nil
+	}
+}
+
+// abandon asks Run to replace conn after a write on it failed, unless conn has
+// already been replaced or a reconnect is already on its way.
+func (c *Client) abandon(conn *websocket.Conn, cause error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn != conn || c.reconnectPending {
+		return
+	}
+	c.reconnectPending = true
+	c.reconnectCause = cause
+	_ = conn.SetReadDeadline(aLongTimeAgo)
+}
+
+// interrupt frees a read parked on the live connection. It holds mu, so it
+// serializes with armRead: either armRead sees the request behind this call,
+// or this call lands after armRead and cuts its deadline short.
+func (c *Client) interrupt() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn != nil {
+		_ = c.conn.SetReadDeadline(aLongTimeAgo)
+	}
+}
+
+// release takes conn out of service. It clears the field first, so writers
+// get ErrNotConnected rather than a closing connection, then closes conn and
+// reports the disconnect. cause is nil for a requested close.
+func (c *Client) release(conn *websocket.Conn, cause error) {
+	c.mu.Lock()
+	if c.conn == conn {
+		c.conn = nil
+		c.reconnectPending, c.reconnectCause = false, nil
+	}
+	c.mu.Unlock()
+	closeConn(conn)
+	c.s.onDisconnect(cause)
+}
+
+// closeConn sends a close frame, waits for the peer's reply only when that
+// frame went out, and closes the socket regardless, so a broken connection
+// cannot leak its fd. Only the goroutine that was reading conn calls it, so
+// the drain is never a second concurrent reader.
+//
+// After a failed read, including one freed early by Reconnect or Shutdown,
+// gorilla/websocket returns the stored error to every later read, so the
+// drain ends at once. The peer still receives the close frame.
+func closeConn(conn *websocket.Conn) {
+	err := conn.WriteControl(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+		time.Now().Add(closeTimeout))
+	if err == nil {
+		_ = conn.SetReadDeadline(time.Now().Add(closeTimeout))
+		for {
+			if _, _, err := conn.NextReader(); err != nil {
+				break
+			}
+		}
+	}
+	_ = conn.Close()
+}

--- a/pkg/wsclient/client.go
+++ b/pkg/wsclient/client.go
@@ -38,15 +38,15 @@ var (
 	ErrAlreadyRunning = errors.New("wsclient: Run has already been called")
 )
 
-// Handler receives each inbound frame. It runs on the Run goroutine, so the
-// next frame is not read until it returns: hand long work to another
+// Handler receives each inbound message. It runs on the Run goroutine, so
+// the next message is not read until it returns: hand long work to another
 // goroutine. ctx is done once Run starts stopping. A non-nil error stops Run,
 // which returns it; call Shutdown for an ordinary stop.
 type Handler func(ctx context.Context, messageType int, payload []byte) error
 
 // Client keeps one WebSocket connection up: it dials, reconnects with
 // jittered backoff whenever the connection drops, and hands every inbound
-// frame to a Handler.
+// message to a Handler.
 //
 // The Client owns its connection. Run is the only goroutine that reads it,
 // writes are serialized, and Reconnect and Shutdown only signal the read
@@ -87,7 +87,7 @@ func New(cfg Config) (*Client, error) {
 	}, nil
 }
 
-// Run dials, then feeds every inbound frame to h until Shutdown is called,
+// Run dials, then feeds every inbound message to h until Shutdown is called,
 // ctx is done, or h returns an error, reconnecting whenever the connection
 // drops. It keeps trying for as long as it runs; OnRetry reports every wait,
 // so a caller that wants to give up can call Shutdown.
@@ -96,9 +96,10 @@ func New(cfg Config) (*Client, error) {
 // connection short of MinBackoff is followed by the same jittered wait a
 // failed dial gets, whether the dial was refused, the peer hung up, or a
 // write failed. Only a connection that lasted at least MinBackoff, or a close
-// the caller asked for through Reconnect or Shutdown, redials at once and
-// restarts the schedule. Without that, a peer that accepts the handshake and
-// drops it can drive a redial loop across a whole fleet.
+// the caller asked for through Reconnect, redials at once and restarts the
+// schedule; Shutdown and a done ctx end Run instead. Without that, a peer
+// that accepts the handshake and drops it can drive a redial loop across a
+// whole fleet.
 //
 // Run returns nil after Shutdown, ctx.Err() once ctx is done, and h's error
 // when h stopped it. The connection is closed before Run returns. A Client
@@ -303,10 +304,17 @@ type disconnect struct {
 // returns h's error when h stopped it, and nil otherwise.
 func (c *Client) serve(ctx context.Context, conn *websocket.Conn, h Handler) (disconnect, error) {
 	opened := time.Now()
-	// A connection that lasted as long as the shortest backoff has shown the
-	// endpoint is worth redialing at once. Counting frames instead would let
-	// a peer that sends one byte and hangs up reset the schedule every time.
-	proven := func() bool { return time.Since(opened) >= c.s.minBackoff }
+	// end takes conn out of service and says how it ended. A connection that
+	// lasted as long as the shortest backoff has shown the endpoint is worth
+	// redialing at once; counting frames instead would let a peer that sends
+	// one byte and hangs up reset the schedule every time. The proof is taken
+	// before release, because the close drain and OnDisconnect run inside it,
+	// and time spent there is not time the connection was up.
+	end := func(cause error) disconnect {
+		ended := disconnect{proven: time.Since(opened) >= c.s.minBackoff, cause: cause}
+		c.release(conn, cause)
+		return ended
+	}
 
 	// gorilla/websocket answers ping frames inside ReadMessage without
 	// touching the read deadline, so a peer whose keepalive is a ping rather
@@ -317,17 +325,23 @@ func (c *Client) serve(ctx context.Context, conn *websocket.Conn, h Handler) (di
 		if err := c.rearm(ctx, conn); err != nil {
 			return err
 		}
-		// A pong that cannot go out means the connection is already failing,
-		// and the read that follows will say so; ending the read here would
-		// only lose that reason.
-		_ = conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(closeTimeout))
-		return nil
+		// A pong the socket refused has failed the write side for good, as a
+		// failed data frame does, and nothing else would notice: each ping
+		// keeps the read deadline moving, so the connection would stay up
+		// without being able to send. Fail the read, as gorilla's own ping
+		// handler does. A pong that only timed out waiting for the write lock
+		// behind a data frame is temporary and skipped; that frame's own
+		// deadline decides the connection.
+		err := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(closeTimeout))
+		if err == nil || errors.Is(err, websocket.ErrCloseSent) || temporary(err) {
+			return nil
+		}
+		return fmt.Errorf("wsclient: answering a ping: %w", err)
 	})
 
 	for {
 		if cause, ending := c.armRead(ctx, conn); ending {
-			c.release(conn, cause)
-			return disconnect{proven: proven(), cause: cause}, nil
+			return end(cause), nil
 		}
 		messageType, payload, err := conn.ReadMessage()
 		if err != nil {
@@ -340,19 +354,16 @@ func (c *Client) serve(ctx context.Context, conn *websocket.Conn, h Handler) (di
 			if ending && wokenOnPurpose(err) {
 				err = cause
 			}
-			c.release(conn, err)
-			return disconnect{proven: proven(), cause: err}, nil
+			return end(err), nil
 		}
 		if err := h(ctx, messageType, payload); err != nil {
 			// A handler that honors its context reports the cancellation that
 			// is already stopping Run. That is not a failure of its own, and
 			// Run must still return nil for a Shutdown.
 			if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, ctxErr) {
-				c.release(conn, nil)
-				return disconnect{proven: proven()}, nil
+				return end(nil), nil
 			}
-			c.release(conn, err)
-			return disconnect{proven: proven(), cause: err}, err
+			return end(err), err
 		}
 	}
 }
@@ -405,6 +416,15 @@ func freeRead(conn *websocket.Conn) {
 	if err := conn.UnderlyingConn().SetReadDeadline(aLongTimeAgo); err != nil {
 		_ = conn.Close()
 	}
+}
+
+// temporary reports what gorilla/websocket marks as passing: its own timeout
+// waiting for the write lock is temporary, while a write that failed on the
+// socket is stored as fatal and is not. A locally declared interface, not
+// net.Error, because that interface's Temporary method is deprecated.
+func temporary(err error) bool {
+	var t interface{ Temporary() bool }
+	return errors.As(err, &t) && t.Temporary()
 }
 
 // wokenOnPurpose reports whether a failed read is one this package caused

--- a/pkg/wsclient/client.go
+++ b/pkg/wsclient/client.go
@@ -59,9 +59,12 @@ type Client struct {
 	// SetReadDeadline happens while it is held.
 	mu   sync.Mutex
 	conn *websocket.Conn
-	// reconnectPending asks Run to replace conn; reconnectCause is what
-	// OnDisconnect then reports: nil for Reconnect, the write error for a
-	// connection a failed write abandoned. Both reset whenever conn changes.
+	// reconnectPending asks Run to replace conn; reconnectCause says why:
+	// nil for Reconnect, the write error for a connection a failed write
+	// abandoned. The cause is reported only when the read ended on the
+	// wakeup this request sent; a peer's own close or error reaches the read
+	// first and outranks it, which is what wokenOnPurpose decides. Both
+	// reset whenever conn changes.
 	reconnectPending bool
 	reconnectCause   error
 

--- a/pkg/wsclient/client.go
+++ b/pkg/wsclient/client.go
@@ -13,9 +13,16 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// closeTimeout bounds each step of closing a connection: sending the close
-// frame, and waiting for the peer's reply to it.
-const closeTimeout = 5 * time.Second
+const (
+	// closeTimeout bounds sending the close frame and each control write.
+	closeTimeout = 5 * time.Second
+
+	// drainTimeout bounds waiting for the peer's reply to our close frame.
+	// It is short because the wait is politeness, not correctness: a peer
+	// that is draining or already gone is exactly the one that will not
+	// answer, and every reconnect would otherwise stall for closeTimeout.
+	drainTimeout = 1 * time.Second
+)
 
 // aLongTimeAgo is a read deadline already in the past. Setting it frees a
 // parked read at once, whatever the clock says.
@@ -85,12 +92,13 @@ func New(cfg Config) (*Client, error) {
 // drops. It keeps trying for as long as it runs; OnRetry reports every wait,
 // so a caller that wants to give up can call Shutdown.
 //
-// The backoff paces attempts, not just failed dials. A connection that ends
-// before it proved itself is followed by the same jittered wait a failed dial
-// gets. A connection proves itself by carrying an inbound frame or by staying
-// up for MinBackoff, and one that does restarts the schedule, as does a
-// reconnect the caller asked for. Without that, a peer that accepts the
-// handshake and closes at once would be redialed in a tight loop.
+// The backoff paces attempts, not just failed dials. Anything that ends a
+// connection short of MinBackoff is followed by the same jittered wait a
+// failed dial gets, whether the dial was refused, the peer hung up, or a
+// write failed. Only a connection that lasted at least MinBackoff, or a close
+// the caller asked for through Reconnect or Shutdown, redials at once and
+// restarts the schedule. Without that, a peer that accepts the handshake and
+// drops it can drive a redial loop across a whole fleet.
 //
 // Run returns nil after Shutdown, ctx.Err() once ctx is done, and h's error
 // when h stopped it. The connection is closed before Run returns. A Client
@@ -158,7 +166,10 @@ func (c *Client) Run(ctx context.Context, h Handler) error {
 		if handlerErr != nil {
 			return handlerErr
 		}
-		if ended.requested || ended.proven {
+		// A close with no failure behind it is one the caller asked for, and
+		// it redials at once. Everything else is a failure, and only a
+		// connection that lasted earns the same treatment.
+		if ended.cause == nil || ended.proven {
 			b.reset()
 			attempt, wait, cause = 0, false, nil
 			continue
@@ -205,7 +216,7 @@ func (c *Client) WriteMessage(messageType int, data []byte) error {
 	// gorilla/websocket keeps the write deadline in a plain field that the
 	// next write reads, so setting it is only safe under writeMu.
 	if err := conn.SetWriteDeadline(time.Now().Add(c.s.writeTimeout)); err != nil {
-		return err
+		return fmt.Errorf("wsclient: setting the write deadline: %w", err)
 	}
 	if err := conn.WriteMessage(messageType, data); err != nil {
 		// gorilla/websocket fails every later write once one has failed, so
@@ -221,7 +232,7 @@ func (c *Client) WriteMessage(messageType int, data []byte) error {
 func (c *Client) WriteJSON(v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {
-		return err
+		return fmt.Errorf("wsclient: encoding the message: %w", err)
 	}
 	return c.WriteMessage(websocket.TextMessage, data)
 }
@@ -275,48 +286,56 @@ func (c *Client) install(ctx context.Context, conn *websocket.Conn) bool {
 // disconnect says how a connection ended, which is what decides whether Run
 // redials at once or waits out a backoff first.
 type disconnect struct {
-	requested bool  // Shutdown, Reconnect or the Run context asked for it
-	proven    bool  // it carried a frame, or stayed up for MinBackoff
-	cause     error // what ended it; nil when the client closed a healthy connection
+	proven bool  // it stayed up for at least MinBackoff
+	cause  error // what ended it; nil only when the caller asked for the close
 }
 
 // serve reads conn into h until the connection ends, and releases it. It
 // returns h's error when h stopped it, and nil otherwise.
 func (c *Client) serve(ctx context.Context, conn *websocket.Conn, h Handler) (disconnect, error) {
 	opened := time.Now()
-	frames := 0
-	// A connection that carried traffic, or lasted as long as the shortest
-	// backoff, has shown the endpoint is worth redialing at once.
-	proven := func() bool { return frames > 0 || time.Since(opened) >= c.s.minBackoff }
+	// A connection that lasted as long as the shortest backoff has shown the
+	// endpoint is worth redialing at once. Counting frames instead would let
+	// a peer that sends one byte and hangs up reset the schedule every time.
+	proven := func() bool { return time.Since(opened) >= c.s.minBackoff }
+
+	// gorilla/websocket answers ping frames inside ReadMessage without
+	// touching the read deadline, so a peer whose keepalive is a ping rather
+	// than a data frame would hit ReadTimeout while talking to us.
+	conn.SetPingHandler(func(appData string) error {
+		c.rearm(ctx, conn)
+		// A pong that cannot go out means the connection is already failing,
+		// and the read that follows will say so; ending the read here would
+		// only lose that reason.
+		_ = conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(closeTimeout))
+		return nil
+	})
 
 	for {
-		if cause, requested := c.armRead(ctx, conn); requested {
+		if cause, ending := c.armRead(ctx, conn); ending {
 			c.release(conn, cause)
-			return disconnect{requested: true, proven: proven(), cause: cause}, nil
+			return disconnect{proven: proven(), cause: cause}, nil
 		}
 		messageType, payload, err := conn.ReadMessage()
 		if err != nil {
-			cause, requested := c.closeRequest(ctx)
+			cause, ending := c.closeRequest(ctx)
 			// Freeing a read produces a timeout and nothing else, so any
 			// other error is the connection's own ending, even if a request
 			// happened to be pending: report that rather than the request.
 			var timeout net.Error
-			if requested && errors.As(err, &timeout) && timeout.Timeout() {
+			if ending && errors.As(err, &timeout) && timeout.Timeout() {
 				err = cause
-			} else {
-				requested = false
 			}
 			c.release(conn, err)
-			return disconnect{requested: requested, proven: proven(), cause: err}, nil
+			return disconnect{proven: proven(), cause: err}, nil
 		}
-		frames++
 		if err := h(ctx, messageType, payload); err != nil {
 			// A handler that honors its context reports the cancellation that
 			// is already stopping Run. That is not a failure of its own, and
 			// Run must still return nil for a Shutdown.
 			if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, ctxErr) {
 				c.release(conn, nil)
-				return disconnect{requested: true, proven: proven()}, nil
+				return disconnect{proven: proven()}, nil
 			}
 			c.release(conn, err)
 			return disconnect{proven: proven(), cause: err}, err
@@ -324,29 +343,45 @@ func (c *Client) serve(ctx context.Context, conn *websocket.Conn, h Handler) (di
 	}
 }
 
-// armRead re-arms conn's read deadline, unless a close has been requested,
-// in which case it reports that and the cause instead. Checking and arming
-// under one lock is what keeps a request from landing between the two and
-// being overwritten by a fresh ReadTimeout.
-func (c *Client) armRead(ctx context.Context, conn *websocket.Conn) (cause error, requested bool) {
+// armRead re-arms conn's read deadline, unless the connection is already
+// ending, in which case it reports that and the cause instead. Checking and
+// arming under one lock is what keeps a request from landing between the two
+// and being overwritten by a fresh ReadTimeout.
+func (c *Client) armRead(ctx context.Context, conn *websocket.Conn) (cause error, ending bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if cause, requested := c.closeRequestLocked(ctx); requested {
+	if cause, ending := c.closeRequestLocked(ctx); ending {
 		return cause, true
 	}
 	_ = conn.SetReadDeadline(time.Now().Add(c.s.readTimeout))
 	return nil, false
 }
 
-// closeRequest reports whether the live connection is ending on request
-// rather than on a failed read, and the cause OnDisconnect should report.
-func (c *Client) closeRequest(ctx context.Context) (cause error, requested bool) {
+// rearm pushes the read deadline out again from the read goroutine, for a
+// keepalive that ReadMessage handled without returning. It takes mu for the
+// same reason armRead does: re-arming over a pending request would park the
+// read for another ReadTimeout and lose the wakeup.
+func (c *Client) rearm(ctx context.Context, conn *websocket.Conn) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ending := c.closeRequestLocked(ctx); ending || c.conn != conn {
+		return
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(c.s.readTimeout))
+}
+
+// closeRequest reports whether the live connection is ending, and the cause
+// OnDisconnect should report for it.
+func (c *Client) closeRequest(ctx context.Context) (cause error, ending bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.closeRequestLocked(ctx)
 }
 
-func (c *Client) closeRequestLocked(ctx context.Context) (cause error, requested bool) {
+// closeRequestLocked reports whether the connection is ending. A nil cause
+// means the caller asked for the close; a non-nil one means something failed,
+// which is what tells Run to pace the redial.
+func (c *Client) closeRequestLocked(ctx context.Context) (cause error, ending bool) {
 	if c.reconnectPending {
 		return c.reconnectCause, true
 	}
@@ -403,20 +438,22 @@ func (c *Client) release(conn *websocket.Conn, cause error) {
 	c.s.onDisconnect(cause)
 }
 
-// closeConn sends a close frame, waits for the peer's reply only when that
+// closeConn sends a close frame, waits briefly for the peer's reply when that
 // frame went out, and closes the socket regardless, so a broken connection
 // cannot leak its fd. Only the goroutine that was reading conn calls it, so
 // the drain is never a second concurrent reader.
 //
-// After a failed read, including one freed early by Reconnect or Shutdown,
-// gorilla/websocket returns the stored error to every later read, so the
-// drain ends at once. The peer still receives the close frame.
+// After a read that already failed, gorilla/websocket returns the stored
+// error to every later read and the drain ends at once. When the close was
+// noticed between reads the connection is still healthy, so the drain waits
+// on the peer, which is why it is bounded by the short drainTimeout rather
+// than by closeTimeout.
 func closeConn(conn *websocket.Conn) {
 	err := conn.WriteControl(websocket.CloseMessage,
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 		time.Now().Add(closeTimeout))
 	if err == nil {
-		_ = conn.SetReadDeadline(time.Now().Add(closeTimeout))
+		_ = conn.SetReadDeadline(time.Now().Add(drainTimeout))
 		for {
 			if _, _, err := conn.NextReader(); err != nil {
 				break

--- a/pkg/wsclient/client.go
+++ b/pkg/wsclient/client.go
@@ -213,11 +213,20 @@ func (c *Client) WriteMessage(messageType int, data []byte) error {
 	if conn == nil {
 		return ErrNotConnected
 	}
-	// gorilla/websocket keeps the write deadline in a plain field that the
-	// next write reads, so setting it is only safe under writeMu.
-	if err := conn.SetWriteDeadline(time.Now().Add(c.s.writeTimeout)); err != nil {
-		return fmt.Errorf("wsclient: setting the write deadline: %w", err)
+	deadline := time.Now().Add(c.s.writeTimeout)
+	// gorilla/websocket applies the write deadline to the socket before each
+	// frame but drops the error, so a net.Conn that refuses write deadlines
+	// would get writes with no bound at all. Ask the socket directly, and give
+	// up a connection that cannot enforce WriteTimeout. The probe is safe from
+	// here: net.Conn methods may be called concurrently.
+	if err := conn.UnderlyingConn().SetWriteDeadline(deadline); err != nil {
+		err = fmt.Errorf("wsclient: arming the write deadline: %w", err)
+		c.abandon(conn, err)
+		return err
 	}
+	// gorilla keeps the deadline in a plain field that it re-applies per
+	// frame; the field is only safe to set under writeMu. It never errors.
+	_ = conn.SetWriteDeadline(deadline)
 	if err := conn.WriteMessage(messageType, data); err != nil {
 		// gorilla/websocket fails every later write once one has failed, so
 		// this connection can no longer send. Replace it now rather than
@@ -303,7 +312,11 @@ func (c *Client) serve(ctx context.Context, conn *websocket.Conn, h Handler) (di
 	// touching the read deadline, so a peer whose keepalive is a ping rather
 	// than a data frame would hit ReadTimeout while talking to us.
 	conn.SetPingHandler(func(appData string) error {
-		c.rearm(ctx, conn)
+		// A conn that stops taking the deadline cannot keep the keepalive
+		// contract; failing the read gives it up the way armRead would.
+		if err := c.rearm(ctx, conn); err != nil {
+			return err
+		}
 		// A pong that cannot go out means the connection is already failing,
 		// and the read that follows will say so; ending the read here would
 		// only lose that reason.
@@ -368,13 +381,16 @@ func (c *Client) armRead(ctx context.Context, conn *websocket.Conn) (cause error
 // keepalive that ReadMessage handled without returning. It takes mu for the
 // same reason armRead does: re-arming over a pending request would park the
 // read for another ReadTimeout and lose the wakeup.
-func (c *Client) rearm(ctx context.Context, conn *websocket.Conn) {
+func (c *Client) rearm(ctx context.Context, conn *websocket.Conn) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if _, ending := c.closeRequestLocked(ctx); ending || c.conn != conn {
-		return
+		return nil
 	}
-	_ = conn.SetReadDeadline(time.Now().Add(c.s.readTimeout))
+	if err := conn.SetReadDeadline(time.Now().Add(c.s.readTimeout)); err != nil {
+		return fmt.Errorf("wsclient: re-arming the read deadline: %w", err)
+	}
+	return nil
 }
 
 // freeRead unblocks a read parked on conn from a goroutine other than the

--- a/pkg/wsclient/client.go
+++ b/pkg/wsclient/client.go
@@ -248,7 +248,7 @@ func (c *Client) Reconnect() {
 	}
 	c.reconnectPending = true
 	c.reconnectCause = nil
-	_ = c.conn.SetReadDeadline(aLongTimeAgo)
+	freeRead(c.conn)
 }
 
 // Shutdown makes Run close the connection and return. It does not wait; Done
@@ -353,7 +353,13 @@ func (c *Client) armRead(ctx context.Context, conn *websocket.Conn) (cause error
 	if cause, ending := c.closeRequestLocked(ctx); ending {
 		return cause, true
 	}
-	_ = conn.SetReadDeadline(time.Now().Add(c.s.readTimeout))
+	if err := conn.SetReadDeadline(time.Now().Add(c.s.readTimeout)); err != nil {
+		// A caller-supplied net.Conn may refuse a deadline. Entering the
+		// read anyway would park it with no timeout, and the interrupts
+		// that free a parked read set the same deadline, so nothing could
+		// end it. Give the connection up instead.
+		return fmt.Errorf("wsclient: arming the read deadline: %w", err), true
+	}
 	return nil, false
 }
 
@@ -368,6 +374,16 @@ func (c *Client) rearm(ctx context.Context, conn *websocket.Conn) {
 		return
 	}
 	_ = conn.SetReadDeadline(time.Now().Add(c.s.readTimeout))
+}
+
+// freeRead unblocks a read parked on conn. Pushing the deadline into the
+// past is the ordinary way, but a caller-supplied net.Conn may refuse a
+// deadline, and then closing the socket is the only thing left that ends the
+// read. Both are safe to call while another goroutine is reading.
+func freeRead(conn *websocket.Conn) {
+	if err := conn.SetReadDeadline(aLongTimeAgo); err != nil {
+		_ = conn.Close()
+	}
 }
 
 // closeRequest reports whether the live connection is ending, and the cause
@@ -410,7 +426,7 @@ func (c *Client) abandon(conn *websocket.Conn, cause error) {
 	}
 	c.reconnectPending = true
 	c.reconnectCause = cause
-	_ = conn.SetReadDeadline(aLongTimeAgo)
+	freeRead(conn)
 }
 
 // interrupt frees a read parked on the live connection. It holds mu, so it
@@ -420,7 +436,7 @@ func (c *Client) interrupt() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.conn != nil {
-		_ = c.conn.SetReadDeadline(aLongTimeAgo)
+		freeRead(c.conn)
 	}
 }
 

--- a/pkg/wsclient/client.go
+++ b/pkg/wsclient/client.go
@@ -188,7 +188,13 @@ func (c *Client) sleep(ctx context.Context, d time.Duration) bool {
 	defer timer.Stop()
 	select {
 	case <-timer.C:
-		return true
+		// A stop that arrives as the timer fires leaves both cases ready,
+		// and a select picks among ready cases at random, so the timer wins
+		// half of those. Ask again rather than send Run off to dial on an
+		// answer that was already there: that dial is a connect to the
+		// backhaul, and a call into a caller's own dial hook, made after the
+		// caller asked the client to stop.
+		return !c.stopping(ctx)
 	case <-ctx.Done():
 		return false
 	case <-c.shutdown:

--- a/pkg/wsclient/client.go
+++ b/pkg/wsclient/client.go
@@ -107,6 +107,11 @@ func New(cfg Config) (*Client, error) {
 // Run returns nil after Shutdown, ctx.Err() once ctx is done, and h's error
 // when h stopped it. The connection is closed before Run returns. A Client
 // runs once: a second call returns ErrAlreadyRunning.
+//
+// It returns that promptly as far as the caller's own code lets it. h, the
+// three hooks and the dialer's dial hook all run on Run's goroutine, so one
+// that blocks holds Run there; a dial hook is the one to watch, because it
+// can be waiting on a socket that does not exist yet and so cannot be freed.
 func (c *Client) Run(ctx context.Context, h Handler) error {
 	if !c.started.CompareAndSwap(false, true) {
 		return ErrAlreadyRunning

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -267,6 +267,34 @@ func readDeadlineProofDialer() *websocket.Dialer {
 	return d
 }
 
+// deadlineRefusingConn accepts a fixed number of read deadlines and then
+// refuses every one, the way a caller-supplied net.Conn that does not
+// implement deadlines behaves.
+type deadlineRefusingConn struct {
+	net.Conn
+	allow *atomic.Int32
+}
+
+func (c deadlineRefusingConn) SetReadDeadline(t time.Time) error {
+	if c.allow.Add(-1) >= 0 {
+		return c.Conn.SetReadDeadline(t)
+	}
+	return errors.New("this conn does not do deadlines")
+}
+
+func deadlineRefusingDialer(allow *atomic.Int32) *websocket.Dialer {
+	d := DefaultDialer()
+	var nd net.Dialer
+	d.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := nd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return deadlineRefusingConn{Conn: conn, allow: allow}, nil
+	}
+	return d
+}
+
 // undeadlinedConn ignores deadlines, so a test can hold a handshake open
 // past the point where the client would otherwise abort it.
 type undeadlinedConn struct{ net.Conn }
@@ -567,6 +595,48 @@ func TestClient_AbortSurvivesTheHandshakeDeadline(t *testing.T) {
 	require.NoError(t, recv(t, result, "Run to return"))
 	assert.Less(t, time.Since(start), handshakeTimeout,
 		"the abort must hold, not be overwritten by the handshake deadline")
+}
+
+// TestClient_GivesUpAConnectionWhoseDeadlineWontArm covers a
+// caller-supplied conn that refuses a read deadline. Reading anyway would
+// park with no timeout, and every way of freeing a parked read sets that
+// same deadline, so Run and Done would block for good.
+func TestClient_GivesUpAConnectionWhoseDeadlineWontArm(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	var allow atomic.Int32 // refuse from the very first arm
+	cfg := testConfig(srv.url)
+	cfg.Dialer = deadlineRefusingDialer(&allow)
+	h.install(&cfg)
+	startClient(t, t.Context(), cfg, discard)
+
+	recv(t, h.connects, "the connect")
+	recv(t, srv.accepted, "the connection")
+	assert.ErrorContains(t, recv(t, h.disconnects, "the disconnect"), "arming the read deadline")
+	recv(t, srv.accepted, "the redial, rather than a read that could never end")
+}
+
+// TestClient_ShutdownClosesAConnThatWontTakeADeadline covers the same
+// refusal arriving later: the read is already parked on a deadline that was
+// accepted once, and the interrupt that should free it is refused. Closing
+// the socket is the only thing left that ends the read.
+func TestClient_ShutdownClosesAConnThatWontTakeADeadline(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	var allow atomic.Int32
+	allow.Store(1) // the first arm succeeds, every interrupt after it fails
+	cfg := testConfig(srv.url)
+	cfg.ReadTimeout = 30 * time.Second // far past the test's patience
+	cfg.Dialer = deadlineRefusingDialer(&allow)
+	h.install(&cfg)
+	c, result := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the connect")
+	recv(t, srv.accepted, "the connection")
+	time.Sleep(50 * time.Millisecond) // let the read park
+
+	c.Shutdown()
+
+	require.NoError(t, recv(t, result, "Run to return"))
 }
 
 // TestClient_ShutdownIsIdempotent is the regression for issue #452's third

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -637,6 +637,52 @@ func TestClient_ShutdownClosesAConnThatWontTakeADeadline(t *testing.T) {
 	c.Shutdown()
 
 	require.NoError(t, recv(t, result, "Run to return"))
+	assert.NoError(t, recv(t, h.disconnects, "the disconnect"),
+		"closing the socket to free the read is still the close Shutdown asked for")
+}
+
+// TestClient_ReconnectOnAConnThatWontTakeADeadlineIsStillARequest pins the
+// cause when freeRead has to close the socket. The read then fails with
+// net.ErrClosed rather than a timeout, and reporting that as the ending
+// would turn the caller's Reconnect into a failure: a wait of MinBackoff,
+// here an hour, where an immediate redial was asked for.
+func TestClient_ReconnectOnAConnThatWontTakeADeadlineIsStillARequest(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	var allow atomic.Int32
+	allow.Store(1) // the first arm succeeds, every interrupt after it fails
+	cfg := testConfig(srv.url)
+	cfg.ReadTimeout = 30 * time.Second
+	cfg.MinBackoff = time.Hour // any paced wait would outlast the test
+	cfg.MaxBackoff = time.Hour
+	cfg.Dialer = deadlineRefusingDialer(&allow)
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the first connect")
+	recv(t, srv.accepted, "the first connection")
+	time.Sleep(50 * time.Millisecond) // let the read park
+
+	c.Reconnect()
+
+	assert.NoError(t, recv(t, h.disconnects, "the disconnect"), "a Reconnect is a request however the read was freed")
+	recv(t, h.connects, "the immediate redial")
+}
+
+// TestClient_DrainGivesUpOnAConnThatWontTakeADeadline covers the close
+// handshake on the same kind of conn. The drain waits for the peer's reply
+// under a deadline; if the conn refuses that deadline and the peer never
+// replies, the drain would wait forever, and Close, which comes after it,
+// would never run.
+func TestClient_DrainGivesUpOnAConnThatWontTakeADeadline(t *testing.T) {
+	srv := newBackhaulServer(t)
+	srv.stallNext.Store(true) // accepts, then never answers the close frame
+	var allow atomic.Int32    // refuse every read deadline
+	cfg := testConfig(srv.url)
+	cfg.Dialer = deadlineRefusingDialer(&allow)
+	startClient(t, t.Context(), cfg, discard)
+
+	recv(t, srv.accepted, "the connection whose deadline will not arm")
+	recv(t, srv.accepted, "the redial, which a drain stuck on a silent peer never reaches")
 }
 
 // TestClient_ShutdownIsIdempotent is the regression for issue #452's third

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -28,13 +28,14 @@ const waitFor = 5 * time.Second
 // backhaulServer is a websocket test double for the Alpacon backhaul. Every
 // connection it accepts is handed to the test over accepted.
 type backhaulServer struct {
-	url           string
-	accepted      chan *serverConn
-	upgrades      atomic.Int32
-	reject        atomic.Int32 // answer this many upgrades with 503 first
-	closeOnAccept atomic.Bool  // accept the upgrade, then close straight away
-	stallNext     atomic.Bool  // never read the next connection, so the client's writes back up
-	done          chan struct{}
+	url            string
+	accepted       chan *serverConn
+	upgrades       atomic.Int32
+	reject         atomic.Int32 // answer this many upgrades with 503 first
+	closeOnAccept  atomic.Bool  // accept the upgrade, then close straight away
+	frameThenClose atomic.Bool  // send one data frame, then close
+	stallNext      atomic.Bool  // never read the next connection, so the client's writes back up
+	done           chan struct{}
 }
 
 // serverConn is the server's end of one accepted connection. The test may
@@ -78,6 +79,13 @@ func newBackhaulServer(t *testing.T) *backhaulServer {
 			return nil
 		})
 		s.accepted <- sc
+		if s.frameThenClose.Load() {
+			_ = conn.WriteMessage(websocket.TextMessage, []byte("hi"))
+			_ = conn.WriteControl(websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseGoingAway, "bye"),
+				time.Now().Add(time.Second))
+			return
+		}
 		if s.closeOnAccept.Load() {
 			_ = conn.WriteControl(websocket.CloseMessage,
 				websocket.FormatCloseMessage(websocket.CloseTryAgainLater, "at capacity"),
@@ -137,7 +145,9 @@ func newHooks() *hooks {
 func (h *hooks) install(cfg *Config) {
 	cfg.OnConnect = func() { h.connects <- struct{}{} }
 	cfg.OnDisconnect = func(err error) { h.disconnects <- err }
-	cfg.OnRetry = func(attempt int, delay time.Duration, err error) { h.retries <- retryEvent{attempt, delay, err} }
+	cfg.OnRetry = func(attempt int, delay time.Duration, err error) {
+		h.retries <- retryEvent{attempt: attempt, delay: delay, err: err}
+	}
 }
 
 // recv waits for one value from ch, failing the test if none arrives.
@@ -508,6 +518,57 @@ func TestClient_ShutdownAbortsAStalledHandshake(t *testing.T) {
 	require.NoError(t, recv(t, result, "Run to return"))
 }
 
+// TestClient_AbortSurvivesTheHandshakeDeadline covers the window the plain
+// abort misses. When the dialer has a handshake timeout, gorilla sets its own
+// deadline on the socket after the dial hook returns, outside this package's
+// wrapper: an abort that landed in between would be silently overwritten and
+// the dial would run to that timeout instead of ending at once.
+func TestClient_AbortSurvivesTheHandshakeDeadline(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	accepted := make(chan net.Conn, 8)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			accepted <- conn // never answer the upgrade
+		}
+	}()
+
+	const handshakeTimeout = 2 * time.Second
+	var c *Client
+	ready := make(chan struct{})
+	cfg := testConfig("ws://" + listener.Addr().String() + "/ws/")
+	cfg.Dialer = &websocket.Dialer{HandshakeTimeout: handshakeTimeout}
+	cfg.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		<-ready
+		var nd net.Dialer
+		conn, err := nd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		// Abort while the socket is already open but before it is handed
+		// back, which is exactly the window gorilla's own deadline lands in.
+		c.Shutdown()
+		<-ctx.Done()
+		time.Sleep(50 * time.Millisecond) // let the abort reach the socket
+		return conn, nil
+	}
+	c, err = New(cfg)
+	require.NoError(t, err)
+	result := make(chan error, 1)
+	go func() { result <- c.Run(t.Context(), discard) }()
+	close(ready)
+
+	start := time.Now()
+	require.NoError(t, recv(t, result, "Run to return"))
+	assert.Less(t, time.Since(start), handshakeTimeout,
+		"the abort must hold, not be overwritten by the handshake deadline")
+}
+
 // TestClient_ShutdownIsIdempotent is the regression for issue #452's third
 // item: pkg/runner's ShutDown closes a channel and panics the second time.
 func TestClient_ShutdownIsIdempotent(t *testing.T) {
@@ -794,6 +855,35 @@ func TestClient_ShutdownFromTheHandler(t *testing.T) {
 	assert.Equal(t, websocket.CloseNormalClosure, recv(t, sc.closeCode, "the close frame"))
 }
 
+// TestClient_ReconnectIsNotHeldUpByASilentPeer bounds the close handshake.
+// When the close is noticed between reads, the connection is still healthy,
+// so the drain really does wait on the peer, and the peer least likely to
+// answer is the draining backhaul that asked for the reconnect. Waiting the
+// full close timeout there would black out every agent in the fleet for it.
+func TestClient_ReconnectIsNotHeldUpByASilentPeer(t *testing.T) {
+	srv := newBackhaulServer(t)
+	srv.stallNext.Store(true) // accepts, then neither reads nor answers the close
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	var c *Client
+	ready := make(chan struct{})
+	c, _ = startClient(t, t.Context(), cfg, func(context.Context, int, []byte) error {
+		<-ready
+		c.Reconnect()
+		return nil
+	})
+	close(ready)
+	recv(t, h.connects, "the first connect")
+	first := recv(t, srv.accepted, "the stalled connection")
+	first.push(t, websocket.TextMessage, `{"query":"reconnect"}`)
+
+	start := time.Now()
+	recv(t, h.connects, "the reconnect")
+	assert.Less(t, time.Since(start), 3*time.Second,
+		"the drain must give up on a peer that never answers the close frame")
+}
+
 func TestClient_ReconnectWithoutAConnectionDoesNothing(t *testing.T) {
 	c, err := New(validConfig())
 	require.NoError(t, err)
@@ -843,6 +933,35 @@ func TestClient_ReadTimeoutTriggersAReconnect(t *testing.T) {
 	recv(t, srv.accepted, "the connection dialed after the timeout")
 }
 
+// TestClient_PingFramesKeepTheConnectionAlive covers a peer whose keepalive
+// is an RFC 6455 ping rather than a data frame. gorilla answers pings inside
+// ReadMessage without returning, so the read deadline is only re-armed once
+// a read completes: without a ping handler of our own, a peer that pings
+// steadily still gets dropped at ReadTimeout.
+func TestClient_PingFramesKeepTheConnectionAlive(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.ReadTimeout = 150 * time.Millisecond
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the connect")
+	sc := recv(t, srv.accepted, "the connection")
+
+	// Pings spanning well over two read timeouts, and no data frame at all.
+	for deadline := time.Now().Add(400 * time.Millisecond); time.Now().Before(deadline); {
+		require.NoError(t, sc.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(time.Second)))
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	select {
+	case err := <-h.disconnects:
+		assert.Fail(t, "a peer that keeps pinging must not hit the read timeout", "disconnected with %v", err)
+	default:
+	}
+	assert.True(t, c.Connected())
+}
+
 func TestClient_ReadLimitDropsAnOversizedFrame(t *testing.T) {
 	srv := newBackhaulServer(t)
 	h := newHooks()
@@ -880,11 +999,12 @@ func TestClient_RetriesARejectedHandshakeThenConnects(t *testing.T) {
 	recv(t, h.connects, "the connect after the rejections")
 	sc := recv(t, srv.accepted, "the connection")
 
-	// A connection that carries a frame has proved itself, which resets the
-	// schedule: after the next drop, counting and waiting both start over
-	// instead of continuing from where they stopped.
-	sc.push(t, websocket.TextMessage, "proof")
-	recv(t, delivered, "the frame that proves the connection")
+	// A connection that lasts at least MinBackoff has proved itself, which
+	// resets the schedule: after the next drop, counting and waiting both
+	// start over instead of continuing from where they stopped.
+	sc.push(t, websocket.TextMessage, "traffic")
+	recv(t, delivered, "the frame")
+	time.Sleep(cfg.MinBackoff + 10*time.Millisecond) // age it past the proof window
 	srv.reject.Store(1)
 	require.NoError(t, sc.conn.UnderlyingConn().Close())
 	require.Error(t, recv(t, h.disconnects, "the drop"))
@@ -907,7 +1027,7 @@ func TestClient_PacesRedialsAfterAnUnprovenConnection(t *testing.T) {
 	cfg := testConfig(srv.url)
 	cfg.MinBackoff = 200 * time.Millisecond
 	cfg.MaxBackoff = time.Minute
-	cfg.Rand = func() float64 { return 0.5 } // factor 1.0, so waits are the base
+	cfg.Rand = func() float64 { return 0 } // factor 1.0, so waits are the base
 	h.install(&cfg)
 	startClient(t, t.Context(), cfg, discard)
 
@@ -922,25 +1042,20 @@ func TestClient_PacesRedialsAfterAnUnprovenConnection(t *testing.T) {
 }
 
 // TestClient_RedialsAtOnceAfterAProvenConnection keeps the other half of the
-// rule honest: pacing must not slow down recovery for a connection that was
+// rule honest: pacing must not slow recovery for a connection that was
 // working, which is every ordinary drop.
 func TestClient_RedialsAtOnceAfterAProvenConnection(t *testing.T) {
 	srv := newBackhaulServer(t)
 	h := newHooks()
 	cfg := testConfig(srv.url)
-	cfg.MinBackoff = time.Hour // any wait at all would hang the test
-	cfg.MaxBackoff = time.Hour
+	cfg.MinBackoff = 50 * time.Millisecond
+	cfg.MaxBackoff = 50 * time.Millisecond
 	h.install(&cfg)
-	delivered := make(chan struct{}, 1)
-	startClient(t, t.Context(), cfg, func(context.Context, int, []byte) error {
-		delivered <- struct{}{}
-		return nil
-	})
+	startClient(t, t.Context(), cfg, discard)
 	recv(t, h.connects, "the first connect")
 	first := recv(t, srv.accepted, "the first connection")
-	first.push(t, websocket.TextMessage, "proof")
-	recv(t, delivered, "the frame that proves the connection")
 
+	time.Sleep(cfg.MinBackoff + 20*time.Millisecond) // age it past the proof window
 	require.NoError(t, first.conn.UnderlyingConn().Close())
 
 	require.Error(t, recv(t, h.disconnects, "the drop"))
@@ -952,11 +1067,65 @@ func TestClient_RedialsAtOnceAfterAProvenConnection(t *testing.T) {
 	}
 }
 
+// TestClient_PacesARedialAfterAFailedWrite is the regression for a write
+// failure jumping the queue. A failed write asks for the connection to be
+// replaced, the same as Reconnect does, but it is a failure: routing it
+// through the caller-requested path reset the backoff and redialed with no
+// wait at all, which is a storm against a backhaul whose write side is sick.
+func TestClient_PacesARedialAfterAFailedWrite(t *testing.T) {
+	srv := newBackhaulServer(t)
+	srv.stallNext.Store(true)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.WriteTimeout = 100 * time.Millisecond
+	cfg.MinBackoff = 300 * time.Millisecond
+	cfg.MaxBackoff = time.Minute
+	cfg.Rand = func() float64 { return 0 } // factor 1.0, so the wait is the base
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the first connect")
+	recv(t, srv.accepted, "the stalled connection")
+
+	require.Error(t, c.WriteMessage(websocket.BinaryMessage, make([]byte, 64<<20)))
+
+	require.Error(t, recv(t, h.disconnects, "the disconnect"))
+	r := recv(t, h.retries, "the wait before the redial")
+	assert.Equal(t, 1, r.attempt)
+	assert.Equal(t, cfg.MinBackoff, r.delay, "a failed write must be paced like any other failure")
+}
+
+// TestClient_AFrameDoesNotProveAConnection is the regression for the rule
+// that decides pacing. Counting frames as proof let a peer send one byte,
+// hang up, and have the backoff reset every round: a redial loop bounded by
+// nothing.
+func TestClient_AFrameDoesNotProveAConnection(t *testing.T) {
+	srv := newBackhaulServer(t)
+	srv.frameThenClose.Store(true)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.MinBackoff = 200 * time.Millisecond
+	cfg.MaxBackoff = time.Minute
+	cfg.Rand = func() float64 { return 0 }
+	h.install(&cfg)
+	delivered := make(chan struct{}, 8)
+	startClient(t, t.Context(), cfg, func(context.Context, int, []byte) error {
+		delivered <- struct{}{}
+		return nil
+	})
+
+	recv(t, h.connects, "the connect")
+	recv(t, delivered, "the one frame the peer sends before hanging up")
+	require.Error(t, recv(t, h.disconnects, "the close that follows it"))
+	r := recv(t, h.retries, "the wait before the redial")
+	assert.Equal(t, cfg.MinBackoff, r.delay, "a frame on a short-lived connection is not proof")
+	assert.Less(t, srv.upgrades.Load(), int32(10), "a paced loop cannot have run away")
+}
+
 // TestClient_ConcurrentWritesDuringReconnect keeps writers busy across a
 // forced reconnect, so writes land on the old connection, in the gap, and on
 // the new one. gorilla/websocket panics on two concurrent writers and a
-// write racing the close corrupts frames, so passing without -race already
-// shows writes are serialized; under -race it also covers the conn field.
+// write racing the close corrupts frames, so this catches a lost write
+// mutex without the race detector, which is what this repository's CI runs.
 func TestClient_ConcurrentWritesDuringReconnect(t *testing.T) {
 	const writers = 8
 	srv := newBackhaulServer(t)

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -1371,6 +1371,13 @@ func TestClient_PacesRedialsAfterAnUnprovenConnection(t *testing.T) {
 		require.Error(t, recv(t, h.disconnects, "the close the server sent"))
 		r := recv(t, h.retries, "the wait before the redial")
 		assert.Equal(t, want, r.delay, "an unproven connection must back off, and keep doubling")
+		// OnRetry fires before the wait, so this measures the wait itself.
+		// Asserting only on the reported delay would pass for a loop that
+		// announced a wait and then redialed immediately.
+		reported, upgrades := time.Now(), srv.upgrades.Load()
+		require.Eventually(t, func() bool { return srv.upgrades.Load() > upgrades },
+			waitFor, time.Millisecond, "the redial never came")
+		assert.GreaterOrEqual(t, time.Since(reported), want*9/10, "the redial must wait out the delay it reported")
 	}
 	assert.Less(t, srv.upgrades.Load(), int32(10), "a paced loop cannot have run away")
 }
@@ -1426,6 +1433,9 @@ func TestClient_PacesARedialAfterAFailedWrite(t *testing.T) {
 	r := recv(t, h.retries, "the wait before the redial")
 	assert.Equal(t, 1, r.attempt)
 	assert.Equal(t, cfg.MinBackoff, r.delay, "a failed write must be paced like any other failure")
+	reported := time.Now()
+	recv(t, srv.accepted, "the redial")
+	assert.GreaterOrEqual(t, time.Since(reported), cfg.MinBackoff*9/10, "the redial must wait out the delay it reported")
 }
 
 // TestClient_AFrameDoesNotProveAConnection is the regression for the rule

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -1022,6 +1022,36 @@ func TestClient_UptimeExcludesTheTimeSpentClosing(t *testing.T) {
 	assert.Equal(t, cfg.MinBackoff, r.delay)
 }
 
+// TestClient_ABackoffWaitPrefersAStopToItsTimer covers the tie the wait can
+// end in. A Shutdown or a done ctx that arrives as the backoff timer fires
+// leaves two of the select's cases ready at once, and a select picks among
+// those at random, so the timer carried it half the time and Run went on to
+// dial. That dial is a connect to the backhaul and a call into a caller's
+// own dial hook, both made after the caller asked the client to stop, and
+// the loop cannot catch it: its own check runs before the wait, not after.
+func TestClient_ABackoffWaitPrefersAStopToItsTimer(t *testing.T) {
+	for name, stop := range map[string]func(*Client, context.CancelFunc){
+		"Shutdown": func(c *Client, _ context.CancelFunc) { c.Shutdown() },
+		"done ctx": func(_ *Client, cancel context.CancelFunc) { cancel() },
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Repeatedly, because a select that picks at random passes any
+			// single run half the time.
+			for range 200 {
+				c, err := New(testConfig("ws://backhaul.example.com/ws/"))
+				require.NoError(t, err)
+				ctx, cancel := context.WithCancel(t.Context())
+				stop(c, cancel)
+				// A zero delay makes the timer ready too, which is the tie a
+				// real Shutdown lands in only when it arrives on the instant.
+				require.False(t, c.sleep(ctx, 0),
+					"a wait that ends with a stop already available must not send Run off to dial")
+				cancel()
+			}
+		})
+	}
+}
+
 // TestClient_ShutdownIsIdempotent is the regression for issue #452's third
 // item: pkg/runner's ShutDown closes a channel and panics the second time.
 func TestClient_ShutdownIsIdempotent(t *testing.T) {

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -1,0 +1,1016 @@
+package wsclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alpacax/alpamon/v2/pkg/version"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests talk to a real httptest server, so they run on the real clock:
+// a synctest bubble does not count a socket wait as blocked. The backoff
+// schedule itself is timed under a fake clock in reconnect_test.go.
+
+const waitFor = 5 * time.Second
+
+// backhaulServer is a websocket test double for the Alpacon backhaul. Every
+// connection it accepts is handed to the test over accepted.
+type backhaulServer struct {
+	url           string
+	accepted      chan *serverConn
+	upgrades      atomic.Int32
+	reject        atomic.Int32 // answer this many upgrades with 503 first
+	closeOnAccept atomic.Bool  // accept the upgrade, then close straight away
+	stallNext     atomic.Bool  // never read the next connection, so the client's writes back up
+	done          chan struct{}
+}
+
+// serverConn is the server's end of one accepted connection. The test may
+// write to conn from one goroutine; the server's own goroutine does the reading.
+type serverConn struct {
+	conn      *websocket.Conn
+	header    http.Header
+	frames    atomic.Int64 // every frame read, including any received had no room for
+	received  chan []byte  // the first frames read; never blocks the server's reads
+	closeCode chan int
+}
+
+func newBackhaulServer(t *testing.T) *backhaulServer {
+	t.Helper()
+	s := &backhaulServer{accepted: make(chan *serverConn, 1024), done: make(chan struct{})}
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.reject.Load() > 0 {
+			s.reject.Add(-1)
+			http.Error(w, "backhaul restarting", http.StatusServiceUnavailable)
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		s.upgrades.Add(1)
+
+		sc := &serverConn{
+			conn:      conn,
+			header:    r.Header.Clone(),
+			received:  make(chan []byte, 1024),
+			closeCode: make(chan int, 1),
+		}
+		conn.SetCloseHandler(func(code int, _ string) error {
+			sc.closeCode <- code
+			// SetCloseHandler replaces gorilla's default reply; answer so the client's drain ends at once.
+			_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(code, ""), time.Now().Add(time.Second))
+			return nil
+		})
+		s.accepted <- sc
+		if s.closeOnAccept.Load() {
+			_ = conn.WriteControl(websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseTryAgainLater, "at capacity"),
+				time.Now().Add(time.Second))
+			return
+		}
+		if s.stallNext.CompareAndSwap(true, false) {
+			<-s.done
+			return
+		}
+
+		for {
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			sc.frames.Add(1)
+			select {
+			case sc.received <- msg:
+			default: // a flooding test only samples; stalling here would stall the client's writes
+			}
+		}
+	}))
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() { close(s.done) }) // runs before ts.Close, releasing stalled handlers
+
+	s.url = strings.Replace(ts.URL, "http", "ws", 1)
+	return s
+}
+
+func (sc *serverConn) push(t *testing.T, messageType int, payload string) {
+	t.Helper()
+	require.NoError(t, sc.conn.WriteMessage(messageType, []byte(payload)))
+}
+
+// hooks records what a client reports through its Config hooks.
+type hooks struct {
+	connects    chan struct{}
+	disconnects chan error
+	retries     chan retryEvent
+}
+
+type retryEvent struct {
+	attempt int
+	delay   time.Duration
+	err     error
+}
+
+func newHooks() *hooks {
+	return &hooks{
+		connects:    make(chan struct{}, 1024),
+		disconnects: make(chan error, 1024),
+		retries:     make(chan retryEvent, 1024),
+	}
+}
+
+func (h *hooks) install(cfg *Config) {
+	cfg.OnConnect = func() { h.connects <- struct{}{} }
+	cfg.OnDisconnect = func(err error) { h.disconnects <- err }
+	cfg.OnRetry = func(attempt int, delay time.Duration, err error) { h.retries <- retryEvent{attempt, delay, err} }
+}
+
+// recv waits for one value from ch, failing the test if none arrives.
+func recv[T any](t *testing.T, ch <-chan T, what string) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(waitFor):
+		t.Fatal("timed out waiting for " + what)
+		var zero T
+		return zero
+	}
+}
+
+func testConfig(url string) Config {
+	return Config{
+		URL:        url,
+		ID:         "srv-1",
+		Key:        "secret",
+		Origin:     "https://alpacon.example.com",
+		MinBackoff: 10 * time.Millisecond,
+		MaxBackoff: 50 * time.Millisecond,
+	}
+}
+
+func discard(context.Context, int, []byte) error { return nil }
+
+// startClient builds a client from cfg and runs it with h, returning the
+// channel Run's result arrives on. Cleanup shuts the client down and waits.
+func startClient(t *testing.T, ctx context.Context, cfg Config, h Handler) (*Client, <-chan error) {
+	t.Helper()
+	c, err := New(cfg)
+	require.NoError(t, err)
+
+	result := make(chan error, 1)
+	go func() { result <- c.Run(ctx, h) }()
+	t.Cleanup(func() {
+		c.Shutdown()
+		select {
+		case <-c.Done():
+		case <-time.After(waitFor):
+			t.Fatal("Run did not return after Shutdown")
+		}
+	})
+	return c, result
+}
+
+// closeTrackingDialer records whether the socket under each connection it
+// opens was closed, which is how a leaked fd shows up in a test.
+type closeTrackingDialer struct {
+	mu     sync.Mutex
+	closed []*atomic.Bool
+}
+
+func (d *closeTrackingDialer) dialer() *websocket.Dialer {
+	ws := DefaultDialer()
+	var nd net.Dialer
+	ws.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := nd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		flag := &atomic.Bool{}
+		d.mu.Lock()
+		d.closed = append(d.closed, flag)
+		d.mu.Unlock()
+		return closeTrackingConn{Conn: conn, closed: flag}, nil
+	}
+	return ws
+}
+
+func (d *closeTrackingDialer) allClosed() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, flag := range d.closed {
+		if !flag.Load() {
+			return false
+		}
+	}
+	return len(d.closed) > 0
+}
+
+type closeTrackingConn struct {
+	net.Conn
+	closed *atomic.Bool
+}
+
+func (c closeTrackingConn) Close() error {
+	c.closed.Store(true)
+	return c.Conn.Close()
+}
+
+// readDeadlineProofConn ignores read deadlines, so a test can keep a read
+// parked through the interrupt a pending request would otherwise use to free
+// it, and decide for itself what the read returns.
+type readDeadlineProofConn struct{ net.Conn }
+
+func (readDeadlineProofConn) SetReadDeadline(time.Time) error { return nil }
+
+// Only the first connection is made deadline-proof: a later one has to stay
+// interruptible, or Shutdown could never free the read loop parked on it.
+func readDeadlineProofDialer() *websocket.Dialer {
+	d := DefaultDialer()
+	var nd net.Dialer
+	var used atomic.Bool
+	d.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := nd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		if used.CompareAndSwap(false, true) {
+			return readDeadlineProofConn{conn}, nil
+		}
+		return conn, nil
+	}
+	return d
+}
+
+// undeadlinedConn ignores deadlines, so a test can hold a handshake open
+// past the point where the client would otherwise abort it.
+type undeadlinedConn struct{ net.Conn }
+
+func (undeadlinedConn) SetDeadline(time.Time) error { return nil }
+
+// countingConn counts Read calls on the client's socket, so a test can tell
+// when the read loop has actually entered a read.
+type countingConn struct {
+	net.Conn
+	reads *atomic.Int64
+}
+
+func (c countingConn) Read(p []byte) (int, error) {
+	c.reads.Add(1)
+	return c.Conn.Read(p)
+}
+
+func countingDialer(reads *atomic.Int64) *websocket.Dialer {
+	d := DefaultDialer()
+	var nd net.Dialer
+	d.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := nd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return countingConn{Conn: conn, reads: reads}, nil
+	}
+	return d
+}
+
+// parkedClient starts a client and returns once Run is inside a read on its
+// first connection, with the default 35-minute read deadline armed. Anything
+// that ends Run from there has to free that read.
+func parkedClient(t *testing.T, ctx context.Context, srv *backhaulServer, h *hooks) (*Client, <-chan error, *serverConn) {
+	t.Helper()
+	var reads, readsAtConnect atomic.Int64
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	cfg.Dialer = countingDialer(&reads)
+	onConnect := cfg.OnConnect
+	cfg.OnConnect = func() {
+		// OnConnect runs on the Run goroutine after the handshake's last read
+		// and before the first ReadMessage, so this is the handshake's count.
+		readsAtConnect.Store(reads.Load())
+		onConnect()
+	}
+
+	c, result := startClient(t, ctx, cfg, discard)
+	recv(t, h.connects, "the first connect")
+	sc := recv(t, srv.accepted, "the first connection")
+	require.Eventually(t, func() bool { return reads.Load() > readsAtConnect.Load() },
+		waitFor, time.Millisecond, "Run never entered its read")
+	return c, result, sc
+}
+
+func TestClient_SendsTheHandshakeHeaders(t *testing.T) {
+	srv := newBackhaulServer(t)
+	startClient(t, t.Context(), testConfig(srv.url), discard)
+
+	sc := recv(t, srv.accepted, "a connection")
+	assert.Equal(t, `id="srv-1", key="secret"`, sc.header.Get("Authorization"))
+	assert.Equal(t, "https://alpacon.example.com", sc.header.Get("Origin"))
+	assert.Equal(t, "alpamon/"+version.Version, sc.header.Get("User-Agent"))
+}
+
+func TestClient_DeliversFramesInOrder(t *testing.T) {
+	type frame struct {
+		messageType int
+		payload     string
+	}
+	srv := newBackhaulServer(t)
+	got := make(chan frame, 8)
+	startClient(t, t.Context(), testConfig(srv.url), func(_ context.Context, mt int, p []byte) error {
+		got <- frame{mt, string(p)}
+		return nil
+	})
+
+	sc := recv(t, srv.accepted, "a connection")
+	sc.push(t, websocket.TextMessage, "one")
+	sc.push(t, websocket.TextMessage, "two")
+	sc.push(t, websocket.BinaryMessage, "three")
+
+	assert.Equal(t, frame{websocket.TextMessage, "one"}, recv(t, got, "the first frame"))
+	assert.Equal(t, frame{websocket.TextMessage, "two"}, recv(t, got, "the second frame"))
+	assert.Equal(t, frame{websocket.BinaryMessage, "three"}, recv(t, got, "the third frame"))
+}
+
+func TestClient_WriteJSONReachesTheServer(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, discard)
+
+	recv(t, h.connects, "the connect")
+	sc := recv(t, srv.accepted, "a connection")
+	require.NoError(t, c.WriteJSON(map[string]string{"query": "ping"}))
+	assert.JSONEq(t, `{"query":"ping"}`, string(recv(t, sc.received, "the frame")))
+}
+
+func TestClient_WriteWithoutAConnection(t *testing.T) {
+	c, err := New(validConfig())
+	require.NoError(t, err)
+
+	assert.ErrorIs(t, c.WriteMessage(websocket.TextMessage, []byte("x")), ErrNotConnected)
+	assert.ErrorIs(t, c.WriteJSON(map[string]string{"query": "ping"}), ErrNotConnected)
+	assert.False(t, c.Connected())
+}
+
+func TestClient_WriteJSONReportsAnEncodingError(t *testing.T) {
+	c, err := New(validConfig())
+	require.NoError(t, err)
+
+	var unsupported *json.UnsupportedTypeError
+	assert.ErrorAs(t, c.WriteJSON(make(chan int)), &unsupported, "an encoding error must come back before any frame is attempted")
+}
+
+// TestClient_WriteMessageRejectsControlFrames keeps the lifecycle with the
+// Client: gorilla/websocket would send a close frame handed to WriteMessage,
+// and every later write would fail while the read loop still counted the
+// connection as live.
+func TestClient_WriteMessageRejectsControlFrames(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the connect")
+	sc := recv(t, srv.accepted, "the connection")
+
+	for _, mt := range []int{websocket.CloseMessage, websocket.PingMessage, websocket.PongMessage, 99} {
+		assert.ErrorContains(t, c.WriteMessage(mt, nil), "data frames only", "message type %d", mt)
+	}
+
+	require.NoError(t, c.WriteJSON(map[string]string{"query": "ping"}), "the connection must be untouched")
+	assert.JSONEq(t, `{"query":"ping"}`, string(recv(t, sc.received, "the frame")))
+	select {
+	case code := <-sc.closeCode:
+		assert.Fail(t, "a rejected control frame reached the server", "close code %d", code)
+	default:
+	}
+}
+
+// TestClient_FailedWriteReplacesTheConnection covers a peer that stops
+// reading. The write must give up at WriteTimeout instead of holding the
+// write lock forever, and because a failed write leaves the connection unable
+// to send, Run must replace it straight away, not 35 minutes later when the
+// read side times out.
+func TestClient_FailedWriteReplacesTheConnection(t *testing.T) {
+	srv := newBackhaulServer(t)
+	srv.stallNext.Store(true)
+	h := newHooks()
+	var tracker closeTrackingDialer
+	cfg := testConfig(srv.url)
+	cfg.WriteTimeout = 200 * time.Millisecond
+	cfg.Dialer = tracker.dialer()
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the first connect")
+	recv(t, srv.accepted, "the stalled connection")
+
+	// Far more than the loopback socket buffers hold, so the write has to block.
+	err := c.WriteMessage(websocket.BinaryMessage, make([]byte, 64<<20))
+
+	var netErr net.Error
+	require.ErrorAs(t, err, &netErr, "a write to a peer that stopped reading must time out, not hang")
+	assert.True(t, netErr.Timeout())
+	assert.ErrorIs(t, recv(t, h.disconnects, "the disconnect"), err, "the failed write is what ended the connection")
+	recv(t, h.connects, "the replacement connect")
+	sc := recv(t, srv.accepted, "the replacement connection")
+	require.NoError(t, c.WriteJSON(map[string]string{"query": "ping"}))
+	assert.JSONEq(t, `{"query":"ping"}`, string(recv(t, sc.received, "a frame on the replacement")))
+
+	// The abandoned connection could not send its close frame, since its
+	// write side was already dead. Its socket must be closed all the same,
+	// or every failed write leaks an fd.
+	c.Shutdown()
+	recv(t, c.Done(), "Run to return")
+	assert.True(t, tracker.allClosed(), "every socket the client opened must be closed")
+}
+
+// TestClient_ShutdownFreesAParkedRead is the regression for issue #452's
+// first two items. pkg/runner's client closes the connection from whatever
+// goroutine calls Close, racing the read loop for the conn field and for the
+// socket itself. Here Shutdown comes from the test goroutine while Run sits in
+// a read with 35 minutes left on its deadline, and it must end Run at once and
+// cleanly.
+func TestClient_ShutdownFreesAParkedRead(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	c, result, sc := parkedClient(t, t.Context(), srv, h)
+	require.True(t, c.Connected())
+
+	c.Shutdown()
+
+	require.NoError(t, recv(t, result, "Run to return"), "Run returns nil after Shutdown")
+	assert.NoError(t, recv(t, h.disconnects, "the disconnect"), "a requested close reports no error")
+	assert.Equal(t, websocket.CloseNormalClosure, recv(t, sc.closeCode, "the close frame"))
+	assert.False(t, c.Connected())
+	select {
+	case <-c.Done():
+	default:
+		assert.Fail(t, "Done must be closed once Run has returned")
+	}
+}
+
+func TestClient_ContextCancelFreesAParkedRead(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	ctx, cancel := context.WithCancel(t.Context())
+	_, result, sc := parkedClient(t, ctx, srv, h)
+
+	cancel()
+
+	require.ErrorIs(t, recv(t, result, "Run to return"), context.Canceled)
+	assert.NoError(t, recv(t, h.disconnects, "the disconnect"), "a requested close reports no error")
+	assert.Equal(t, websocket.CloseNormalClosure, recv(t, sc.closeCode, "the close frame"))
+}
+
+// TestClient_ShutdownAbortsAStalledHandshake covers a peer that completes the
+// TCP connect and then never answers the upgrade. gorilla/websocket stops
+// watching the context at that point, so only HandshakeTimeout would end the
+// wait, and this dialer has none: without an abort of its own the client
+// would hang here forever, and a pod would be killed mid-shutdown.
+func TestClient_ShutdownAbortsAStalledHandshake(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	accepted := make(chan net.Conn, 8)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			accepted <- conn // never answer the upgrade
+		}
+	}()
+
+	cfg := testConfig("ws://" + listener.Addr().String() + "/ws/")
+	cfg.Dialer = &websocket.Dialer{} // no HandshakeTimeout, so nothing else can end the wait
+	c, result := startClient(t, t.Context(), cfg, discard)
+	stalled := recv(t, accepted, "the connection the client opened")
+	t.Cleanup(func() { _ = stalled.Close() })
+
+	c.Shutdown()
+
+	require.NoError(t, recv(t, result, "Run to return"))
+}
+
+// TestClient_ShutdownIsIdempotent is the regression for issue #452's third
+// item: pkg/runner's ShutDown closes a channel and panics the second time.
+func TestClient_ShutdownIsIdempotent(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	c, result, _ := parkedClient(t, t.Context(), srv, h)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(c.Shutdown)
+	}
+	wg.Wait()
+
+	require.NoError(t, recv(t, result, "Run to return"))
+	assert.NotPanics(t, c.Shutdown, "Shutdown after Run returned")
+}
+
+func TestClient_ShutdownBeforeRunNeverDials(t *testing.T) {
+	srv := newBackhaulServer(t)
+	var dials atomic.Int32
+	cfg := testConfig(srv.url)
+	cfg.Dialer = DefaultDialer()
+	cfg.Dialer.NetDialContext = func(context.Context, string, string) (net.Conn, error) {
+		dials.Add(1)
+		return nil, errors.New("dialed after Shutdown")
+	}
+	c, err := New(cfg)
+	require.NoError(t, err)
+
+	c.Shutdown()
+	require.NoError(t, c.Run(t.Context(), discard))
+
+	assert.Zero(t, dials.Load(), "a client shut down before Run must not dial")
+}
+
+// TestClient_ShutdownDuringADialNeverConnects holds a dial open across
+// Shutdown and then lets it succeed. The connection it produces must be
+// closed unannounced: an OnConnect after Shutdown would flip a caller's
+// connected gauge back to 1 for a connection that is already going away.
+func TestClient_ShutdownDuringADialNeverConnects(t *testing.T) {
+	srv := newBackhaulServer(t)
+	dialing := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	var connects, disconnects atomic.Int32
+	cfg := testConfig(srv.url)
+	cfg.OnConnect = func() { connects.Add(1) }
+	cfg.OnDisconnect = func(error) { disconnects.Add(1) }
+	cfg.Dialer = DefaultDialer()
+	cfg.Dialer.NetDialContext = func(_ context.Context, network, addr string) (net.Conn, error) {
+		once.Do(func() { close(dialing) })
+		<-release
+		// Ignore the cancelled dial context, and refuse the deadline the
+		// abort would force, so the handshake always completes: this is the
+		// case where the connection is already established when Shutdown
+		// lands, which is the one install has to refuse.
+		var nd net.Dialer
+		conn, err := nd.DialContext(context.Background(), network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return undeadlinedConn{conn}, nil
+	}
+	c, err := New(cfg)
+	require.NoError(t, err)
+	result := make(chan error, 1)
+	go func() { result <- c.Run(t.Context(), discard) }()
+
+	recv(t, dialing, "the dial to start")
+	c.Shutdown()
+	close(release)
+
+	require.NoError(t, recv(t, result, "Run to return"))
+	assert.Zero(t, connects.Load(), "a connection that completes after Shutdown must not be announced")
+	assert.Zero(t, disconnects.Load(), "and it must not be mourned either: OnDisconnect belongs to an announced connection")
+	assert.False(t, c.Connected())
+	sc := recv(t, srv.accepted, "the connection the held dial produced")
+	assert.Equal(t, websocket.CloseNormalClosure, recv(t, sc.closeCode, "its close frame"), "it must still be closed cleanly")
+}
+
+func TestClient_RunIsSingleUse(t *testing.T) {
+	c, err := New(validConfig())
+	require.NoError(t, err)
+	c.Shutdown()
+
+	require.NoError(t, c.Run(t.Context(), discard))
+	assert.ErrorIs(t, c.Run(t.Context(), discard), ErrAlreadyRunning)
+}
+
+func TestClient_RunRejectsANilHandler(t *testing.T) {
+	c, err := New(validConfig())
+	require.NoError(t, err)
+
+	assert.ErrorContains(t, c.Run(t.Context(), nil), "non-nil Handler")
+	select {
+	case <-c.Done():
+	default:
+		assert.Fail(t, "Done must close even when Run refuses to start")
+	}
+}
+
+func TestClient_HandlerErrorStopsRun(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	errStop := errors.New("unparseable command")
+	_, result := startClient(t, t.Context(), cfg, func(context.Context, int, []byte) error { return errStop })
+
+	sc := recv(t, srv.accepted, "a connection")
+	sc.push(t, websocket.TextMessage, "garbage")
+
+	require.ErrorIs(t, recv(t, result, "Run to return"), errStop)
+	assert.ErrorIs(t, recv(t, h.disconnects, "the disconnect"), errStop, "OnDisconnect names what ended the connection")
+	assert.Equal(t, websocket.CloseNormalClosure, recv(t, sc.closeCode, "the close frame"))
+}
+
+func TestClient_ReconnectDialsAFreshConnection(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	got := make(chan string, 8)
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, func(_ context.Context, _ int, p []byte) error {
+		got <- string(p)
+		return nil
+	})
+	recv(t, h.connects, "the first connect")
+	first := recv(t, srv.accepted, "the first connection")
+
+	c.Reconnect()
+
+	assert.Equal(t, websocket.CloseNormalClosure, recv(t, first.closeCode, "the close frame on the old connection"))
+	assert.NoError(t, recv(t, h.disconnects, "the disconnect"), "a requested reconnect reports no error")
+	recv(t, h.connects, "the second connect")
+	second := recv(t, srv.accepted, "the second connection")
+	second.push(t, websocket.TextMessage, "after reconnect")
+	assert.Equal(t, "after reconnect", recv(t, got, "a frame on the new connection"))
+}
+
+// TestClient_ShutdownCancelsTheHandlerContext covers the handler contract in
+// both directions: Shutdown has to release a handler blocked on its context,
+// and a handler that reports that cancellation is not failing. Run must still
+// return nil, and the disconnect is a requested one, not an error.
+func TestClient_ShutdownCancelsTheHandlerContext(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	started := make(chan struct{}, 1)
+	c, result := startClient(t, t.Context(), cfg, func(ctx context.Context, _ int, _ []byte) error {
+		started <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	recv(t, h.connects, "the connect")
+	recv(t, srv.accepted, "the connection").push(t, websocket.TextMessage, "work")
+	recv(t, started, "the handler to block on its context")
+
+	c.Shutdown()
+
+	require.NoError(t, recv(t, result, "Run to return"),
+		"a handler reporting the cancellation that is already stopping Run has not failed")
+	assert.NoError(t, recv(t, h.disconnects, "the disconnect"))
+}
+
+func TestClient_ContextCancelReachesTheHandler(t *testing.T) {
+	srv := newBackhaulServer(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	started := make(chan struct{}, 1)
+	_, result := startClient(t, ctx, testConfig(srv.url), func(ctx context.Context, _ int, _ []byte) error {
+		started <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	recv(t, srv.accepted, "the connection").push(t, websocket.TextMessage, "work")
+	recv(t, started, "the handler to block on its context")
+
+	cancel()
+
+	assert.ErrorIs(t, recv(t, result, "Run to return"), context.Canceled)
+}
+
+// TestClient_ReportsThePeersCloseCode keeps the disconnect cause honest: a
+// close code the server chose must reach OnDisconnect, not be flattened into
+// the nil of a requested close.
+func TestClient_ReportsThePeersCloseCode(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the connect")
+	sc := recv(t, srv.accepted, "the connection")
+
+	require.NoError(t, sc.conn.WriteControl(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "revoked"),
+		time.Now().Add(time.Second)))
+
+	err := recv(t, h.disconnects, "the disconnect")
+	var closeErr *websocket.CloseError
+	require.ErrorAs(t, err, &closeErr)
+	assert.Equal(t, websocket.ClosePolicyViolation, closeErr.Code)
+	assert.Equal(t, "revoked", closeErr.Text)
+}
+
+// TestClient_PrefersThePeersReasonOverAPendingRequest pins which of two
+// simultaneous endings gets reported. A write fails, which marks the
+// connection for replacement, and only then does the peer's close arrive.
+// The close carries the reason an operator needs, so it must win: reporting
+// the write error instead would hide "revoked" behind "i/o timeout".
+func TestClient_PrefersThePeersReasonOverAPendingRequest(t *testing.T) {
+	srv := newBackhaulServer(t)
+	srv.stallNext.Store(true)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.WriteTimeout = 200 * time.Millisecond
+	cfg.Dialer = readDeadlineProofDialer()
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the connect")
+	sc := recv(t, srv.accepted, "the stalled connection")
+
+	// The peer has stopped reading, so this write times out and marks the
+	// connection for replacement while the read stays parked.
+	require.Error(t, c.WriteMessage(websocket.BinaryMessage, make([]byte, 64<<20)))
+	require.NoError(t, sc.conn.WriteControl(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "revoked"),
+		time.Now().Add(time.Second)))
+
+	err := recv(t, h.disconnects, "the disconnect")
+	var closeErr *websocket.CloseError
+	require.ErrorAs(t, err, &closeErr, "the peer's close must outrank the pending write failure")
+	assert.Equal(t, "revoked", closeErr.Text)
+}
+
+// TestClient_ReconnectFromTheHandler is how a plugin answers the server's
+// "reconnect" query: from inside the handler, between two reads. The request
+// lands before the loop re-arms its read deadline, so it only takes effect if
+// the loop checks for it before arming; otherwise the next read parks with a
+// fresh 35 minutes and the reconnect never happens.
+func TestClient_ReconnectFromTheHandler(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	var c *Client
+	ready := make(chan struct{})
+	c, _ = startClient(t, t.Context(), cfg, func(_ context.Context, _ int, p []byte) error {
+		<-ready
+		if string(p) == `{"query":"reconnect"}` {
+			c.Reconnect()
+		}
+		return nil
+	})
+	close(ready)
+	recv(t, h.connects, "the first connect")
+	first := recv(t, srv.accepted, "the first connection")
+
+	first.push(t, websocket.TextMessage, `{"query":"reconnect"}`)
+
+	assert.Equal(t, websocket.CloseNormalClosure, recv(t, first.closeCode, "the close frame on the old connection"))
+	assert.NoError(t, recv(t, h.disconnects, "the disconnect"))
+	recv(t, srv.accepted, "the connection the handler asked for")
+}
+
+// TestClient_ShutdownFromTheHandler is the "quit" query: Shutdown from inside
+// the handler, before the loop's next read.
+func TestClient_ShutdownFromTheHandler(t *testing.T) {
+	srv := newBackhaulServer(t)
+	var c *Client
+	ready := make(chan struct{})
+	c, result := startClient(t, t.Context(), testConfig(srv.url), func(context.Context, int, []byte) error {
+		<-ready
+		c.Shutdown()
+		return nil
+	})
+	close(ready)
+	sc := recv(t, srv.accepted, "the connection")
+
+	sc.push(t, websocket.TextMessage, `{"query":"quit"}`)
+
+	require.NoError(t, recv(t, result, "Run to return"))
+	assert.Equal(t, websocket.CloseNormalClosure, recv(t, sc.closeCode, "the close frame"))
+}
+
+func TestClient_ReconnectWithoutAConnectionDoesNothing(t *testing.T) {
+	c, err := New(validConfig())
+	require.NoError(t, err)
+
+	c.Reconnect()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	assert.False(t, c.reconnectPending, "a request with nothing to drop must not linger and cut the next connection short")
+}
+
+func TestClient_RedialsAfterTheServerDropsTheConnection(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	got := make(chan string, 8)
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	startClient(t, t.Context(), cfg, func(_ context.Context, _ int, p []byte) error {
+		got <- string(p)
+		return nil
+	})
+	recv(t, h.connects, "the first connect")
+	first := recv(t, srv.accepted, "the first connection")
+
+	require.NoError(t, first.conn.UnderlyingConn().Close())
+
+	assert.Error(t, recv(t, h.disconnects, "the disconnect"), "a dropped connection reports why")
+	recv(t, h.connects, "the second connect")
+	second := recv(t, srv.accepted, "the second connection")
+	second.push(t, websocket.TextMessage, "after redial")
+	assert.Equal(t, "after redial", recv(t, got, "a frame on the new connection"))
+}
+
+func TestClient_ReadTimeoutTriggersAReconnect(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.ReadTimeout = 100 * time.Millisecond
+	h.install(&cfg)
+	startClient(t, t.Context(), cfg, discard)
+	recv(t, srv.accepted, "the first connection")
+
+	err := recv(t, h.disconnects, "the disconnect")
+	var netErr net.Error
+	require.ErrorAs(t, err, &netErr, "a silent peer must surface as a read failure, not a requested close")
+	assert.True(t, netErr.Timeout())
+	recv(t, srv.accepted, "the connection dialed after the timeout")
+}
+
+func TestClient_ReadLimitDropsAnOversizedFrame(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.ReadLimit = 16
+	h.install(&cfg)
+	startClient(t, t.Context(), cfg, discard)
+	sc := recv(t, srv.accepted, "the first connection")
+
+	sc.push(t, websocket.TextMessage, strings.Repeat("x", 64))
+
+	assert.ErrorIs(t, recv(t, h.disconnects, "the disconnect"), websocket.ErrReadLimit)
+	recv(t, srv.accepted, "the connection dialed after the drop")
+}
+
+func TestClient_RetriesARejectedHandshakeThenConnects(t *testing.T) {
+	srv := newBackhaulServer(t)
+	srv.reject.Store(2)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.Rand = func() float64 { return 0 } // factor 0.5, so the first waits clamp to MinBackoff
+	h.install(&cfg)
+	delivered := make(chan struct{}, 1)
+	startClient(t, t.Context(), cfg, func(context.Context, int, []byte) error {
+		delivered <- struct{}{}
+		return nil
+	})
+
+	first := recv(t, h.retries, "the first retry")
+	second := recv(t, h.retries, "the second retry")
+	assert.Equal(t, 1, first.attempt)
+	assert.Equal(t, 2, second.attempt)
+	require.ErrorIs(t, first.err, websocket.ErrBadHandshake)
+	assert.ErrorContains(t, first.err, "HTTP 503", "the status is what tells an outage from a revoked key")
+	recv(t, h.connects, "the connect after the rejections")
+	sc := recv(t, srv.accepted, "the connection")
+
+	// A connection that carries a frame has proved itself, which resets the
+	// schedule: after the next drop, counting and waiting both start over
+	// instead of continuing from where they stopped.
+	sc.push(t, websocket.TextMessage, "proof")
+	recv(t, delivered, "the frame that proves the connection")
+	srv.reject.Store(1)
+	require.NoError(t, sc.conn.UnderlyingConn().Close())
+	require.Error(t, recv(t, h.disconnects, "the drop"))
+	third := recv(t, h.retries, "the retry after the drop")
+	assert.Equal(t, 1, third.attempt, "attempt counting restarts after a connection")
+	assert.Equal(t, cfg.MinBackoff, third.delay, "the wait restarts at the floor after a connection")
+	recv(t, h.connects, "the reconnect")
+}
+
+// TestClient_PacesRedialsAfterAnUnprovenConnection is the regression for a
+// reconnect storm. A peer that accepts the handshake and closes at once used
+// to be redialed with no wait at all, because the backoff only ever applied
+// between failed dials: thousands of upgrades a second, per agent, and
+// OnRetry silent throughout. A connection that ends before it proved itself
+// must now be followed by the same backoff a failed dial gets.
+func TestClient_PacesRedialsAfterAnUnprovenConnection(t *testing.T) {
+	srv := newBackhaulServer(t)
+	srv.closeOnAccept.Store(true)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.MinBackoff = 200 * time.Millisecond
+	cfg.MaxBackoff = time.Minute
+	cfg.Rand = func() float64 { return 0.5 } // factor 1.0, so waits are the base
+	h.install(&cfg)
+	startClient(t, t.Context(), cfg, discard)
+
+	// Two rounds of accept-then-close, each paced and reported.
+	for _, want := range []time.Duration{200 * time.Millisecond, 400 * time.Millisecond} {
+		recv(t, h.connects, "a connect")
+		require.Error(t, recv(t, h.disconnects, "the close the server sent"))
+		r := recv(t, h.retries, "the wait before the redial")
+		assert.Equal(t, want, r.delay, "an unproven connection must back off, and keep doubling")
+	}
+	assert.Less(t, srv.upgrades.Load(), int32(10), "a paced loop cannot have run away")
+}
+
+// TestClient_RedialsAtOnceAfterAProvenConnection keeps the other half of the
+// rule honest: pacing must not slow down recovery for a connection that was
+// working, which is every ordinary drop.
+func TestClient_RedialsAtOnceAfterAProvenConnection(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.MinBackoff = time.Hour // any wait at all would hang the test
+	cfg.MaxBackoff = time.Hour
+	h.install(&cfg)
+	delivered := make(chan struct{}, 1)
+	startClient(t, t.Context(), cfg, func(context.Context, int, []byte) error {
+		delivered <- struct{}{}
+		return nil
+	})
+	recv(t, h.connects, "the first connect")
+	first := recv(t, srv.accepted, "the first connection")
+	first.push(t, websocket.TextMessage, "proof")
+	recv(t, delivered, "the frame that proves the connection")
+
+	require.NoError(t, first.conn.UnderlyingConn().Close())
+
+	require.Error(t, recv(t, h.disconnects, "the drop"))
+	recv(t, h.connects, "the immediate redial")
+	select {
+	case r := <-h.retries:
+		assert.Fail(t, "a proven connection must be redialed without waiting", "waited %s", r.delay)
+	default:
+	}
+}
+
+// TestClient_ConcurrentWritesDuringReconnect keeps writers busy across a
+// forced reconnect, so writes land on the old connection, in the gap, and on
+// the new one. gorilla/websocket panics on two concurrent writers and a
+// write racing the close corrupts frames, so passing without -race already
+// shows writes are serialized; under -race it also covers the conn field.
+func TestClient_ConcurrentWritesDuringReconnect(t *testing.T) {
+	const writers = 8
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the first connect")
+	first := recv(t, srv.accepted, "the first connection")
+
+	stop := make(chan struct{})
+	var sent, refused atomic.Int64
+	var wg sync.WaitGroup
+	// Registered before the writers start: an assertion below calls FailNow,
+	// which would otherwise leave eight goroutines spinning on the write path
+	// for the rest of the package's run.
+	var stopOnce sync.Once
+	halt := func() { stopOnce.Do(func() { close(stop) }); wg.Wait() }
+	t.Cleanup(halt)
+	for w := range writers {
+		wg.Go(func() {
+			for seq := 0; ; seq++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if err := c.WriteJSON(map[string]int{"writer": w, "seq": seq}); err != nil {
+					refused.Add(1)
+					continue
+				}
+				sent.Add(1)
+			}
+		})
+	}
+
+	require.Eventually(t, func() bool { return first.frames.Load() > 0 },
+		waitFor, time.Millisecond, "no write reached the first connection")
+	c.Reconnect()
+	second := recv(t, srv.accepted, "the connection Reconnect asked for")
+	require.Eventually(t, func() bool { return second.frames.Load() > 0 },
+		waitFor, time.Millisecond, "no write reached the connection dialed by Reconnect")
+	halt()
+
+	assert.Positive(t, sent.Load())
+	for _, sc := range []*serverConn{first, second} {
+		for drained := false; !drained; {
+			select {
+			case msg := <-sc.received:
+				var body map[string]int
+				assert.NoError(t, json.Unmarshal(msg, &body), "frame %q was corrupted", msg)
+			default:
+				drained = true
+			}
+		}
+	}
+}

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -43,7 +43,7 @@ type backhaulServer struct {
 type serverConn struct {
 	conn      *websocket.Conn
 	header    http.Header
-	frames    atomic.Int64 // every frame read, including any received had no room for
+	frames    atomic.Int64 // every frame read, including those received was too full to keep
 	received  chan []byte  // the first frames read; never blocks the server's reads
 	closeCode chan int
 }
@@ -269,10 +269,12 @@ func readDeadlineProofDialer() *websocket.Dialer {
 
 // deadlineRefusingConn accepts a fixed number of read deadlines and then
 // refuses every one, the way a caller-supplied net.Conn that does not
-// implement deadlines behaves.
+// implement deadlines behaves. It also counts reads, so a test can tell when
+// the read loop has actually entered one.
 type deadlineRefusingConn struct {
 	net.Conn
 	allow *atomic.Int32
+	reads *atomic.Int64
 }
 
 func (c deadlineRefusingConn) SetReadDeadline(t time.Time) error {
@@ -282,7 +284,12 @@ func (c deadlineRefusingConn) SetReadDeadline(t time.Time) error {
 	return errors.New("this conn does not do deadlines")
 }
 
-func deadlineRefusingDialer(allow *atomic.Int32) *websocket.Dialer {
+func (c deadlineRefusingConn) Read(p []byte) (int, error) {
+	c.reads.Add(1)
+	return c.Conn.Read(p)
+}
+
+func deadlineRefusingDialer(allow *atomic.Int32, reads *atomic.Int64) *websocket.Dialer {
 	d := DefaultDialer()
 	var nd net.Dialer
 	d.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -290,9 +297,61 @@ func deadlineRefusingDialer(allow *atomic.Int32) *websocket.Dialer {
 		if err != nil {
 			return nil, err
 		}
-		return deadlineRefusingConn{Conn: conn, allow: allow}, nil
+		return deadlineRefusingConn{Conn: conn, allow: allow, reads: reads}, nil
 	}
 	return d
+}
+
+// parkOnARefusingConn starts a client whose conn accepts exactly one read
+// deadline, and returns once Run is inside a read armed with it. From there,
+// every interrupt is refused, so only freeRead's close fallback can end the
+// read. Waiting on a read-entry signal rather than a fixed sleep is what
+// makes that certain: on a slow runner a request could otherwise land before
+// the read and be handled by armRead, and the test would pass without ever
+// reaching the fallback.
+func parkOnARefusingConn(t *testing.T, srv *backhaulServer, cfg Config, h *hooks) (*Client, <-chan error) {
+	t.Helper()
+	var allow atomic.Int32
+	allow.Store(1)
+	var reads, readsAtConnect atomic.Int64
+	cfg.Dialer = deadlineRefusingDialer(&allow, &reads)
+	h.install(&cfg)
+	onConnect := cfg.OnConnect
+	cfg.OnConnect = func() {
+		readsAtConnect.Store(reads.Load()) // the handshake's reads, before the loop's first
+		onConnect()
+	}
+
+	c, result := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the first connect")
+	recv(t, srv.accepted, "the first connection")
+	require.Eventually(t, func() bool { return reads.Load() > readsAtConnect.Load() },
+		waitFor, time.Millisecond, "Run never entered its read")
+	return c, result
+}
+
+// writeDeadlineRefusingConn refuses every write deadline. gorilla applies
+// the write deadline to the socket per frame and drops the error, so without
+// a probe of its own the client would write to it with no bound at all.
+type writeDeadlineRefusingConn struct{ net.Conn }
+
+func (writeDeadlineRefusingConn) SetWriteDeadline(time.Time) error {
+	return errors.New("this conn does not do write deadlines")
+}
+
+// setDeadlineRefusingConn accepts a fixed number of SetDeadline calls and
+// then refuses every one, which is how a dial abort meets a caller-supplied
+// conn that only half implements deadlines.
+type setDeadlineRefusingConn struct {
+	net.Conn
+	allow *atomic.Int32
+}
+
+func (c setDeadlineRefusingConn) SetDeadline(t time.Time) error {
+	if c.allow.Add(-1) >= 0 {
+		return c.Conn.SetDeadline(t)
+	}
+	return errors.New("this conn does not do deadlines")
 }
 
 // undeadlinedConn ignores deadlines, so a test can hold a handshake open
@@ -518,8 +577,9 @@ func TestClient_ContextCancelFreesAParkedRead(t *testing.T) {
 // TestClient_ShutdownAbortsAStalledHandshake covers a peer that completes the
 // TCP connect and then never answers the upgrade. gorilla/websocket stops
 // watching the context at that point, so only HandshakeTimeout would end the
-// wait, and this dialer has none: without an abort of its own the client
-// would hang here forever, and a pod would be killed mid-shutdown.
+// wait. This dialer sets none, which resolve turns into the 30-second
+// default: without an abort of its own, Shutdown would wait all of that out,
+// which is a pod's whole termination grace period.
 func TestClient_ShutdownAbortsAStalledHandshake(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -536,7 +596,7 @@ func TestClient_ShutdownAbortsAStalledHandshake(t *testing.T) {
 	}()
 
 	cfg := testConfig("ws://" + listener.Addr().String() + "/ws/")
-	cfg.Dialer = &websocket.Dialer{} // no HandshakeTimeout, so nothing else can end the wait
+	cfg.Dialer = &websocket.Dialer{} // defaults to a 30s handshake timeout, far past the test's patience
 	c, result := startClient(t, t.Context(), cfg, discard)
 	stalled := recv(t, accepted, "the connection the client opened")
 	t.Cleanup(func() { _ = stalled.Close() })
@@ -605,8 +665,9 @@ func TestClient_GivesUpAConnectionWhoseDeadlineWontArm(t *testing.T) {
 	srv := newBackhaulServer(t)
 	h := newHooks()
 	var allow atomic.Int32 // refuse from the very first arm
+	var reads atomic.Int64
 	cfg := testConfig(srv.url)
-	cfg.Dialer = deadlineRefusingDialer(&allow)
+	cfg.Dialer = deadlineRefusingDialer(&allow, &reads)
 	h.install(&cfg)
 	startClient(t, t.Context(), cfg, discard)
 
@@ -623,16 +684,9 @@ func TestClient_GivesUpAConnectionWhoseDeadlineWontArm(t *testing.T) {
 func TestClient_ShutdownClosesAConnThatWontTakeADeadline(t *testing.T) {
 	srv := newBackhaulServer(t)
 	h := newHooks()
-	var allow atomic.Int32
-	allow.Store(1) // the first arm succeeds, every interrupt after it fails
 	cfg := testConfig(srv.url)
 	cfg.ReadTimeout = 30 * time.Second // far past the test's patience
-	cfg.Dialer = deadlineRefusingDialer(&allow)
-	h.install(&cfg)
-	c, result := startClient(t, t.Context(), cfg, discard)
-	recv(t, h.connects, "the connect")
-	recv(t, srv.accepted, "the connection")
-	time.Sleep(50 * time.Millisecond) // let the read park
+	c, result := parkOnARefusingConn(t, srv, cfg, h)
 
 	c.Shutdown()
 
@@ -649,18 +703,11 @@ func TestClient_ShutdownClosesAConnThatWontTakeADeadline(t *testing.T) {
 func TestClient_ReconnectOnAConnThatWontTakeADeadlineIsStillARequest(t *testing.T) {
 	srv := newBackhaulServer(t)
 	h := newHooks()
-	var allow atomic.Int32
-	allow.Store(1) // the first arm succeeds, every interrupt after it fails
 	cfg := testConfig(srv.url)
 	cfg.ReadTimeout = 30 * time.Second
 	cfg.MinBackoff = time.Hour // any paced wait would outlast the test
 	cfg.MaxBackoff = time.Hour
-	cfg.Dialer = deadlineRefusingDialer(&allow)
-	h.install(&cfg)
-	c, _ := startClient(t, t.Context(), cfg, discard)
-	recv(t, h.connects, "the first connect")
-	recv(t, srv.accepted, "the first connection")
-	time.Sleep(50 * time.Millisecond) // let the read park
+	c, _ := parkOnARefusingConn(t, srv, cfg, h)
 
 	c.Reconnect()
 
@@ -677,12 +724,110 @@ func TestClient_DrainGivesUpOnAConnThatWontTakeADeadline(t *testing.T) {
 	srv := newBackhaulServer(t)
 	srv.stallNext.Store(true) // accepts, then never answers the close frame
 	var allow atomic.Int32    // refuse every read deadline
+	var reads atomic.Int64
 	cfg := testConfig(srv.url)
-	cfg.Dialer = deadlineRefusingDialer(&allow)
+	cfg.Dialer = deadlineRefusingDialer(&allow, &reads)
 	startClient(t, t.Context(), cfg, discard)
 
 	recv(t, srv.accepted, "the connection whose deadline will not arm")
 	recv(t, srv.accepted, "the redial, which a drain stuck on a silent peer never reaches")
+}
+
+// TestClient_GivesUpAConnectionThatWontTakeAWriteDeadline covers the write
+// side. gorilla drops the error from setting a write deadline on the socket,
+// so a conn that refuses one would take writes with no bound: a stalled peer
+// would then hold the write lock, and every writer behind it, for good.
+func TestClient_GivesUpAConnectionThatWontTakeAWriteDeadline(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.Dialer = DefaultDialer()
+	var nd net.Dialer
+	cfg.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := nd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return writeDeadlineRefusingConn{conn}, nil
+	}
+	h.install(&cfg)
+	c, _ := startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the connect")
+	recv(t, srv.accepted, "the connection")
+
+	err := c.WriteJSON(map[string]string{"query": "ping"})
+
+	assert.ErrorContains(t, err, "arming the write deadline")
+	assert.ErrorIs(t, recv(t, h.disconnects, "the disconnect"), err, "a conn that cannot bound its writes is given up")
+	recv(t, srv.accepted, "the redial")
+}
+
+// TestClient_GivesUpAConnectionWhosePingReArmIsRefused covers the keepalive
+// path. A ping re-arms the read deadline from inside ReadMessage; when the
+// conn starts refusing, the deadline stops moving and a peer that pings on
+// schedule would still be cut off at ReadTimeout. Failing the read instead
+// gives the connection up the way armRead does.
+func TestClient_GivesUpAConnectionWhosePingReArmIsRefused(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	var allow atomic.Int32
+	allow.Store(1) // the loop's own arm succeeds; the ping's re-arm is refused
+	var reads atomic.Int64
+	cfg := testConfig(srv.url)
+	cfg.ReadTimeout = 30 * time.Second // the read must end on the refusal, not on this
+	cfg.Dialer = deadlineRefusingDialer(&allow, &reads)
+	h.install(&cfg)
+	startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the connect")
+	sc := recv(t, srv.accepted, "the connection")
+
+	require.NoError(t, sc.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(time.Second)))
+
+	assert.ErrorContains(t, recv(t, h.disconnects, "the disconnect"), "re-arming the read deadline")
+}
+
+// TestClient_AbortClosesAConnThatRefusesTheAbortDeadline covers the dial
+// abort meeting a conn that accepted the handshake deadline and then refuses
+// the one that would end it. Setting the deadline alone would leave the
+// handshake waiting out HandshakeTimeout after Shutdown.
+func TestClient_AbortClosesAConnThatRefusesTheAbortDeadline(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	accepted := make(chan net.Conn, 8)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			accepted <- conn // never answer the upgrade
+		}
+	}()
+
+	const handshakeTimeout = 3 * time.Second
+	var allow atomic.Int32
+	allow.Store(1) // gorilla's own handshake deadline is accepted; the abort's is refused
+	cfg := testConfig("ws://" + listener.Addr().String() + "/ws/")
+	cfg.Dialer = &websocket.Dialer{HandshakeTimeout: handshakeTimeout}
+	var nd net.Dialer
+	cfg.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := nd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return setDeadlineRefusingConn{Conn: conn, allow: &allow}, nil
+	}
+	c, result := startClient(t, t.Context(), cfg, discard)
+	stalled := recv(t, accepted, "the connection the client opened")
+	t.Cleanup(func() { _ = stalled.Close() })
+
+	start := time.Now()
+	c.Shutdown()
+
+	require.NoError(t, recv(t, result, "Run to return"))
+	assert.Less(t, time.Since(start), handshakeTimeout/2,
+		"a refused abort deadline must close the socket rather than wait out the handshake")
 }
 
 // TestClient_ShutdownIsIdempotent is the regression for issue #452's third
@@ -1098,7 +1243,7 @@ func TestClient_RetriesARejectedHandshakeThenConnects(t *testing.T) {
 	srv.reject.Store(2)
 	h := newHooks()
 	cfg := testConfig(srv.url)
-	cfg.Rand = func() float64 { return 0 } // factor 0.5, so the first waits clamp to MinBackoff
+	cfg.Rand = func() float64 { return 0 } // factor 1.0, so each wait is the base and the first is MinBackoff
 	h.install(&cfg)
 	delivered := make(chan struct{}, 1)
 	startClient(t, t.Context(), cfg, func(context.Context, int, []byte) error {

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -391,11 +392,12 @@ func (c *deadlineDelayingConn) SetDeadline(t time.Time) error {
 type writeFailingConn struct {
 	net.Conn
 	failWrites *atomic.Bool
+	err        error
 }
 
 func (c writeFailingConn) Write(p []byte) (int, error) {
 	if c.failWrites.Load() {
-		return 0, errors.New("broken pipe")
+		return 0, c.err
 	}
 	return c.Conn.Write(p)
 }
@@ -932,30 +934,65 @@ func TestClient_AbortClosesAConnThatRefusesTheAbortDeadline(t *testing.T) {
 // read deadline, so ReadTimeout never fires; if the failed pong were
 // ignored, the connection would stay up for good without being able to send
 // a byte. The failed pong has to end it.
+//
+// Both shapes a dead send side comes in, because the handler keeps the
+// connection for a write error that reports itself as temporary and the two
+// differ in exactly that: a broken pipe says nothing about being temporary,
+// while an expired write deadline says it is. Gorilla is what makes the
+// second one end the connection anyway, by running every socket write error
+// through hideTempErr, which rewrites a temporary net.Error into one that is
+// not. Nothing in this package would notice if that stopped being true, and
+// the case that would then hang is the deadline, not the pipe.
 func TestClient_GivesUpAConnectionThatCannotAnswerAPing(t *testing.T) {
-	srv := newBackhaulServer(t)
-	h := newHooks()
-	var failWrites atomic.Bool
-	cfg := testConfig(srv.url)
-	cfg.ReadTimeout = 30 * time.Second // the connection must end on the pong, long before this
-	cfg.Dialer = DefaultDialer()
-	var nd net.Dialer
-	cfg.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		conn, err := nd.DialContext(ctx, network, addr)
-		if err != nil {
-			return nil, err
-		}
-		return writeFailingConn{Conn: conn, failWrites: &failWrites}, nil
+	for name, writeErr := range map[string]error{
+		"a write error that is not temporary": errors.New("broken pipe"),
+		"a write error that is temporary":     &net.OpError{Op: "write", Err: os.ErrDeadlineExceeded},
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv := newBackhaulServer(t)
+			h := newHooks()
+			var failWrites atomic.Bool
+			cfg := testConfig(srv.url)
+			cfg.ReadTimeout = 30 * time.Second // the connection must end on the pong, long before this
+			cfg.Dialer = DefaultDialer()
+			var nd net.Dialer
+			cfg.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				conn, err := nd.DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				return writeFailingConn{Conn: conn, failWrites: &failWrites, err: writeErr}, nil
+			}
+			h.install(&cfg)
+			startClient(t, t.Context(), cfg, discard)
+			recv(t, h.connects, "the connect")
+			sc := recv(t, srv.accepted, "the connection")
+
+			failWrites.Store(true)
+			require.NoError(t, sc.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(time.Second)))
+
+			assert.ErrorContains(t, recv(t, h.disconnects, "the disconnect"), "answering a ping")
+		})
 	}
-	h.install(&cfg)
-	startClient(t, t.Context(), cfg, discard)
-	recv(t, h.connects, "the connect")
-	sc := recv(t, srv.accepted, "the connection")
+}
 
-	failWrites.Store(true)
-	require.NoError(t, sc.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(time.Second)))
+// TestTemporary_ReadsGorillasOwnWriteErrors pins the other half of the ping
+// handler's decision, the half the test above cannot reach: a pong that only
+// waited out gorilla's writer lock must be skipped, not treated as a dead
+// send side. Gorilla answers both the expired deadline and the lock it never
+// won with the same errWriteTimeout, so a deadline already past produces the
+// value the contended path would.
+func TestTemporary_ReadsGorillasOwnWriteErrors(t *testing.T) {
+	srv := newBackhaulServer(t)
+	conn, _, err := Dial(t.Context(), testConfig(srv.url))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
 
-	assert.ErrorContains(t, recv(t, h.disconnects, "the disconnect"), "answering a ping")
+	lockWait := conn.WriteControl(websocket.PongMessage, nil, time.Now().Add(-time.Second))
+
+	require.Error(t, lockWait)
+	assert.True(t, temporary(lockWait),
+		"a pong that only lost the race for the writer lock leaves the connection usable")
 }
 
 // TestClient_UptimeExcludesTheTimeSpentClosing pins when the proof is taken.

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -43,7 +43,7 @@ type backhaulServer struct {
 type serverConn struct {
 	conn      *websocket.Conn
 	header    http.Header
-	frames    atomic.Int64 // every frame read, including those received was too full to keep
+	frames    atomic.Int64 // every message read, including those dropped because received was full
 	received  chan []byte  // the first frames read; never blocks the server's reads
 	closeCode chan int
 }
@@ -352,6 +352,21 @@ func (c setDeadlineRefusingConn) SetDeadline(t time.Time) error {
 		return c.Conn.SetDeadline(t)
 	}
 	return errors.New("this conn does not do deadlines")
+}
+
+// writeFailingConn passes the handshake, then fails every write once
+// failWrites is set, which is what a connection whose send side has died
+// while its receive side is still delivering looks like.
+type writeFailingConn struct {
+	net.Conn
+	failWrites *atomic.Bool
+}
+
+func (c writeFailingConn) Write(p []byte) (int, error) {
+	if c.failWrites.Load() {
+		return 0, errors.New("broken pipe")
+	}
+	return c.Conn.Write(p)
 }
 
 // undeadlinedConn ignores deadlines, so a test can hold a handshake open
@@ -828,6 +843,64 @@ func TestClient_AbortClosesAConnThatRefusesTheAbortDeadline(t *testing.T) {
 	require.NoError(t, recv(t, result, "Run to return"))
 	assert.Less(t, time.Since(start), handshakeTimeout/2,
 		"a refused abort deadline must close the socket rather than wait out the handshake")
+}
+
+// TestClient_GivesUpAConnectionThatCannotAnswerAPing covers a connection
+// whose send side has died while pings keep arriving. Each ping re-arms the
+// read deadline, so ReadTimeout never fires; if the failed pong were
+// ignored, the connection would stay up for good without being able to send
+// a byte. The failed pong has to end it.
+func TestClient_GivesUpAConnectionThatCannotAnswerAPing(t *testing.T) {
+	srv := newBackhaulServer(t)
+	h := newHooks()
+	var failWrites atomic.Bool
+	cfg := testConfig(srv.url)
+	cfg.ReadTimeout = 30 * time.Second // the connection must end on the pong, long before this
+	cfg.Dialer = DefaultDialer()
+	var nd net.Dialer
+	cfg.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := nd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return writeFailingConn{Conn: conn, failWrites: &failWrites}, nil
+	}
+	h.install(&cfg)
+	startClient(t, t.Context(), cfg, discard)
+	recv(t, h.connects, "the connect")
+	sc := recv(t, srv.accepted, "the connection")
+
+	failWrites.Store(true)
+	require.NoError(t, sc.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(time.Second)))
+
+	assert.ErrorContains(t, recv(t, h.disconnects, "the disconnect"), "answering a ping")
+}
+
+// TestClient_UptimeExcludesTheTimeSpentClosing pins when the proof is taken.
+// Releasing a connection runs the close drain and the caller's OnDisconnect,
+// and neither is time the connection was up. Measured after them, a peer that
+// hangs up at once looks proven whenever cleanup outlasts MinBackoff, and its
+// redials skip the backoff entirely.
+func TestClient_UptimeExcludesTheTimeSpentClosing(t *testing.T) {
+	srv := newBackhaulServer(t)
+	srv.closeOnAccept.Store(true)
+	h := newHooks()
+	cfg := testConfig(srv.url)
+	cfg.MinBackoff = 100 * time.Millisecond
+	cfg.MaxBackoff = time.Minute
+	cfg.Rand = func() float64 { return 0 }
+	h.install(&cfg)
+	onDisconnect := cfg.OnDisconnect
+	cfg.OnDisconnect = func(err error) {
+		time.Sleep(2 * cfg.MinBackoff) // a slow hook, longer than MinBackoff
+		onDisconnect(err)
+	}
+	startClient(t, t.Context(), cfg, discard)
+
+	recv(t, h.connects, "a connect")
+	require.Error(t, recv(t, h.disconnects, "the close the server sent"))
+	r := recv(t, h.retries, "the wait a connection that lasted no time at all should get")
+	assert.Equal(t, cfg.MinBackoff, r.delay)
 }
 
 // TestClient_ShutdownIsIdempotent is the regression for issue #452's third

--- a/pkg/wsclient/client_test.go
+++ b/pkg/wsclient/client_test.go
@@ -354,6 +354,37 @@ func (c setDeadlineRefusingConn) SetDeadline(t time.Time) error {
 	return errors.New("this conn does not do deadlines")
 }
 
+// deadlineDelayingConn turns the window inside the abort wrapper into a
+// certainty. On the first deadline the handshake installs it calls Shutdown
+// and waits for the abort's own deadline to reach this socket before passing
+// the handshake deadline down. A wrapper that reads the abort flag and
+// forwards the deadline as two steps therefore always overwrites the abort
+// here; a wrapper that does both under one lock never can, because the abort
+// cannot land while this call is inside it, and the wait falls through to its
+// bound instead.
+type deadlineDelayingConn struct {
+	net.Conn
+	shutdown func()
+	first    sync.Once
+	once     sync.Once
+	aborted  chan struct{}
+}
+
+func (c *deadlineDelayingConn) SetDeadline(t time.Time) error {
+	if !t.IsZero() && t.Before(time.Now()) {
+		c.once.Do(func() { close(c.aborted) })
+		return c.Conn.SetDeadline(t)
+	}
+	c.first.Do(func() {
+		c.shutdown()
+		select {
+		case <-c.aborted:
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+	return c.Conn.SetDeadline(t)
+}
+
 // writeFailingConn passes the handshake, then fails every write once
 // failWrites is set, which is what a connection whose send side has died
 // while its receive side is still delivering looks like.
@@ -670,6 +701,57 @@ func TestClient_AbortSurvivesTheHandshakeDeadline(t *testing.T) {
 	require.NoError(t, recv(t, result, "Run to return"))
 	assert.Less(t, time.Since(start), handshakeTimeout,
 		"the abort must hold, not be overwritten by the handshake deadline")
+}
+
+// TestClient_AbortSurvivesADeadlineAlreadyInFlight covers the same overwrite
+// one step further in. The wrapper lets the handshake deadline through only
+// while no abort has landed, so reading that answer and installing the
+// deadline have to be one step: an abort that lands between them has already
+// pushed the socket into the past, and the handshake deadline puts it back
+// where it was. Nothing notices, because the dial then ends the way it would
+// have anyway, a whole HandshakeTimeout later.
+func TestClient_AbortSurvivesADeadlineAlreadyInFlight(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	accepted := make(chan net.Conn, 8)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			accepted <- conn // never answer the upgrade
+		}
+	}()
+
+	const handshakeTimeout = 2 * time.Second
+	var c *Client
+	cfg := testConfig("ws://" + listener.Addr().String() + "/ws/")
+	cfg.Dialer = &websocket.Dialer{HandshakeTimeout: handshakeTimeout}
+	var nd net.Dialer
+	cfg.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := nd.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return &deadlineDelayingConn{
+			Conn:     conn,
+			shutdown: func() { c.Shutdown() },
+			aborted:  make(chan struct{}),
+		}, nil
+	}
+	c, err = New(cfg)
+	require.NoError(t, err)
+	result := make(chan error, 1)
+	go func() { result <- c.Run(t.Context(), discard) }()
+	stalled := recv(t, accepted, "the connection the client opened")
+	t.Cleanup(func() { _ = stalled.Close() })
+
+	start := time.Now()
+	require.NoError(t, recv(t, result, "Run to return"))
+	assert.Less(t, time.Since(start), handshakeTimeout/2,
+		"the abort must stand, not be undone by a handshake deadline already on its way")
 }
 
 // TestClient_GivesUpAConnectionWhoseDeadlineWontArm covers a

--- a/pkg/wsclient/config.go
+++ b/pkg/wsclient/config.go
@@ -84,8 +84,9 @@ type Config struct {
 	WriteTimeout time.Duration
 
 	// MinBackoff and MaxBackoff bound the wait between reconnect attempts.
-	// Each wait is the doubling base times a random factor in [0.5, 1.5),
-	// clamped to this range. Zero means DefaultMinBackoff and DefaultMaxBackoff.
+	// Each wait is the doubling base times a random factor in [1.0, 1.5),
+	// clamped to this range, so MinBackoff is a true floor. Zero means
+	// DefaultMinBackoff and DefaultMaxBackoff.
 	MinBackoff time.Duration
 	MaxBackoff time.Duration
 

--- a/pkg/wsclient/config.go
+++ b/pkg/wsclient/config.go
@@ -3,6 +3,7 @@ package wsclient
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"slices"
@@ -22,11 +23,11 @@ const (
 	// connection is treated as dead. The Alpacon backhaul pings well inside it.
 	DefaultReadTimeout = 35 * time.Minute
 
-	// DefaultWriteTimeout bounds each write, so a stalled peer cannot hold up
-	// every other writer.
+	// DefaultWriteTimeout bounds each WriteMessage or WriteJSON call, so a
+	// stalled peer cannot hold up every other writer.
 	DefaultWriteTimeout = 10 * time.Second
 
-	// DefaultReadLimit is the largest inbound frame accepted, in bytes.
+	// DefaultReadLimit is the largest inbound message accepted, in bytes.
 	DefaultReadLimit = 10 << 20
 
 	// DefaultMinBackoff and DefaultMaxBackoff bound the reconnect schedule.
@@ -74,14 +75,17 @@ type Config struct {
 	// or negotiates. Start from DefaultDialer() to keep its proxy settings.
 	Dialer *websocket.Dialer
 
-	// ReadLimit is the largest inbound frame accepted, in bytes. Zero means
-	// DefaultReadLimit; a negative value removes the limit.
+	// ReadLimit is the largest inbound message accepted, in bytes: its
+	// frames' payloads summed as they arrive, before any decompression. Zero
+	// means DefaultReadLimit; a negative value removes the limit.
 	ReadLimit int64
 
 	// ReadTimeout is re-armed before every read. Zero means DefaultReadTimeout.
 	ReadTimeout time.Duration
 
-	// WriteTimeout bounds every write. Zero means DefaultWriteTimeout.
+	// WriteTimeout bounds each WriteMessage and WriteJSON call. Control frames
+	// the client sends itself, pongs and close frames, have a short fixed
+	// bound of their own. Zero means DefaultWriteTimeout.
 	WriteTimeout time.Duration
 
 	// MinBackoff and MaxBackoff bound the wait between reconnect attempts.
@@ -230,6 +234,16 @@ func (c Config) resolveDial() (dialSettings, error) {
 	// time, where a Client would retry the same doomed handshake forever.
 	if _, ok := header["Sec-Websocket-Protocol"]; ok && len(dialer.Subprotocols) > 0 {
 		return dialSettings{}, errors.New("wsclient: set the subprotocol in Dialer.Subprotocols or in Header, not both")
+	}
+
+	// gorilla sends a Host entry as the request's Host, and net/http refuses
+	// to write one it cannot punycode, which would fail every dial and have a
+	// Client retry a config error forever. Ask that same writer now.
+	if vs := header["Host"]; len(vs) > 0 && vs[0] != "" {
+		probe := &http.Request{Method: http.MethodGet, URL: &url.URL{Path: "/"}, Host: vs[0], Header: http.Header{}}
+		if err := probe.Write(io.Discard); err != nil {
+			return dialSettings{}, fmt.Errorf("wsclient: header Host cannot be sent: %w", err)
+		}
 	}
 
 	return dialSettings{url: u, header: header, dialer: dialer, readLimit: readLimit}, nil

--- a/pkg/wsclient/config.go
+++ b/pkg/wsclient/config.go
@@ -1,0 +1,297 @@
+package wsclient
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/alpacax/alpamon/v2/pkg/version"
+	"github.com/gorilla/websocket"
+)
+
+// Defaults applied to zero-valued Config fields.
+const (
+	// DefaultHandshakeTimeout bounds the opening handshake in DefaultDialer.
+	DefaultHandshakeTimeout = 30 * time.Second
+
+	// DefaultReadTimeout is how long a read may wait for a frame before the
+	// connection is treated as dead. The Alpacon backhaul pings well inside it.
+	DefaultReadTimeout = 35 * time.Minute
+
+	// DefaultWriteTimeout bounds each write, so a stalled peer cannot hold up
+	// every other writer.
+	DefaultWriteTimeout = 10 * time.Second
+
+	// DefaultReadLimit is the largest inbound frame accepted, in bytes.
+	DefaultReadLimit = 10 << 20
+
+	// DefaultMinBackoff and DefaultMaxBackoff bound the reconnect schedule.
+	DefaultMinBackoff = 5 * time.Second
+	DefaultMaxBackoff = 60 * time.Second
+)
+
+// Config is what a caller injects to build a Client or Dial. Only URL, ID and
+// Key are required; every other zero value means the documented default.
+type Config struct {
+	// URL is the full endpoint, e.g. wss://backhaul.example.com/ws/servers/backhaul/.
+	// http and https are accepted and mapped to ws and wss.
+	URL string
+
+	// ID and Key are sent as Authorization: id="<ID>", key="<Key>".
+	ID  string
+	Key string
+
+	// Origin, when non-empty, is sent as the Origin header.
+	Origin string
+
+	// UserAgent is sent as the User-Agent header. Empty means
+	// "alpamon/<version>", which is only right for alpamon itself: any other
+	// agent should name itself here.
+	UserAgent string
+
+	// Header carries extra request headers. Authorization and User-Agent
+	// always come from the fields above, as does Origin when it is set.
+	Header http.Header
+
+	// Dialer opens the connection. Nil means DefaultDialer(). A non-nil
+	// dialer is used as given, so start from DefaultDialer() to keep its
+	// handshake timeout and proxy settings.
+	Dialer *websocket.Dialer
+
+	// ReadLimit is the largest inbound frame accepted, in bytes. Zero means
+	// DefaultReadLimit; a negative value removes the limit.
+	ReadLimit int64
+
+	// ReadTimeout is re-armed before every read. Zero means DefaultReadTimeout.
+	ReadTimeout time.Duration
+
+	// WriteTimeout bounds every write. Zero means DefaultWriteTimeout.
+	WriteTimeout time.Duration
+
+	// MinBackoff and MaxBackoff bound the wait between reconnect attempts.
+	// Each wait is the doubling base times a random factor in [0.5, 1.5),
+	// clamped to this range. Zero means DefaultMinBackoff and DefaultMaxBackoff.
+	MinBackoff time.Duration
+	MaxBackoff time.Duration
+
+	// Rand returns the value in [0, 1) the jitter factor is drawn from. Nil
+	// means math/rand/v2. Tests pin it for a deterministic schedule.
+	Rand func() float64
+
+	// OnConnect runs after every successful dial. OnDisconnect runs once for
+	// every connection that OnConnect announced; err is nil when the client
+	// closed a healthy connection because Shutdown, Reconnect or the Run
+	// context asked it to, and is otherwise what ended the connection: a
+	// failed read or write, the peer's close, or the handler's error. OnRetry
+	// runs before each wait between connection attempts, whether the last dial
+	// failed or a connection ended before it proved itself; err is what caused
+	// the wait, and attempt counts from 1, restarting after a connection that
+	// worked. All three run on the Run goroutine, so a slow hook delays
+	// reading and reconnecting. They may call any Client method except Run.
+	OnConnect    func()
+	OnDisconnect func(err error)
+	OnRetry      func(attempt int, delay time.Duration, err error)
+}
+
+// DefaultDialer returns the dialer a nil Config.Dialer stands for: a
+// DefaultHandshakeTimeout handshake, the proxy named by HTTPS_PROXY,
+// HTTP_PROXY and NO_PROXY, and the system roots for TLS. Each call returns a
+// new dialer, which the caller may adjust before putting it in a Config.
+func DefaultDialer() *websocket.Dialer {
+	return &websocket.Dialer{
+		Proxy:            http.ProxyFromEnvironment,
+		HandshakeTimeout: DefaultHandshakeTimeout,
+	}
+}
+
+// reservedHeaders are the request headers gorilla/websocket sets itself and
+// refuses to take from the caller. Rejecting them up front keeps a config
+// mistake from turning into a dial that fails, and retries, forever.
+var reservedHeaders = []string{
+	"Upgrade",
+	"Connection",
+	"Sec-Websocket-Key",
+	"Sec-Websocket-Version",
+	"Sec-Websocket-Extensions",
+}
+
+// dialSettings is the validated part of a Config that opening a connection
+// needs. Dial uses only this.
+type dialSettings struct {
+	url       string
+	header    http.Header
+	dialer    *websocket.Dialer
+	readLimit int64
+}
+
+// settings is a fully validated Config with every default applied.
+type settings struct {
+	dialSettings
+
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+	minBackoff   time.Duration
+	maxBackoff   time.Duration
+	rand         func() float64
+
+	onConnect    func()
+	onDisconnect func(error)
+	onRetry      func(int, time.Duration, error)
+}
+
+func (c Config) dialSettings() (dialSettings, error) {
+	u, err := normalizeURL(c.URL)
+	if err != nil {
+		return dialSettings{}, err
+	}
+	if err := checkCredential("ID", c.ID); err != nil {
+		return dialSettings{}, err
+	}
+	if err := checkCredential("Key", c.Key); err != nil {
+		return dialSettings{}, err
+	}
+
+	header := make(http.Header, len(c.Header)+3)
+	for k, vs := range c.Header {
+		ck := http.CanonicalHeaderKey(k)
+		header[ck] = append(header[ck], vs...)
+	}
+	for _, k := range reservedHeaders {
+		if _, ok := header[k]; ok {
+			return dialSettings{}, fmt.Errorf("wsclient: header %s is set by the websocket handshake and cannot be overridden", k)
+		}
+	}
+	header.Set("Authorization", fmt.Sprintf(`id="%s", key="%s"`, c.ID, c.Key))
+	if c.Origin != "" {
+		header.Set("Origin", c.Origin)
+	}
+	userAgent := c.UserAgent
+	if userAgent == "" {
+		userAgent = "alpamon/" + version.Version
+	}
+	header.Set("User-Agent", userAgent)
+
+	var dialer *websocket.Dialer
+	if c.Dialer == nil {
+		dialer = DefaultDialer()
+	} else {
+		copied := *c.Dialer // later edits to the caller's dialer must not reach a running client
+		dialer = &copied
+	}
+
+	readLimit := c.ReadLimit
+	switch {
+	case readLimit == 0:
+		readLimit = DefaultReadLimit
+	case readLimit < 0:
+		readLimit = 0 // gorilla/websocket reads zero as no limit
+	}
+
+	// gorilla/websocket refuses this pair as well, and refuses it at dial
+	// time, where a Client would retry the same doomed handshake forever.
+	if _, ok := header["Sec-Websocket-Protocol"]; ok && len(dialer.Subprotocols) > 0 {
+		return dialSettings{}, errors.New("wsclient: set the subprotocol in Dialer.Subprotocols or in Header, not both")
+	}
+
+	return dialSettings{url: u, header: header, dialer: dialer, readLimit: readLimit}, nil
+}
+
+func (c Config) resolve() (settings, error) {
+	ds, err := c.dialSettings()
+	if err != nil {
+		return settings{}, err
+	}
+
+	s := settings{
+		dialSettings: ds,
+		readTimeout:  c.ReadTimeout,
+		writeTimeout: c.WriteTimeout,
+		minBackoff:   c.MinBackoff,
+		maxBackoff:   c.MaxBackoff,
+		rand:         c.Rand,
+		onConnect:    c.OnConnect,
+		onDisconnect: c.OnDisconnect,
+		onRetry:      c.OnRetry,
+	}
+
+	for _, d := range []struct {
+		name  string
+		value *time.Duration
+		def   time.Duration
+	}{
+		{"ReadTimeout", &s.readTimeout, DefaultReadTimeout},
+		{"WriteTimeout", &s.writeTimeout, DefaultWriteTimeout},
+		{"MinBackoff", &s.minBackoff, DefaultMinBackoff},
+		{"MaxBackoff", &s.maxBackoff, DefaultMaxBackoff},
+	} {
+		switch {
+		case *d.value < 0:
+			return settings{}, fmt.Errorf("wsclient: %s must not be negative, got %s", d.name, *d.value)
+		case *d.value == 0:
+			*d.value = d.def
+		}
+	}
+	if s.minBackoff > s.maxBackoff {
+		return settings{}, fmt.Errorf("wsclient: MinBackoff %s exceeds MaxBackoff %s", s.minBackoff, s.maxBackoff)
+	}
+
+	if s.onConnect == nil {
+		s.onConnect = func() {}
+	}
+	if s.onDisconnect == nil {
+		s.onDisconnect = func(error) {}
+	}
+	if s.onRetry == nil {
+		s.onRetry = func(int, time.Duration, error) {}
+	}
+	return s, nil
+}
+
+// normalizeURL checks that raw names a websocket endpoint and maps http and
+// https onto ws and wss, the only schemes gorilla/websocket dials.
+func normalizeURL(raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("wsclient: URL is required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		// url.Error repeats the whole URL, which may carry a token; keep only the cause.
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			err = urlErr.Err
+		}
+		return "", fmt.Errorf("wsclient: invalid URL: %w", err)
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "ws", "http":
+		u.Scheme = "ws"
+	case "wss", "https":
+		u.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("wsclient: URL scheme %q is not one of ws, wss, http or https", u.Scheme)
+	}
+	if u.User != nil {
+		return "", errors.New("wsclient: URL must not carry credentials; use ID and Key")
+	}
+	if u.Host == "" {
+		return "", errors.New("wsclient: URL has no host")
+	}
+	return u.String(), nil
+}
+
+// checkCredential rejects a value that would corrupt the Authorization header:
+// the backhaul parses it with id="([^"]+)", so a quote would silently cut the
+// value short.
+func checkCredential(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("wsclient: %s is required", name)
+	}
+	if strings.ContainsAny(value, "\"\r\n") {
+		return fmt.Errorf("wsclient: %s must not contain quotes or line breaks", name)
+	}
+	return nil
+}

--- a/pkg/wsclient/config.go
+++ b/pkg/wsclient/config.go
@@ -66,13 +66,20 @@ type Config struct {
 	Header http.Header
 
 	// Dialer opens the connection. Nil means DefaultDialer(). A non-nil
-	// dialer is used as given except for three things. A zero
+	// dialer is used as given except for four things. A zero
 	// HandshakeTimeout becomes DefaultHandshakeTimeout, because
 	// gorilla/websocket stops watching the context once the socket is up and
 	// an unbounded handshake would hang with no signal at all; a negative one
 	// is rejected. TLSClientConfig and Subprotocols are copied, so that later
 	// edits to them cannot change how a running client verifies certificates
 	// or negotiates. Start from DefaultDialer() to keep its proxy settings.
+	//
+	// The fourth is the dial hooks, which are wrapped so that Shutdown and a
+	// done context can free a socket the handshake is still waiting on. A
+	// hook has to return that socket first: NetDialContext is handed a
+	// context that ends with the client's, but NetDial takes none and is
+	// adapted to the wrapper, so nothing can interrupt it before it returns.
+	// Prefer NetDialContext, and give a NetDial a timeout of its own.
 	Dialer *websocket.Dialer
 
 	// ReadLimit is the largest inbound message accepted, in bytes: its
@@ -234,6 +241,33 @@ func (c Config) resolveDial() (dialSettings, error) {
 	// time, where a Client would retry the same doomed handshake forever.
 	if _, ok := header["Sec-Websocket-Protocol"]; ok && len(dialer.Subprotocols) > 0 {
 		return dialSettings{}, errors.New("wsclient: set the subprotocol in Dialer.Subprotocols or in Header, not both")
+	}
+
+	// net/http serializes the header, and it answers a field it cannot write
+	// by leaving it out rather than by failing: a name outside the HTTP token
+	// grammar is dropped, and a CR or LF in a value is replaced by a space.
+	// Header promises the caller that what it carries is sent, and a header
+	// that goes missing or arrives rewritten is a handshake the server may
+	// refuse on every attempt, with a Client retrying it forever and nothing
+	// in the config to point at. Ask that same writer, one field at a time,
+	// and treat what it will not write as the config error it is.
+	for name, values := range header {
+		if name == "Host" {
+			continue // sent as the request's Host, and probed as one below
+		}
+		for _, v := range values {
+			if strings.ContainsAny(v, "\r\n") {
+				return dialSettings{}, fmt.Errorf("wsclient: header %s has a value with a line break, which net/http rewrites rather than sends", name)
+			}
+		}
+		probe := &http.Request{Method: http.MethodGet, URL: &url.URL{Path: "/"}, Host: "probe.invalid", Header: http.Header{name: {"probe"}}}
+		var written strings.Builder
+		if err := probe.Write(&written); err != nil {
+			return dialSettings{}, fmt.Errorf("wsclient: header %s cannot be sent: %w", name, err)
+		}
+		if !strings.Contains(written.String(), "\r\n"+name+": probe\r\n") {
+			return dialSettings{}, fmt.Errorf("wsclient: header %s cannot be sent: net/http does not write that field name", name)
+		}
 	}
 
 	// gorilla sends a Host entry as the request's Host, so ask net/http, the

--- a/pkg/wsclient/config.go
+++ b/pkg/wsclient/config.go
@@ -236,12 +236,21 @@ func (c Config) resolveDial() (dialSettings, error) {
 		return dialSettings{}, errors.New("wsclient: set the subprotocol in Dialer.Subprotocols or in Header, not both")
 	}
 
-	// gorilla sends a Host entry as the request's Host, and net/http refuses
-	// to write one it cannot punycode, which would fail every dial and have a
-	// Client retry a config error forever. Ask that same writer now.
+	// gorilla sends a Host entry as the request's Host, so ask net/http, the
+	// writer that will have to serialize it, whether it can. A Host it cannot
+	// punycode fails the write outright; one it can punycode but will not put
+	// in a header, such as a value carrying a space, a slash or a line break,
+	// it drops in silence, and the handshake then goes out with an empty Host
+	// that all but any server answers with 400. Either way every dial fails
+	// and a Client retries a config error forever.
+	//
+	// WriteProxy, not Write, because they differ in exactly that second case:
+	// Write zeroes the field, while WriteProxy reports it. Nothing here is
+	// proxied, and the two serialize a request with no URL scheme the same
+	// way; WriteProxy is used only because it is the one that answers.
 	if vs := header["Host"]; len(vs) > 0 && vs[0] != "" {
 		probe := &http.Request{Method: http.MethodGet, URL: &url.URL{Path: "/"}, Host: vs[0], Header: http.Header{}}
-		if err := probe.Write(io.Discard); err != nil {
+		if err := probe.WriteProxy(io.Discard); err != nil {
 			return dialSettings{}, fmt.Errorf("wsclient: header Host cannot be sent: %w", err)
 		}
 	}

--- a/pkg/wsclient/config.go
+++ b/pkg/wsclient/config.go
@@ -38,6 +38,13 @@ const (
 type Config struct {
 	// URL is the full endpoint, e.g. wss://backhaul.example.com/ws/servers/backhaul/.
 	// http and https are accepted and mapped to ws and wss.
+	//
+	// It must come from trusted configuration. The credential below is sent
+	// to whatever host it names, and nothing here pins that host, so a URL
+	// taken from a server response or from user input hands the agent's key
+	// to that host. A ws:// or http:// URL sends the credential in the
+	// clear, which is for a local endpoint or a mesh that supplies its own
+	// transport security, never the open internet.
 	URL string
 
 	// ID and Key are sent as Authorization: id="<ID>", key="<Key>".
@@ -57,8 +64,12 @@ type Config struct {
 	Header http.Header
 
 	// Dialer opens the connection. Nil means DefaultDialer(). A non-nil
-	// dialer is used as given, so start from DefaultDialer() to keep its
-	// handshake timeout and proxy settings.
+	// dialer is used as given except for two things: a zero HandshakeTimeout
+	// becomes DefaultHandshakeTimeout, because gorilla/websocket stops
+	// watching the context once the socket is up and an unbounded handshake
+	// would hang with no signal at all, and TLSClientConfig is cloned so
+	// that later edits to it cannot change how a running client verifies
+	// certificates. Start from DefaultDialer() to keep its proxy settings.
 	Dialer *websocket.Dialer
 
 	// ReadLimit is the largest inbound frame accepted, in bytes. Zero means
@@ -142,7 +153,7 @@ type settings struct {
 	onRetry      func(int, time.Duration, error)
 }
 
-func (c Config) dialSettings() (dialSettings, error) {
+func (c Config) resolveDial() (dialSettings, error) {
 	u, err := normalizeURL(c.URL)
 	if err != nil {
 		return dialSettings{}, err
@@ -178,8 +189,22 @@ func (c Config) dialSettings() (dialSettings, error) {
 	if c.Dialer == nil {
 		dialer = DefaultDialer()
 	} else {
-		copied := *c.Dialer // later edits to the caller's dialer must not reach a running client
+		// A copy, so later edits to the caller's own dialer value cannot
+		// reach a running client. The copy is shallow, so the reference
+		// fields it shares are handled below.
+		copied := *c.Dialer
 		dialer = &copied
+	}
+	if dialer.HandshakeTimeout == 0 {
+		dialer.HandshakeTimeout = DefaultHandshakeTimeout
+	}
+	if dialer.TLSClientConfig != nil {
+		// Shared, this is the one field whose later mutation would change
+		// how an already-running client verifies certificates: gorilla reads
+		// it again on every dial, so a caller flipping InsecureSkipVerify on
+		// a tls.Config it also uses elsewhere would silently disable
+		// verification on the next reconnect.
+		dialer.TLSClientConfig = dialer.TLSClientConfig.Clone()
 	}
 
 	readLimit := c.ReadLimit
@@ -200,7 +225,7 @@ func (c Config) dialSettings() (dialSettings, error) {
 }
 
 func (c Config) resolve() (settings, error) {
-	ds, err := c.dialSettings()
+	ds, err := c.resolveDial()
 	if err != nil {
 		return settings{}, err
 	}

--- a/pkg/wsclient/config.go
+++ b/pkg/wsclient/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -198,6 +199,9 @@ func (c Config) resolveDial() (dialSettings, error) {
 	if dialer.HandshakeTimeout == 0 {
 		dialer.HandshakeTimeout = DefaultHandshakeTimeout
 	}
+	// The shallow copy shares this slice's backing array with the caller, so
+	// an edit to an entry after New would change later handshakes.
+	dialer.Subprotocols = slices.Clone(dialer.Subprotocols)
 	if dialer.TLSClientConfig != nil {
 		// Shared, this is the one field whose later mutation would change
 		// how an already-running client verifies certificates: gorilla reads

--- a/pkg/wsclient/config.go
+++ b/pkg/wsclient/config.go
@@ -327,7 +327,10 @@ func normalizeURL(raw string) (string, error) {
 	if u.User != nil {
 		return "", errors.New("wsclient: URL must not carry credentials; use ID and Key")
 	}
-	if u.Host == "" {
+	// Hostname too, not just Host: url.Parse reads "wss://:443" as the
+	// authority ":443", which is non-empty but names no destination, and
+	// every dial would fail on it.
+	if u.Host == "" || u.Hostname() == "" {
 		return "", errors.New("wsclient: URL has no host")
 	}
 	return u.String(), nil

--- a/pkg/wsclient/config.go
+++ b/pkg/wsclient/config.go
@@ -65,12 +65,13 @@ type Config struct {
 	Header http.Header
 
 	// Dialer opens the connection. Nil means DefaultDialer(). A non-nil
-	// dialer is used as given except for two things: a zero HandshakeTimeout
-	// becomes DefaultHandshakeTimeout, because gorilla/websocket stops
-	// watching the context once the socket is up and an unbounded handshake
-	// would hang with no signal at all, and TLSClientConfig is cloned so
-	// that later edits to it cannot change how a running client verifies
-	// certificates. Start from DefaultDialer() to keep its proxy settings.
+	// dialer is used as given except for three things. A zero
+	// HandshakeTimeout becomes DefaultHandshakeTimeout, because
+	// gorilla/websocket stops watching the context once the socket is up and
+	// an unbounded handshake would hang with no signal at all; a negative one
+	// is rejected. TLSClientConfig and Subprotocols are copied, so that later
+	// edits to them cannot change how a running client verifies certificates
+	// or negotiates. Start from DefaultDialer() to keep its proxy settings.
 	Dialer *websocket.Dialer
 
 	// ReadLimit is the largest inbound frame accepted, in bytes. Zero means
@@ -197,7 +198,12 @@ func (c Config) resolveDial() (dialSettings, error) {
 		copied := *c.Dialer
 		dialer = &copied
 	}
-	if dialer.HandshakeTimeout == 0 {
+	switch {
+	case dialer.HandshakeTimeout < 0:
+		// gorilla would hand this to context.WithTimeout, which expires at
+		// once: every dial fails, and a Client retries a config error forever.
+		return dialSettings{}, fmt.Errorf("wsclient: Dialer.HandshakeTimeout must not be negative, got %s", dialer.HandshakeTimeout)
+	case dialer.HandshakeTimeout == 0:
 		dialer.HandshakeTimeout = DefaultHandshakeTimeout
 	}
 	// The shallow copy shares this slice's backing array with the caller, so

--- a/pkg/wsclient/config_test.go
+++ b/pkg/wsclient/config_test.go
@@ -130,6 +130,14 @@ func TestResolve_Rejects(t *testing.T) {
 		"Host with a line break": {func(c *Config) { c.Header = http.Header{"Host": {"good.example\r\nX: 1"}} }, "header Host cannot be sent"},
 		"Host with a space":      {func(c *Config) { c.Header = http.Header{"Host": {"bad host"}} }, "header Host cannot be sent"},
 		"Host with a path":       {func(c *Config) { c.Header = http.Header{"Host": {"host/path"}} }, "header Host cannot be sent"},
+		// net/http drops a field name outside the HTTP token grammar and
+		// rewrites a line break in a value, both without a word, so a header
+		// the caller counted on would go missing or arrive changed and every
+		// handshake that needed it would be refused.
+		"header name with a space":                  {func(c *Config) { c.Header = http.Header{"Bad Name": {"v"}} }, "header Bad Name cannot be sent"},
+		"header name with a colon":                  {func(c *Config) { c.Header = http.Header{"Bad:Name": {"v"}} }, "header Bad:Name cannot be sent"},
+		"header name net/http sends from elsewhere": {func(c *Config) { c.Header = http.Header{"Content-Length": {"7"}} }, "header Content-Length cannot be sent"},
+		"header value with a line break":            {func(c *Config) { c.Header = http.Header{"X-Trace": {"good\r\nX-Injected: 1"}} }, "header X-Trace has a value with a line break"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := validConfig()
@@ -185,6 +193,21 @@ func TestResolve_AcceptsASendableHost(t *testing.T) {
 			cfg.Header = http.Header{"Host": {host}}
 			_, err := cfg.resolve()
 			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestResolve_AcceptsASendableHeader keeps the header check to what net/http
+// really refuses to write. The token grammar is wider than it looks, and a
+// name this rejected would be a header the caller cannot send at all.
+func TestResolve_AcceptsASendableHeader(t *testing.T) {
+	for _, name := range []string{"X-Trace-Id", "x-lowercase", "X_Underscore", "X.Dot", "Cookie", "If-None-Match"} {
+		t.Run(name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Header = http.Header{name: {"value"}}
+			s, err := cfg.resolve()
+			require.NoError(t, err)
+			assert.Equal(t, "value", s.header.Get(name))
 		})
 	}
 }

--- a/pkg/wsclient/config_test.go
+++ b/pkg/wsclient/config_test.go
@@ -42,6 +42,7 @@ func TestNormalizeURL_Rejects(t *testing.T) {
 		{"ftp://example.com/", `scheme "ftp"`},
 		{"example.com/ws/", `scheme ""`},
 		{"wss:///ws/", "no host"},
+		{"wss://:443/ws/", "no host"}, // url.Parse reads ":443" as a non-empty authority
 		{"wss://user:pass@example.com/ws/", "must not carry credentials"},
 		{"wss://exa mple.com/ws/", "invalid URL"},
 	} {

--- a/pkg/wsclient/config_test.go
+++ b/pkg/wsclient/config_test.go
@@ -1,0 +1,209 @@
+package wsclient
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/alpacax/alpamon/v2/pkg/version"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validConfig() Config {
+	return Config{URL: "wss://backhaul.example.com/ws/servers/backhaul/", ID: "srv-1", Key: "secret"}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"http://example.com/ws/", "ws://example.com/ws/"},
+		{"https://example.com/ws/", "wss://example.com/ws/"},
+		{"HTTPS://example.com:8443/ws/?a=1", "wss://example.com:8443/ws/?a=1"},
+		{"ws://127.0.0.1:8081/ws/", "ws://127.0.0.1:8081/ws/"},
+		{"wss://example.com/ws/", "wss://example.com/ws/"},
+	} {
+		got, err := normalizeURL(tc.in)
+		require.NoError(t, err, tc.in)
+		assert.Equal(t, tc.want, got, tc.in)
+	}
+}
+
+func TestNormalizeURL_Rejects(t *testing.T) {
+	for _, tc := range []struct {
+		in, wantErr string
+	}{
+		{"", "URL is required"},
+		{"ftp://example.com/", `scheme "ftp"`},
+		{"example.com/ws/", `scheme ""`},
+		{"wss:///ws/", "no host"},
+		{"wss://user:pass@example.com/ws/", "must not carry credentials"},
+		{"wss://exa mple.com/ws/", "invalid URL"},
+	} {
+		_, err := normalizeURL(tc.in)
+		assert.ErrorContains(t, err, tc.wantErr, tc.in)
+	}
+}
+
+// TestNormalizeURL_ParseErrorHidesTheURL matters because an endpoint URL can
+// carry a token in its query, and the error is going to end up in a log.
+func TestNormalizeURL_ParseErrorHidesTheURL(t *testing.T) {
+	_, err := normalizeURL("wss://exa mple.com/ws/?token=hunter2")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "hunter2")
+}
+
+func TestResolve_AppliesDefaults(t *testing.T) {
+	s, err := validConfig().resolve()
+	require.NoError(t, err)
+
+	assert.Equal(t, DefaultReadTimeout, s.readTimeout)
+	assert.Equal(t, DefaultWriteTimeout, s.writeTimeout)
+	assert.Equal(t, DefaultMinBackoff, s.minBackoff)
+	assert.Equal(t, DefaultMaxBackoff, s.maxBackoff)
+	assert.Equal(t, int64(DefaultReadLimit), s.readLimit)
+	assert.Equal(t, DefaultHandshakeTimeout, s.dialer.HandshakeTimeout)
+	assert.NotNil(t, s.dialer.Proxy, "the default dialer must honor the proxy environment")
+	assert.NotNil(t, s.onConnect)
+	assert.NotNil(t, s.onDisconnect)
+	assert.NotNil(t, s.onRetry)
+}
+
+func TestResolve_KeepsExplicitValues(t *testing.T) {
+	cfg := validConfig()
+	cfg.ReadTimeout = time.Minute
+	cfg.WriteTimeout = 2 * time.Second
+	cfg.MinBackoff = time.Second
+	cfg.MaxBackoff = 16 * time.Minute
+	cfg.ReadLimit = 4096
+
+	s, err := cfg.resolve()
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Minute, s.readTimeout)
+	assert.Equal(t, 2*time.Second, s.writeTimeout)
+	assert.Equal(t, time.Second, s.minBackoff)
+	assert.Equal(t, 16*time.Minute, s.maxBackoff)
+	assert.Equal(t, int64(4096), s.readLimit)
+}
+
+func TestResolve_NegativeReadLimitMeansUnlimited(t *testing.T) {
+	cfg := validConfig()
+	cfg.ReadLimit = -1
+
+	s, err := cfg.resolve()
+	require.NoError(t, err)
+	assert.Zero(t, s.readLimit, "gorilla/websocket reads a zero limit as none")
+}
+
+func TestResolve_Rejects(t *testing.T) {
+	for name, tc := range map[string]struct {
+		mutate  func(*Config)
+		wantErr string
+	}{
+		"missing ID":                 {func(c *Config) { c.ID = "" }, "ID is required"},
+		"missing Key":                {func(c *Config) { c.Key = "" }, "Key is required"},
+		"quote in ID":                {func(c *Config) { c.ID = `a"b` }, "ID must not contain quotes"},
+		"line break in Key":          {func(c *Config) { c.Key = "a\r\nX-Evil: 1" }, "Key must not contain quotes or line breaks"},
+		"negative ReadTimeout":       {func(c *Config) { c.ReadTimeout = -time.Second }, "ReadTimeout must not be negative"},
+		"negative WriteTimeout":      {func(c *Config) { c.WriteTimeout = -time.Second }, "WriteTimeout must not be negative"},
+		"negative MinBackoff":        {func(c *Config) { c.MinBackoff = -time.Second }, "MinBackoff must not be negative"},
+		"negative MaxBackoff":        {func(c *Config) { c.MaxBackoff = -time.Second }, "MaxBackoff must not be negative"},
+		"min above max":              {func(c *Config) { c.MinBackoff, c.MaxBackoff = time.Minute, time.Second }, "exceeds MaxBackoff"},
+		"min above the default max":  {func(c *Config) { c.MinBackoff = 2 * DefaultMaxBackoff }, "exceeds MaxBackoff"},
+		"reserved header":            {func(c *Config) { c.Header = http.Header{"Upgrade": {"h2c"}} }, "Upgrade is set by the websocket handshake"},
+		"reserved header, lowercase": {func(c *Config) { c.Header = http.Header{"sec-websocket-key": {"x"}} }, "Sec-Websocket-Key is set by the websocket handshake"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := validConfig()
+			tc.mutate(&cfg)
+			_, err := cfg.resolve()
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestResolve_RejectsASubprotocolSetTwice covers the other pair
+// gorilla/websocket refuses at dial time, which a Client would otherwise
+// retry forever.
+func TestResolve_RejectsASubprotocolSetTwice(t *testing.T) {
+	cfg := validConfig()
+	cfg.Header = http.Header{"Sec-WebSocket-Protocol": {"alpacon.v1"}}
+	cfg.Dialer = DefaultDialer()
+	cfg.Dialer.Subprotocols = []string{"alpacon.v1"}
+
+	_, err := cfg.resolve()
+
+	assert.ErrorContains(t, err, "not both")
+}
+
+func TestResolve_AllowsASubprotocolInOnePlace(t *testing.T) {
+	cfg := validConfig()
+	cfg.Header = http.Header{"Sec-WebSocket-Protocol": {"alpacon.v1"}}
+	_, err := cfg.resolve()
+	require.NoError(t, err)
+
+	cfg = validConfig()
+	cfg.Dialer = DefaultDialer()
+	cfg.Dialer.Subprotocols = []string{"alpacon.v1"}
+	_, err = cfg.resolve()
+	assert.NoError(t, err)
+}
+
+func TestResolve_Header(t *testing.T) {
+	cfg := validConfig()
+	cfg.Origin = "https://alpacon.example.com"
+	cfg.UserAgent = "alpamon-kube/0.1.0"
+	cfg.Header = http.Header{
+		"x-cluster-id":  {"c-1"},
+		"Authorization": {"Bearer should-lose"},
+		"User-Agent":    {"should-lose"},
+	}
+
+	s, err := cfg.resolve()
+	require.NoError(t, err)
+
+	assert.Equal(t, `id="srv-1", key="secret"`, s.header.Get("Authorization"), "the exact format the backhaul parses")
+	assert.Equal(t, "https://alpacon.example.com", s.header.Get("Origin"))
+	assert.Equal(t, "alpamon-kube/0.1.0", s.header.Get("User-Agent"))
+	assert.Equal(t, "c-1", s.header.Get("X-Cluster-Id"), "extra headers pass through, canonicalized")
+	assert.Len(t, s.header.Values("Authorization"), 1, "the caller's Authorization must be replaced, not appended to")
+}
+
+func TestResolve_HeaderDefaults(t *testing.T) {
+	cfg := validConfig()
+	cfg.Header = http.Header{"Origin": {"https://from-header.example.com"}}
+
+	s, err := cfg.resolve()
+	require.NoError(t, err)
+
+	assert.Equal(t, "alpamon/"+version.Version, s.header.Get("User-Agent"))
+	assert.Equal(t, "https://from-header.example.com", s.header.Get("Origin"), "an empty Origin field leaves the caller's header alone")
+}
+
+func TestResolve_DoesNotAliasCallerState(t *testing.T) {
+	extra := http.Header{"X-Trace": {"a"}}
+	dialer := &websocket.Dialer{HandshakeTimeout: time.Second}
+	cfg := validConfig()
+	cfg.Header = extra
+	cfg.Dialer = dialer
+
+	s, err := cfg.resolve()
+	require.NoError(t, err)
+
+	extra["X-Trace"][0] = "changed"
+	extra.Set("X-Late", "late")
+	dialer.HandshakeTimeout = time.Hour
+
+	assert.Equal(t, "a", s.header.Get("X-Trace"), "the caller's header slices must be copied")
+	assert.Empty(t, s.header.Get("X-Late"))
+	assert.Equal(t, time.Second, s.dialer.HandshakeTimeout, "a running client must not see later edits to the caller's dialer")
+}
+
+func TestDefaultDialer_ReturnsAFreshDialer(t *testing.T) {
+	a, b := DefaultDialer(), DefaultDialer()
+	a.HandshakeTimeout = time.Hour
+	assert.Equal(t, DefaultHandshakeTimeout, b.HandshakeTimeout)
+}

--- a/pkg/wsclient/config_test.go
+++ b/pkg/wsclient/config_test.go
@@ -261,6 +261,17 @@ func TestDefaults_AreTheValuesTheyClaim(t *testing.T) {
 	assert.Equal(t, 60*time.Second, DefaultMaxBackoff)
 }
 
+func TestResolve_RejectsANegativeHandshakeTimeout(t *testing.T) {
+	cfg := validConfig()
+	cfg.Dialer = &websocket.Dialer{HandshakeTimeout: -time.Second}
+
+	_, err := cfg.resolve()
+
+	// Passed through, gorilla's context.WithTimeout would expire at once and
+	// a Client would retry a config error forever.
+	assert.ErrorContains(t, err, "HandshakeTimeout must not be negative")
+}
+
 func TestNew_RejectsAnInvalidConfig(t *testing.T) {
 	c, err := New(Config{})
 	assert.Nil(t, c, "New must not hand back a half-built client")

--- a/pkg/wsclient/config_test.go
+++ b/pkg/wsclient/config_test.go
@@ -123,6 +123,13 @@ func TestResolve_Rejects(t *testing.T) {
 		"reserved header, lowercase": {func(c *Config) { c.Header = http.Header{"sec-websocket-key": {"x"}} }, "Sec-Websocket-Key is set by the websocket handshake"},
 		// net/http cannot punycode this Host, so it would fail every dial.
 		"unsendable Host": {func(c *Config) { c.Header = http.Header{"Host": {"é.xn--!"}} }, "header Host cannot be sent"},
+		// These three punycode fine and then lose to net/http's header check,
+		// which drops the whole Host rather than refusing it. A handshake with
+		// no Host is one a server answers with 400, so a Client that took them
+		// would retry a config error for as long as it ran.
+		"Host with a line break": {func(c *Config) { c.Header = http.Header{"Host": {"good.example\r\nX: 1"}} }, "header Host cannot be sent"},
+		"Host with a space":      {func(c *Config) { c.Header = http.Header{"Host": {"bad host"}} }, "header Host cannot be sent"},
+		"Host with a path":       {func(c *Config) { c.Header = http.Header{"Host": {"host/path"}} }, "header Host cannot be sent"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := validConfig()
@@ -165,11 +172,14 @@ func TestResolve_AllowsASubprotocolInOnePlace(t *testing.T) {
 }
 
 // TestResolve_AcceptsASendableHost keeps the Host check to what net/http
-// really refuses: an internationalized name it can punycode, a port, and a
-// value with a line break in it, which net/http neutralizes rather than
-// refuses, all dial fine.
+// can really send: an internationalized name it punycodes, a port, an
+// address already in its ASCII form, and an IPv6 literal with a zone it
+// strips on the way out all dial fine, and none of them may be refused here.
 func TestResolve_AcceptsASendableHost(t *testing.T) {
-	for _, host := range []string{"backhaul.example.com", "bücher.example", "bücher.example:8443", "good.example\r\nX: 1"} {
+	for _, host := range []string{
+		"backhaul.example.com", "bücher.example", "bücher.example:8443",
+		"xn--bcher-kva.example", "[::1]:8443", "[fe80::1%25en0]:443",
+	} {
 		t.Run(host, func(t *testing.T) {
 			cfg := validConfig()
 			cfg.Header = http.Header{"Host": {host}}

--- a/pkg/wsclient/config_test.go
+++ b/pkg/wsclient/config_test.go
@@ -120,6 +120,8 @@ func TestResolve_Rejects(t *testing.T) {
 		"min above the default max":  {func(c *Config) { c.MinBackoff = 2 * DefaultMaxBackoff }, "exceeds MaxBackoff"},
 		"reserved header":            {func(c *Config) { c.Header = http.Header{"Upgrade": {"h2c"}} }, "Upgrade is set by the websocket handshake"},
 		"reserved header, lowercase": {func(c *Config) { c.Header = http.Header{"sec-websocket-key": {"x"}} }, "Sec-Websocket-Key is set by the websocket handshake"},
+		// net/http cannot punycode this Host, so it would fail every dial.
+		"unsendable Host": {func(c *Config) { c.Header = http.Header{"Host": {"é.xn--!"}} }, "header Host cannot be sent"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := validConfig()
@@ -155,6 +157,21 @@ func TestResolve_AllowsASubprotocolInOnePlace(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cfg := validConfig()
 			set(&cfg)
+			_, err := cfg.resolve()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestResolve_AcceptsASendableHost keeps the Host check to what net/http
+// really refuses: an internationalized name it can punycode, a port, and a
+// value with a line break in it, which net/http neutralizes rather than
+// refuses, all dial fine.
+func TestResolve_AcceptsASendableHost(t *testing.T) {
+	for _, host := range []string{"backhaul.example.com", "bücher.example", "bücher.example:8443", "good.example\r\nX: 1"} {
+		t.Run(host, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Header = http.Header{"Host": {host}}
 			_, err := cfg.resolve()
 			assert.NoError(t, err)
 		})

--- a/pkg/wsclient/config_test.go
+++ b/pkg/wsclient/config_test.go
@@ -1,6 +1,7 @@
 package wsclient
 
 import (
+	"crypto/tls"
 	"net/http"
 	"testing"
 	"time"
@@ -25,9 +26,11 @@ func TestNormalizeURL(t *testing.T) {
 		{"ws://127.0.0.1:8081/ws/", "ws://127.0.0.1:8081/ws/"},
 		{"wss://example.com/ws/", "wss://example.com/ws/"},
 	} {
-		got, err := normalizeURL(tc.in)
-		require.NoError(t, err, tc.in)
-		assert.Equal(t, tc.want, got, tc.in)
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := normalizeURL(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
 	}
 }
 
@@ -42,8 +45,10 @@ func TestNormalizeURL_Rejects(t *testing.T) {
 		{"wss://user:pass@example.com/ws/", "must not carry credentials"},
 		{"wss://exa mple.com/ws/", "invalid URL"},
 	} {
-		_, err := normalizeURL(tc.in)
-		assert.ErrorContains(t, err, tc.wantErr, tc.in)
+		t.Run(tc.in, func(t *testing.T) {
+			_, err := normalizeURL(tc.in)
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
 	}
 }
 
@@ -140,16 +145,20 @@ func TestResolve_RejectsASubprotocolSetTwice(t *testing.T) {
 }
 
 func TestResolve_AllowsASubprotocolInOnePlace(t *testing.T) {
-	cfg := validConfig()
-	cfg.Header = http.Header{"Sec-WebSocket-Protocol": {"alpacon.v1"}}
-	_, err := cfg.resolve()
-	require.NoError(t, err)
-
-	cfg = validConfig()
-	cfg.Dialer = DefaultDialer()
-	cfg.Dialer.Subprotocols = []string{"alpacon.v1"}
-	_, err = cfg.resolve()
-	assert.NoError(t, err)
+	for name, set := range map[string]func(*Config){
+		"in Header": func(c *Config) { c.Header = http.Header{"Sec-WebSocket-Protocol": {"alpacon.v1"}} },
+		"in Dialer": func(c *Config) {
+			c.Dialer = DefaultDialer()
+			c.Dialer.Subprotocols = []string{"alpacon.v1"}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := validConfig()
+			set(&cfg)
+			_, err := cfg.resolve()
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestResolve_Header(t *testing.T) {
@@ -200,6 +209,60 @@ func TestResolve_DoesNotAliasCallerState(t *testing.T) {
 	assert.Equal(t, "a", s.header.Get("X-Trace"), "the caller's header slices must be copied")
 	assert.Empty(t, s.header.Get("X-Late"))
 	assert.Equal(t, time.Second, s.dialer.HandshakeTimeout, "a running client must not see later edits to the caller's dialer")
+}
+
+// TestResolve_BoundsACallerDialersHandshake covers the obvious thing to
+// write, &websocket.Dialer{}: gorilla stops watching the context once the
+// socket is up, so a zero handshake timeout leaves a peer that accepts TCP
+// and never answers able to wedge the client with no signal at all.
+func TestResolve_BoundsACallerDialersHandshake(t *testing.T) {
+	cfg := validConfig()
+	cfg.Dialer = &websocket.Dialer{}
+
+	s, err := cfg.resolve()
+	require.NoError(t, err)
+	assert.Equal(t, DefaultHandshakeTimeout, s.dialer.HandshakeTimeout)
+
+	cfg.Dialer = &websocket.Dialer{HandshakeTimeout: time.Second}
+	s, err = cfg.resolve()
+	require.NoError(t, err)
+	assert.Equal(t, time.Second, s.dialer.HandshakeTimeout, "an explicit timeout is left alone")
+}
+
+// TestResolve_ClonesTheTLSConfig matters because gorilla reads
+// TLSClientConfig again on every dial: a caller that shares one tls.Config
+// with something else and later sets InsecureSkipVerify on it would
+// otherwise turn off certificate verification for the next reconnect.
+func TestResolve_ClonesTheTLSConfig(t *testing.T) {
+	shared := &tls.Config{MinVersion: tls.VersionTLS13}
+	cfg := validConfig()
+	cfg.Dialer = &websocket.Dialer{TLSClientConfig: shared}
+
+	s, err := cfg.resolve()
+	require.NoError(t, err)
+
+	shared.InsecureSkipVerify = true
+
+	assert.False(t, s.dialer.TLSClientConfig.InsecureSkipVerify,
+		"a running client must not start skipping verification because the caller edited its tls.Config")
+}
+
+// TestDefaults_AreTheValuesTheyClaim pins the constants themselves. Asserting
+// that the resolver assigns DefaultReadTimeout only proves the wiring; a typo
+// in the constant would ship green.
+func TestDefaults_AreTheValuesTheyClaim(t *testing.T) {
+	assert.Equal(t, 30*time.Second, DefaultHandshakeTimeout)
+	assert.Equal(t, 35*time.Minute, DefaultReadTimeout)
+	assert.Equal(t, 10*time.Second, DefaultWriteTimeout)
+	assert.Equal(t, int64(10<<20), int64(DefaultReadLimit))
+	assert.Equal(t, 5*time.Second, DefaultMinBackoff)
+	assert.Equal(t, 60*time.Second, DefaultMaxBackoff)
+}
+
+func TestNew_RejectsAnInvalidConfig(t *testing.T) {
+	c, err := New(Config{})
+	assert.Nil(t, c, "New must not hand back a half-built client")
+	assert.ErrorContains(t, err, "URL is required")
 }
 
 func TestDefaultDialer_ReturnsAFreshDialer(t *testing.T) {

--- a/pkg/wsclient/config_test.go
+++ b/pkg/wsclient/config_test.go
@@ -194,7 +194,7 @@ func TestResolve_HeaderDefaults(t *testing.T) {
 
 func TestResolve_DoesNotAliasCallerState(t *testing.T) {
 	extra := http.Header{"X-Trace": {"a"}}
-	dialer := &websocket.Dialer{HandshakeTimeout: time.Second}
+	dialer := &websocket.Dialer{HandshakeTimeout: time.Second, Subprotocols: []string{"alpacon.v1"}}
 	cfg := validConfig()
 	cfg.Header = extra
 	cfg.Dialer = dialer
@@ -205,10 +205,12 @@ func TestResolve_DoesNotAliasCallerState(t *testing.T) {
 	extra["X-Trace"][0] = "changed"
 	extra.Set("X-Late", "late")
 	dialer.HandshakeTimeout = time.Hour
+	dialer.Subprotocols[0] = "changed"
 
 	assert.Equal(t, "a", s.header.Get("X-Trace"), "the caller's header slices must be copied")
 	assert.Empty(t, s.header.Get("X-Late"))
 	assert.Equal(t, time.Second, s.dialer.HandshakeTimeout, "a running client must not see later edits to the caller's dialer")
+	assert.Equal(t, []string{"alpacon.v1"}, s.dialer.Subprotocols, "the shallow copy shares this slice's array, so it has to be cloned")
 }
 
 // TestResolve_BoundsACallerDialersHandshake covers the obvious thing to

--- a/pkg/wsclient/dial.go
+++ b/pkg/wsclient/dial.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -115,30 +114,14 @@ func unofferedExtension(values []string, compression bool) (string, bool) {
 // in a pod is the whole termination grace period.
 func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, func()) {
 	dialer := *d
-
-	var (
-		mu       sync.Mutex
-		opened   []net.Conn
-		aborted  atomic.Bool
-		finished bool
-	)
-	track := func(c net.Conn) net.Conn {
-		wrapped := abortableConn{Conn: c, aborted: &aborted}
-		mu.Lock()
-		defer mu.Unlock()
-		if aborted.Load() {
-			_ = forceAbort(wrapped) // it closes what refuses the deadline; nothing left to do
-		}
-		opened = append(opened, wrapped)
-		return wrapped
-	}
+	state := &abortState{}
 	wrap := func(dial func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
 		return func(ctx context.Context, network, addr string) (net.Conn, error) {
 			c, err := dial(ctx, network, addr)
 			if err != nil {
 				return nil, err
 			}
-			return track(c), nil
+			return state.track(c), nil
 		}
 	}
 
@@ -158,33 +141,79 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 		dialer.NetDialTLSContext = wrap(dialer.NetDialTLSContext)
 	}
 
-	stop := context.AfterFunc(ctx, func() {
-		mu.Lock()
-		defer mu.Unlock()
-		if finished {
-			return
-		}
-		aborted.Store(true)
-		for _, c := range opened {
-			_ = forceAbort(c)
-		}
-	})
-
+	stop := context.AfterFunc(ctx, state.abort)
 	return &dialer, func() {
 		stop()
-		mu.Lock()
-		defer mu.Unlock()
-		finished = true
-		if !aborted.Load() {
-			return
-		}
-		aborted.Store(false)
-		// The abort can land on a handshake that had already finished. Clear
-		// it so a connection handed back to a caller is still usable; one
-		// that is on its way out is closed by the caller either way.
-		for _, c := range opened {
-			_ = c.SetDeadline(time.Time{})
-		}
+		state.finish()
+	}
+}
+
+// abortState is what one dial's sockets share. Every field is read and
+// written under mu, and so is every deadline that reaches a socket through
+// abortableConn, which is the point: an abort and a deadline on its way down
+// both end in a SetDeadline on the same socket, and whichever lands second
+// decides how long the dial waits. Holding mu across the call keeps the
+// abort's deadline from being the first of the two.
+//
+// opened holds the sockets as the dial hook returned them, not the wrappers,
+// so nothing below re-enters abortableConn and deadlocks on mu.
+type abortState struct {
+	mu       sync.Mutex
+	opened   []net.Conn
+	aborted  bool
+	finished bool
+}
+
+// track takes ownership of a freshly opened socket and returns it wrapped.
+func (s *abortState) track(c net.Conn) net.Conn {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.aborted {
+		_ = forceAbort(c) // it closes what refuses the deadline; nothing left to do
+	}
+	s.opened = append(s.opened, c)
+	return abortableConn{Conn: c, state: s}
+}
+
+// abort unblocks every socket the dial has opened, and every socket it opens
+// from here on.
+func (s *abortState) abort() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.finished {
+		return
+	}
+	s.aborted = true
+	for _, c := range s.opened {
+		_ = forceAbort(c)
+	}
+}
+
+// setDeadline installs t on c, unless the dial has been aborted, in which
+// case the abort's deadline is the one that stands.
+func (s *abortState) setDeadline(c net.Conn, t time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.aborted {
+		return forceAbort(c)
+	}
+	return c.SetDeadline(t)
+}
+
+// finish ends the dial and lifts an abort that landed on it.
+func (s *abortState) finish() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.finished = true
+	if !s.aborted {
+		return
+	}
+	s.aborted = false
+	// The abort can land on a handshake that had already finished. Clear it
+	// so a connection handed back to a caller is still usable; one that is on
+	// its way out is closed by the caller either way.
+	for _, c := range s.opened {
+		_ = c.SetDeadline(time.Time{})
 	}
 }
 
@@ -194,14 +223,11 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 // quietly overwritten and the dial would run to its handshake timeout.
 type abortableConn struct {
 	net.Conn
-	aborted *atomic.Bool
+	state *abortState
 }
 
 func (c abortableConn) SetDeadline(t time.Time) error {
-	if c.aborted.Load() {
-		return forceAbort(c.Conn)
-	}
-	return c.Conn.SetDeadline(t)
+	return c.state.setDeadline(c.Conn, t)
 }
 
 // forceAbort unblocks a dial on c. A deadline in the past is the ordinary

--- a/pkg/wsclient/dial.go
+++ b/pkg/wsclient/dial.go
@@ -66,22 +66,42 @@ func (s dialSettings) dial(ctx context.Context) (conn *websocket.Conn, resp *htt
 		return nil, resp, err
 	}
 
-	// gorilla/websocket switches decompression on for any server that answers
-	// with permessage-deflate, including one that was never offered it, and a
-	// read limit counts the compressed bytes. Together that turns a small
-	// frame into an unbounded allocation, so refuse the connection instead.
-	// Values, not Get: gorilla reads every Sec-WebSocket-Extensions header
-	// it was sent, so a server that puts an empty one first and
-	// permessage-deflate second would walk straight past a check on the
-	// first value alone.
-	if extensions := resp.Header.Values("Sec-WebSocket-Extensions"); len(extensions) > 0 && !s.dialer.EnableCompression {
+	// A client must fail the connection when the server answers with an
+	// extension it never offered (RFC 6455, section 9.1), and here it matters
+	// beyond form: gorilla/websocket switches decompression on for any
+	// permessage-deflate answer, offered or not, and a read limit counts the
+	// compressed bytes, so a small frame could inflate without bound.
+	// Values, not Get, because gorilla reads every Sec-WebSocket-Extensions
+	// header, so a server that hid the real one behind an empty first header
+	// would pass a check on the first value alone.
+	if name, ok := unofferedExtension(resp.Header.Values("Sec-WebSocket-Extensions"), s.dialer.EnableCompression); ok {
 		_ = conn.Close()
-		return nil, resp, fmt.Errorf("wsclient: server negotiated %q, an extension this client did not offer",
-			strings.Join(extensions, ", "))
+		return nil, resp, fmt.Errorf("wsclient: server negotiated %q, an extension this client did not offer", name)
 	}
 
 	conn.SetReadLimit(s.readLimit)
 	return conn, resp, nil
+}
+
+// unofferedExtension returns the first extension named in the server's
+// answer that this client did not offer. The only extension gorilla/websocket
+// ever offers is permessage-deflate, and only with EnableCompression. Anything
+// this parser cannot place is reported rather than skipped, so a header it
+// reads differently from gorilla fails closed.
+func unofferedExtension(values []string, compression bool) (string, bool) {
+	for _, value := range values {
+		for _, extension := range strings.Split(value, ",") {
+			name, _, _ := strings.Cut(extension, ";")
+			name = strings.TrimSpace(name)
+			switch {
+			case name == "":
+			case compression && strings.EqualFold(name, "permessage-deflate"):
+			default:
+				return name, true
+			}
+		}
+	}
+	return "", false
 }
 
 // abortable copies d with its dial hooks wrapped so that every socket they
@@ -90,9 +110,9 @@ func (s dialSettings) dial(ctx context.Context) (conn *websocket.Conn, resp *htt
 //
 // gorilla/websocket stops watching ctx as soon as the socket is up: the HTTP
 // upgrade exchange, and a proxy CONNECT before it, are bounded only by
-// HandshakeTimeout, which a caller-supplied dialer may leave at zero. Without
-// this a Shutdown waits on a peer that has stopped answering, which for an
-// agent in a pod means waiting out the termination grace period.
+// HandshakeTimeout. Without this a Shutdown would wait that timeout out on a
+// peer that has stopped answering, 30 seconds by default, which for an agent
+// in a pod is the whole termination grace period.
 func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, func()) {
 	dialer := *d
 
@@ -107,7 +127,7 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 		mu.Lock()
 		defer mu.Unlock()
 		if aborted.Load() {
-			_ = wrapped.SetDeadline(aLongTimeAgo)
+			forceAbort(wrapped)
 		}
 		opened = append(opened, wrapped)
 		return wrapped
@@ -146,7 +166,7 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 		}
 		aborted.Store(true)
 		for _, c := range opened {
-			_ = c.SetDeadline(aLongTimeAgo)
+			forceAbort(c)
 		}
 	})
 
@@ -179,7 +199,18 @@ type abortableConn struct {
 
 func (c abortableConn) SetDeadline(t time.Time) error {
 	if c.aborted.Load() {
-		return c.Conn.SetDeadline(aLongTimeAgo)
+		return forceAbort(c.Conn)
 	}
 	return c.Conn.SetDeadline(t)
+}
+
+// forceAbort unblocks a dial on c. A deadline in the past is the ordinary
+// way, but a caller-supplied net.Conn may refuse deadlines, and then closing
+// it is what is left.
+func forceAbort(c net.Conn) error {
+	if err := c.SetDeadline(aLongTimeAgo); err != nil {
+		_ = c.Close()
+		return err
+	}
+	return nil
 }

--- a/pkg/wsclient/dial.go
+++ b/pkg/wsclient/dial.go
@@ -1,0 +1,151 @@
+package wsclient
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Dial opens one connection and hands it over: the caller owns it outright,
+// including reading, writing, deadlines and closing, and nothing reconnects
+// it. It suits a connection with its own lifecycle, such as a tunnel data
+// plane wrapped in tunnel.WebSocketConn for smux.
+//
+// Dial uses URL, ID, Key, Origin, UserAgent, Header, Dialer and ReadLimit
+// from cfg, and ignores the timeout, backoff and hook fields. When the server
+// rejects the handshake, the error wraps websocket.ErrBadHandshake and the
+// response is returned alongside it.
+func Dial(ctx context.Context, cfg Config) (*websocket.Conn, *http.Response, error) {
+	s, err := cfg.dialSettings()
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.dial(ctx)
+}
+
+// dial opens one connection with the handshake headers and read limit.
+func (s dialSettings) dial(ctx context.Context) (conn *websocket.Conn, resp *http.Response, err error) {
+	dialer, finish := abortable(ctx, s.dialer)
+	defer finish()
+
+	// gorilla/websocket v1.5.3 reads the reason phrase out of a proxy's
+	// CONNECT status line without checking there is one (proxy.go), so a
+	// proxy answering "HTTP/1.1 407" panics whichever goroutine dialed. For
+	// an agent that goroutine is the one keeping the process alive, and a
+	// proxy is reachable by default through the environment, so turn it into
+	// the error it should have been.
+	defer func() {
+		if r := recover(); r != nil {
+			conn, resp, err = nil, nil, fmt.Errorf("wsclient: dial panicked, most likely on a malformed proxy response: %v", r)
+		}
+	}()
+
+	conn, resp, err = dialer.DialContext(ctx, s.url, s.header)
+	if err != nil {
+		if resp != nil {
+			// gorilla/websocket reports every rejected handshake as the same
+			// ErrBadHandshake; the status is what tells a 401 from a 503.
+			err = fmt.Errorf("%w (HTTP %d)", err, resp.StatusCode)
+		}
+		return nil, resp, err
+	}
+
+	// gorilla/websocket switches decompression on for any server that answers
+	// with permessage-deflate, including one that was never offered it, and a
+	// read limit counts the compressed bytes. Together that turns a small
+	// frame into an unbounded allocation, so refuse the connection instead.
+	if extensions := resp.Header.Get("Sec-WebSocket-Extensions"); extensions != "" && !s.dialer.EnableCompression {
+		_ = conn.Close()
+		return nil, resp, fmt.Errorf("wsclient: server negotiated %q, an extension this client did not offer", extensions)
+	}
+
+	conn.SetReadLimit(s.readLimit)
+	return conn, resp, nil
+}
+
+// abortable copies d with its dial hooks wrapped so that every socket they
+// open is unblocked once ctx ends, and returns a function to call when the
+// dial is over.
+//
+// gorilla/websocket stops watching ctx as soon as the socket is up: the HTTP
+// upgrade exchange, and a proxy CONNECT before it, are bounded only by
+// HandshakeTimeout, which a caller-supplied dialer may leave at zero. Without
+// this a Shutdown waits on a peer that has stopped answering, which for an
+// agent in a pod means waiting out the termination grace period.
+func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, func()) {
+	dialer := *d
+
+	var (
+		mu       sync.Mutex
+		opened   []net.Conn
+		aborted  bool
+		finished bool
+	)
+	track := func(c net.Conn) net.Conn {
+		mu.Lock()
+		defer mu.Unlock()
+		if aborted {
+			_ = c.SetDeadline(aLongTimeAgo)
+		}
+		opened = append(opened, c)
+		return c
+	}
+	wrap := func(dial func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
+		return func(ctx context.Context, network, addr string) (net.Conn, error) {
+			c, err := dial(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return track(c), nil
+		}
+	}
+
+	base := dialer.NetDialContext
+	switch {
+	case base != nil:
+	case dialer.NetDial != nil:
+		netDial := dialer.NetDial
+		base = func(_ context.Context, network, addr string) (net.Conn, error) { return netDial(network, addr) }
+	default:
+		var nd net.Dialer
+		base = nd.DialContext
+	}
+	dialer.NetDial = nil // NetDialContext wins anyway; leaving it would only mislead
+	dialer.NetDialContext = wrap(base)
+	if dialer.NetDialTLSContext != nil {
+		dialer.NetDialTLSContext = wrap(dialer.NetDialTLSContext)
+	}
+
+	stop := context.AfterFunc(ctx, func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if finished {
+			return
+		}
+		aborted = true
+		for _, c := range opened {
+			_ = c.SetDeadline(aLongTimeAgo)
+		}
+	})
+
+	return &dialer, func() {
+		stop()
+		mu.Lock()
+		defer mu.Unlock()
+		finished = true
+		if !aborted {
+			return
+		}
+		// The abort can land on a handshake that had already finished. Clear
+		// it so a connection handed back to a caller is still usable; one
+		// that is on its way out is closed by the caller either way.
+		for _, c := range opened {
+			_ = c.SetDeadline(time.Time{})
+		}
+	}
+}

--- a/pkg/wsclient/dial.go
+++ b/pkg/wsclient/dial.go
@@ -127,7 +127,7 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 		mu.Lock()
 		defer mu.Unlock()
 		if aborted.Load() {
-			forceAbort(wrapped)
+			_ = forceAbort(wrapped) // it closes what refuses the deadline; nothing left to do
 		}
 		opened = append(opened, wrapped)
 		return wrapped
@@ -166,7 +166,7 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 		}
 		aborted.Store(true)
 		for _, c := range opened {
-			forceAbort(c)
+			_ = forceAbort(c)
 		}
 	})
 

--- a/pkg/wsclient/dial.go
+++ b/pkg/wsclient/dial.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -19,9 +21,11 @@ import (
 // Dial uses URL, ID, Key, Origin, UserAgent, Header, Dialer and ReadLimit
 // from cfg, and ignores the timeout, backoff and hook fields. When the server
 // rejects the handshake, the error wraps websocket.ErrBadHandshake and the
-// response is returned alongside it.
+// response is returned alongside it, with the Authorization header stripped
+// from the request hanging off it so that logging the response cannot spill
+// the credential.
 func Dial(ctx context.Context, cfg Config) (*websocket.Conn, *http.Response, error) {
-	s, err := cfg.dialSettings()
+	s, err := cfg.resolveDial()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,6 +50,13 @@ func (s dialSettings) dial(ctx context.Context) (conn *websocket.Conn, resp *htt
 	}()
 
 	conn, resp, err = dialer.DialContext(ctx, s.url, s.header)
+	// http.ReadResponse hangs the request off the response, and that request
+	// carries the Authorization header. Callers are invited to inspect the
+	// response, and one logged struct would put the agent's long-lived key
+	// wherever those logs go.
+	if resp != nil && resp.Request != nil {
+		resp.Request.Header.Del("Authorization")
+	}
 	if err != nil {
 		if resp != nil {
 			// gorilla/websocket reports every rejected handshake as the same
@@ -59,9 +70,14 @@ func (s dialSettings) dial(ctx context.Context) (conn *websocket.Conn, resp *htt
 	// with permessage-deflate, including one that was never offered it, and a
 	// read limit counts the compressed bytes. Together that turns a small
 	// frame into an unbounded allocation, so refuse the connection instead.
-	if extensions := resp.Header.Get("Sec-WebSocket-Extensions"); extensions != "" && !s.dialer.EnableCompression {
+	// Values, not Get: gorilla reads every Sec-WebSocket-Extensions header
+	// it was sent, so a server that puts an empty one first and
+	// permessage-deflate second would walk straight past a check on the
+	// first value alone.
+	if extensions := resp.Header.Values("Sec-WebSocket-Extensions"); len(extensions) > 0 && !s.dialer.EnableCompression {
 		_ = conn.Close()
-		return nil, resp, fmt.Errorf("wsclient: server negotiated %q, an extension this client did not offer", extensions)
+		return nil, resp, fmt.Errorf("wsclient: server negotiated %q, an extension this client did not offer",
+			strings.Join(extensions, ", "))
 	}
 
 	conn.SetReadLimit(s.readLimit)
@@ -83,17 +99,18 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 	var (
 		mu       sync.Mutex
 		opened   []net.Conn
-		aborted  bool
+		aborted  atomic.Bool
 		finished bool
 	)
 	track := func(c net.Conn) net.Conn {
+		wrapped := abortableConn{Conn: c, aborted: &aborted}
 		mu.Lock()
 		defer mu.Unlock()
-		if aborted {
-			_ = c.SetDeadline(aLongTimeAgo)
+		if aborted.Load() {
+			_ = wrapped.SetDeadline(aLongTimeAgo)
 		}
-		opened = append(opened, c)
-		return c
+		opened = append(opened, wrapped)
+		return wrapped
 	}
 	wrap := func(dial func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
 		return func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -127,7 +144,7 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 		if finished {
 			return
 		}
-		aborted = true
+		aborted.Store(true)
 		for _, c := range opened {
 			_ = c.SetDeadline(aLongTimeAgo)
 		}
@@ -138,9 +155,10 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 		mu.Lock()
 		defer mu.Unlock()
 		finished = true
-		if !aborted {
+		if !aborted.Load() {
 			return
 		}
+		aborted.Store(false)
 		// The abort can land on a handshake that had already finished. Clear
 		// it so a connection handed back to a caller is still usable; one
 		// that is on its way out is closed by the caller either way.
@@ -148,4 +166,20 @@ func abortable(ctx context.Context, d *websocket.Dialer) (*websocket.Dialer, fun
 			_ = c.SetDeadline(time.Time{})
 		}
 	}
+}
+
+// abortableConn keeps an aborted dial aborted. gorilla/websocket sets its own
+// handshake deadline on whatever the dial hook returned, outside this
+// package's wrapper, so without this an abort landing in that window would be
+// quietly overwritten and the dial would run to its handshake timeout.
+type abortableConn struct {
+	net.Conn
+	aborted *atomic.Bool
+}
+
+func (c abortableConn) SetDeadline(t time.Time) error {
+	if c.aborted.Load() {
+		return c.Conn.SetDeadline(aLongTimeAgo)
+	}
+	return c.Conn.SetDeadline(t)
 }

--- a/pkg/wsclient/dial_test.go
+++ b/pkg/wsclient/dial_test.go
@@ -2,8 +2,10 @@ package wsclient
 
 import (
 	"bufio"
+	"context"
 	"crypto/sha1"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -192,6 +194,42 @@ func TestDial_KeepsTheCredentialOutOfARejectedResponse(t *testing.T) {
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Request)
 	assert.Empty(t, resp.Request.Header.Get("Authorization"))
+}
+
+// TestDial_HandsTheProxyAnHTTPScheme covers what DefaultDialer's
+// http.ProxyFromEnvironment has to be given. That resolver matches
+// HTTP_PROXY and HTTPS_PROXY on the request's scheme and answers nil for
+// anything else, so a ws or wss scheme reaching it would turn every
+// environment proxy off in silence, which is the sort of thing found in
+// production rather than in a test. What keeps it from happening belongs to
+// gorilla, not to this package: it rewrites the scheme before building the
+// request it hands to Dialer.Proxy. Pin it, because nothing here would
+// notice it changing.
+func TestDial_HandsTheProxyAnHTTPScheme(t *testing.T) {
+	for _, tc := range []struct{ url, want string }{
+		{"ws://backhaul.example.com/ws/", "http"},
+		{"wss://backhaul.example.com/ws/", "https"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			var seen string
+			cfg := testConfig(tc.url)
+			cfg.Dialer = DefaultDialer()
+			cfg.Dialer.Proxy = func(r *http.Request) (*url.URL, error) {
+				seen = r.URL.Scheme
+				return nil, nil
+			}
+			// gorilla consults Proxy before it dials, so the socket is never
+			// needed and the name never has to resolve.
+			cfg.Dialer.NetDialContext = func(context.Context, string, string) (net.Conn, error) {
+				return nil, errors.New("the scheme the proxy saw is the whole test")
+			}
+
+			_, _, err := Dial(t.Context(), cfg)
+
+			require.Error(t, err)
+			assert.Equal(t, tc.want, seen, "http.ProxyFromEnvironment matches on this and nothing else")
+		})
+	}
 }
 
 // TestDial_SurvivesAProxyWithoutAReasonPhrase covers gorilla/websocket

--- a/pkg/wsclient/dial_test.go
+++ b/pkg/wsclient/dial_test.go
@@ -140,6 +140,31 @@ func TestDial_RefusesAnExtensionItNeverOffered(t *testing.T) {
 	}
 }
 
+func TestUnofferedExtension(t *testing.T) {
+	const deflate = "permessage-deflate; server_no_context_takeover; client_no_context_takeover"
+	for _, tc := range []struct {
+		name        string
+		values      []string
+		compression bool
+		want        string
+	}{
+		{name: "no header"},
+		{name: "an empty header", values: []string{""}},
+		{name: "deflate, not offered", values: []string{deflate}, want: "permessage-deflate"},
+		{name: "deflate, offered", values: []string{deflate}, compression: true},
+		{name: "deflate in another case, offered", values: []string{"PerMessage-Deflate"}, compression: true},
+		{name: "an unknown extension, with compression on", values: []string{"x-evil"}, compression: true, want: "x-evil"},
+		{name: "an unknown one after deflate", values: []string{deflate + ", x-evil"}, compression: true, want: "x-evil"},
+		{name: "deflate hidden behind an empty header", values: []string{"", deflate}, want: "permessage-deflate"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, found := unofferedExtension(tc.values, tc.compression)
+			assert.Equal(t, tc.want != "", found)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // TestDial_KeepsTheCredentialOutOfTheResponse covers the request that
 // http.ReadResponse hangs off the response it returns. Dial invites callers
 // to inspect that response, and the request carries the Authorization

--- a/pkg/wsclient/dial_test.go
+++ b/pkg/wsclient/dial_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/sha1"
 	"encoding/base64"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -102,26 +103,70 @@ func TestDial_ReportsARejectedHandshake(t *testing.T) {
 // decompression on for it regardless, and a read limit counts compressed
 // bytes, so accepting would let a small frame inflate without bound.
 func TestDial_RefusesAnExtensionItNeverOffered(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, buf, err := w.(http.Hijacker).Hijack()
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		sum := sha1.Sum([]byte(r.Header.Get("Sec-WebSocket-Key") + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
-		_, _ = buf.WriteString("HTTP/1.1 101 Switching Protocols\r\n" +
-			"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
-			"Sec-WebSocket-Accept: " + base64.StdEncoding.EncodeToString(sum[:]) + "\r\n" +
-			"Sec-WebSocket-Extensions: permessage-deflate; server_no_context_takeover; client_no_context_takeover\r\n\r\n")
-		_ = buf.Flush()
+	// gorilla/websocket reads every Sec-WebSocket-Extensions header it is
+	// sent, so a server can hide the real one behind an empty first value.
+	// Checking only the first value let that straight through, and the
+	// connection came back with decompression on and a read limit that
+	// counts compressed bytes: a small frame could then allocate without
+	// bound.
+	for name, extensions := range map[string][]string{
+		"one header":                          {"permessage-deflate; server_no_context_takeover; client_no_context_takeover"},
+		"hidden behind an empty first header": {"", "permessage-deflate; server_no_context_takeover; client_no_context_takeover"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, buf, err := w.(http.Hijacker).Hijack()
+				if err != nil {
+					return
+				}
+				defer func() { _ = conn.Close() }()
+				sum := sha1.Sum([]byte(r.Header.Get("Sec-WebSocket-Key") + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+				response := "HTTP/1.1 101 Switching Protocols\r\n" +
+					"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+					"Sec-WebSocket-Accept: " + base64.StdEncoding.EncodeToString(sum[:]) + "\r\n"
+				for _, ext := range extensions {
+					response += "Sec-WebSocket-Extensions: " + ext + "\r\n"
+				}
+				_, _ = buf.WriteString(response + "\r\n")
+				_ = buf.Flush()
+			}))
+			t.Cleanup(ts.Close)
+
+			conn, _, err := Dial(t.Context(), testConfig(ts.URL))
+
+			assert.Nil(t, conn, "a connection with decompression the client never asked for must be refused")
+			assert.ErrorContains(t, err, "did not offer")
+		})
+	}
+}
+
+// TestDial_KeepsTheCredentialOutOfTheResponse covers the request that
+// http.ReadResponse hangs off the response it returns. Dial invites callers
+// to inspect that response, and the request carries the Authorization
+// header, so one logged struct would put the agent's key in the logs.
+func TestDial_KeepsTheCredentialOutOfTheResponse(t *testing.T) {
+	srv := newBackhaulServer(t)
+	conn, resp, err := Dial(t.Context(), testConfig(srv.url))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	require.NotNil(t, resp.Request)
+	assert.Empty(t, resp.Request.Header.Get("Authorization"))
+	assert.NotContains(t, fmt.Sprint(resp.Request.Header), "secret")
+}
+
+func TestDial_KeepsTheCredentialOutOfARejectedResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
 	}))
 	t.Cleanup(ts.Close)
 
-	conn, _, err := Dial(t.Context(), testConfig(ts.URL))
+	_, resp, err := Dial(t.Context(), testConfig(ts.URL))
 
-	assert.Nil(t, conn)
-	assert.ErrorContains(t, err, "permessage-deflate")
-	assert.ErrorContains(t, err, "did not offer")
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Request)
+	assert.Empty(t, resp.Request.Header.Get("Authorization"))
 }
 
 // TestDial_SurvivesAProxyWithoutAReasonPhrase covers gorilla/websocket

--- a/pkg/wsclient/dial_test.go
+++ b/pkg/wsclient/dial_test.go
@@ -1,0 +1,165 @@
+package wsclient
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDial_HandsOverAWorkingConnection(t *testing.T) {
+	srv := newBackhaulServer(t)
+	cfg := testConfig(srv.url)
+
+	conn, resp, err := Dial(t.Context(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	sc := recv(t, srv.accepted, "the connection")
+	assert.Equal(t, `id="srv-1", key="secret"`, sc.header.Get("Authorization"))
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("hello")))
+	assert.Equal(t, "hello", string(recv(t, sc.received, "the frame")))
+
+	sc.push(t, websocket.TextMessage, "back")
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(waitFor)))
+	_, payload, err := conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, "back", string(payload))
+}
+
+func TestDial_AppliesTheReadLimit(t *testing.T) {
+	srv := newBackhaulServer(t)
+	cfg := testConfig(srv.url)
+	cfg.ReadLimit = 16
+
+	conn, _, err := Dial(t.Context(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	recv(t, srv.accepted, "the connection").push(t, websocket.TextMessage, strings.Repeat("x", 64))
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(waitFor)))
+	_, _, err = conn.ReadMessage()
+	assert.ErrorIs(t, err, websocket.ErrReadLimit)
+}
+
+func TestDial_RejectsABadConfigBeforeDialing(t *testing.T) {
+	var hits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { hits.Add(1) }))
+	t.Cleanup(ts.Close)
+
+	cfg := testConfig(strings.Replace(ts.URL, "http", "ftp", 1))
+	_, _, err := Dial(t.Context(), cfg)
+	assert.ErrorContains(t, err, `scheme "ftp"`)
+
+	cfg = testConfig(ts.URL)
+	cfg.Key = ""
+	_, _, err = Dial(t.Context(), cfg)
+	assert.ErrorContains(t, err, "Key is required")
+
+	assert.Zero(t, hits.Load(), "a config error must not reach the network")
+}
+
+func TestDial_IgnoresTheLoopOnlyFields(t *testing.T) {
+	srv := newBackhaulServer(t)
+	cfg := testConfig(srv.url)
+	cfg.MinBackoff = -time.Second // invalid for a Client, irrelevant to one dial
+
+	conn, _, err := Dial(t.Context(), cfg)
+	require.NoError(t, err)
+	_ = conn.Close()
+}
+
+func TestDial_ReportsARejectedHandshake(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "invalid credentials", http.StatusUnauthorized)
+	}))
+	t.Cleanup(ts.Close)
+
+	conn, resp, err := Dial(t.Context(), testConfig(ts.URL))
+
+	assert.Nil(t, conn)
+	require.ErrorIs(t, err, websocket.ErrBadHandshake)
+	assert.ErrorContains(t, err, "HTTP 401")
+	require.NotNil(t, resp, "the response comes back with the error so the caller can inspect it")
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestDial_RefusesAnExtensionItNeverOffered covers a server that answers with
+// permessage-deflate the client never asked for. gorilla/websocket switches
+// decompression on for it regardless, and a read limit counts compressed
+// bytes, so accepting would let a small frame inflate without bound.
+func TestDial_RefusesAnExtensionItNeverOffered(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, buf, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		sum := sha1.Sum([]byte(r.Header.Get("Sec-WebSocket-Key") + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+		_, _ = buf.WriteString("HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+			"Sec-WebSocket-Accept: " + base64.StdEncoding.EncodeToString(sum[:]) + "\r\n" +
+			"Sec-WebSocket-Extensions: permessage-deflate; server_no_context_takeover; client_no_context_takeover\r\n\r\n")
+		_ = buf.Flush()
+	}))
+	t.Cleanup(ts.Close)
+
+	conn, _, err := Dial(t.Context(), testConfig(ts.URL))
+
+	assert.Nil(t, conn)
+	assert.ErrorContains(t, err, "permessage-deflate")
+	assert.ErrorContains(t, err, "did not offer")
+}
+
+// TestDial_SurvivesAProxyWithoutAReasonPhrase covers gorilla/websocket
+// v1.5.3 reading the reason phrase out of a CONNECT status line that has
+// none, which panics the dialing goroutine. For an agent that goroutine is
+// the process, and a proxy is reachable by default through the environment,
+// so this has to come back as an error.
+func TestDial_SurvivesAProxyWithoutAReasonPhrase(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			reader := bufio.NewReader(conn)
+			for { // drain the CONNECT request
+				line, err := reader.ReadString('\n')
+				if err != nil || line == "\r\n" {
+					break
+				}
+			}
+			_, _ = conn.Write([]byte("HTTP/1.1 407\r\n\r\n")) // a status line with no reason phrase
+			_ = conn.Close()
+		}
+	}()
+
+	proxyURL, err := url.Parse("http://" + listener.Addr().String())
+	require.NoError(t, err)
+	cfg := testConfig("wss://backhaul.example.com/ws/")
+	cfg.Dialer = DefaultDialer()
+	cfg.Dialer.Proxy = func(*http.Request) (*url.URL, error) { return proxyURL, nil }
+
+	conn, _, err := Dial(t.Context(), cfg)
+
+	assert.Nil(t, conn)
+	require.Error(t, err, "a malformed proxy response must not take the process down")
+	assert.ErrorContains(t, err, "proxy")
+}

--- a/pkg/wsclient/dial_test.go
+++ b/pkg/wsclient/dial_test.go
@@ -223,8 +223,9 @@ func TestDial_SurvivesAProxyWithoutAReasonPhrase(t *testing.T) {
 
 	proxyURL, err := url.Parse("http://" + listener.Addr().String())
 	require.NoError(t, err)
+	var tracker closeTrackingDialer
 	cfg := testConfig("wss://backhaul.example.com/ws/")
-	cfg.Dialer = DefaultDialer()
+	cfg.Dialer = tracker.dialer()
 	cfg.Dialer.Proxy = func(*http.Request) (*url.URL, error) { return proxyURL, nil }
 
 	conn, _, err := Dial(t.Context(), cfg)
@@ -232,4 +233,11 @@ func TestDial_SurvivesAProxyWithoutAReasonPhrase(t *testing.T) {
 	assert.Nil(t, conn)
 	require.Error(t, err, "a malformed proxy response must not take the process down")
 	assert.ErrorContains(t, err, "proxy")
+	// The panic unwinds past gorilla's own cleanup, and finish only clears
+	// deadlines, so the socket is closed here only because proxy.go closes it
+	// on the line before the one that panics. Nothing in this package would
+	// notice if that stopped being true, and a Run that keeps retrying would
+	// leak an fd per attempt.
+	assert.True(t, tracker.allClosed(),
+		"the socket the proxy dial opened must be closed before the panic is turned into an error")
 }

--- a/pkg/wsclient/doc.go
+++ b/pkg/wsclient/doc.go
@@ -6,10 +6,10 @@
 // A Client dials with the Authorization header the backhaul expects
 // (id="...", key="..."), re-arms a read timeout before every read, and
 // reconnects whenever the connection drops. Exponential backoff with jitter
-// paces the attempts, including a redial after a connection that ended
-// before it proved itself, so a peer that accepts the handshake and closes
-// at once cannot draw a tight loop out of a fleet of agents. Everything it
-// needs arrives through Config; nothing here reads
+// paces the attempts, including the redial after a connection that lasted
+// less than MinBackoff, so a peer that accepts the handshake and drops it
+// cannot draw a tight loop out of a fleet of agents. Everything it needs
+// arrives through Config; nothing here reads
 // alpamon's global settings. It reports connects, drops and retries through
 // the hooks on Config instead of logging, so the caller decides where those
 // go.

--- a/pkg/wsclient/doc.go
+++ b/pkg/wsclient/doc.go
@@ -20,8 +20,8 @@
 // goroutine that reads, writes are serialized, and Shutdown and Reconnect
 // only signal the read loop, so gorilla/websocket's rule of one concurrent
 // reader and one concurrent writer holds by construction. A caller that needs
-// a connection of its own, to wrap in tunnel.WebSocketConn for smux say, uses
-// Dial and takes on that responsibility itself.
+// a connection of its own, for example to wrap in tunnel.WebSocketConn for
+// smux, uses Dial and takes on that responsibility itself.
 //
 // # Dependencies
 //

--- a/pkg/wsclient/doc.go
+++ b/pkg/wsclient/doc.go
@@ -1,0 +1,32 @@
+// Package wsclient is the WebSocket transport for connections to the Alpacon
+// backhaul, packaged as a leaf so that modules outside this repository, such
+// as the in-cluster alpamon-kube agent, can use it without compiling the host
+// agent.
+//
+// A Client dials with the Authorization header the backhaul expects
+// (id="...", key="..."), re-arms a read timeout before every read, and
+// reconnects whenever the connection drops. Exponential backoff with jitter
+// paces the attempts, including a redial after a connection that ended
+// before it proved itself, so a peer that accepts the handshake and closes
+// at once cannot draw a tight loop out of a fleet of agents. Everything it
+// needs arrives through Config; nothing here reads
+// alpamon's global settings. It reports connects, drops and retries through
+// the hooks on Config instead of logging, so the caller decides where those
+// go.
+//
+// # Ownership
+//
+// A Client owns its connection and never exposes it. Run is the only
+// goroutine that reads, writes are serialized, and Shutdown and Reconnect
+// only signal the read loop, so gorilla/websocket's rule of one concurrent
+// reader and one concurrent writer holds by construction. A caller that needs
+// a connection of its own, to wrap in tunnel.WebSocketConn for smux say, uses
+// Dial and takes on that responsibility itself.
+//
+// # Dependencies
+//
+// This package may import the standard library, github.com/gorilla/websocket,
+// and alpamon's pkg/tunnel and pkg/version, and nothing else. The leaf-guard
+// job in .github/workflows/build-and-test.yml fails the build if its
+// dependency graph reaches any other package.
+package wsclient

--- a/pkg/wsclient/reconnect_test.go
+++ b/pkg/wsclient/reconnect_test.go
@@ -33,9 +33,9 @@ func refusingConfig() Config {
 }
 
 // TestRun_BackoffScheduleUnderAFakeClock checks both the waits Run reports and
-// when each retry actually happens. With the draw pinned to 0 (factor 0.5)
-// the base doubles 1s, 2s, 4s, 8s, 8s, 8s and each wait is half of it,
-// clamped up to the 1s floor.
+// when each retry actually happens. With the draw pinned to 0 the factor is
+// 1.0, so each wait is the base itself: 1s, 2s, 4s, then 8s from the ceiling
+// on.
 func TestRun_BackoffScheduleUnderAFakeClock(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
@@ -63,24 +63,24 @@ func TestRun_BackoffScheduleUnderAFakeClock(t *testing.T) {
 
 		assert.Equal(t, []int{1, 2, 3, 4, 5, 6}, attempts)
 		assert.Equal(t, []time.Duration{
-			time.Second, // 0.5s raw, clamped up to the floor
 			time.Second,
 			2 * time.Second,
 			4 * time.Second,
-			4 * time.Second, // the base is capped at 8s from here on
-			4 * time.Second,
+			8 * time.Second, // the base is capped at 8s from here on
+			8 * time.Second,
+			8 * time.Second,
 		}, waits)
 		// Each retry fires exactly when the previous wait ends: the bubble's
 		// clock is exact, so these would catch a wait that ran long or short.
 		assert.Equal(t, []time.Duration{
 			0,
 			time.Second,
-			2 * time.Second,
-			4 * time.Second,
-			8 * time.Second,
-			12 * time.Second,
+			3 * time.Second,
+			7 * time.Second,
+			15 * time.Second,
+			23 * time.Second,
 		}, at)
-		assert.Equal(t, 12*time.Second, time.Since(start), "cancelling during a retry must not wait out its delay")
+		assert.Equal(t, 23*time.Second, time.Since(start), "cancelling during a retry must not wait out its delay")
 	})
 }
 
@@ -107,14 +107,15 @@ func TestRun_ShutdownDuringBackoffReturnsAtOnce(t *testing.T) {
 	})
 }
 
-// TestRun_JitterDesynchronizesClients is the point of the jitter: clients that
-// lose the backhaul at the same instant must not retry in lockstep. It samples
-// the third attempt, after two draws, because the first wait clamps half of all
-// draws to the same 1s floor and would understate the spread.
+// TestRun_JitterDesynchronizesClients is the point of the jitter: clients
+// that lose the backhaul at the same instant must not retry in lockstep. It
+// samples the very first wait, which is the one that matters after a fleet-
+// wide drop, and which a factor range starting below 1.0 would collapse onto
+// the floor for half the fleet.
 func TestRun_JitterDesynchronizesClients(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const clients = 50
-		thirdAttempt := make(chan time.Duration, clients)
+		firstRetry := make(chan time.Duration, clients)
 		start := time.Now()
 		ctx, cancel := context.WithCancel(t.Context())
 
@@ -123,8 +124,8 @@ func TestRun_JitterDesynchronizesClients(t *testing.T) {
 			cfg.MinBackoff = time.Second
 			cfg.MaxBackoff = time.Minute
 			cfg.OnRetry = func(attempt int, _ time.Duration, _ error) {
-				if attempt == 3 {
-					thirdAttempt <- time.Since(start)
+				if attempt == 2 {
+					firstRetry <- time.Since(start)
 				}
 			}
 			c, err := New(cfg)
@@ -135,14 +136,14 @@ func TestRun_JitterDesynchronizesClients(t *testing.T) {
 		seen := map[time.Duration]bool{}
 		earliest, latest := time.Duration(1<<63-1), time.Duration(0)
 		for range clients {
-			d := <-thirdAttempt
+			d := <-firstRetry
 			seen[d] = true
 			earliest, latest = min(earliest, d), max(latest, d)
 		}
 		cancel()
-		synctest.Wait()
 
 		assert.Greater(t, len(seen), clients*9/10, "clients should retry at distinct instants")
-		assert.GreaterOrEqual(t, latest-earliest, time.Second, "the retries should spread across the jitter window")
+		assert.GreaterOrEqual(t, earliest, time.Second, "no wait may undercut MinBackoff")
+		assert.GreaterOrEqual(t, latest-earliest, 300*time.Millisecond, "the first retries should spread across the jitter window")
 	})
 }

--- a/pkg/wsclient/reconnect_test.go
+++ b/pkg/wsclient/reconnect_test.go
@@ -1,0 +1,148 @@
+package wsclient
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests time the reconnect schedule under synctest's fake clock. That
+// only works because no socket is involved: the dialer fails in-process, so
+// the one thing Run ever blocks on is its backoff timer, which the bubble
+// counts as blocked and fast-forwards.
+
+var errRefused = errors.New("connection refused")
+
+// refusingConfig returns a config whose every dial fails at once, without
+// touching the network. Proxy stays nil so no dial step reads the environment.
+func refusingConfig() Config {
+	cfg := validConfig()
+	cfg.Dialer = &websocket.Dialer{
+		NetDialContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errRefused
+		},
+	}
+	return cfg
+}
+
+// TestRun_BackoffScheduleUnderAFakeClock checks both the waits Run reports and
+// when each retry actually happens. With the draw pinned to 0 (factor 0.5)
+// the base doubles 1s, 2s, 4s, 8s, 8s, 8s and each wait is half of it,
+// clamped up to the 1s floor.
+func TestRun_BackoffScheduleUnderAFakeClock(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		start := time.Now()
+
+		var attempts []int
+		var waits, at []time.Duration
+		cfg := refusingConfig()
+		cfg.MinBackoff = time.Second
+		cfg.MaxBackoff = 8 * time.Second
+		cfg.Rand = func() float64 { return 0 }
+		cfg.OnRetry = func(attempt int, delay time.Duration, err error) {
+			assert.ErrorIs(t, err, errRefused)
+			attempts = append(attempts, attempt)
+			waits = append(waits, delay)
+			at = append(at, time.Since(start))
+			if attempt == 6 {
+				cancel() // lands before Run waits out the sixth delay
+			}
+		}
+		c, err := New(cfg)
+		require.NoError(t, err)
+
+		require.ErrorIs(t, c.Run(ctx, discard), context.Canceled)
+
+		assert.Equal(t, []int{1, 2, 3, 4, 5, 6}, attempts)
+		assert.Equal(t, []time.Duration{
+			time.Second, // 0.5s raw, clamped up to the floor
+			time.Second,
+			2 * time.Second,
+			4 * time.Second,
+			4 * time.Second, // the base is capped at 8s from here on
+			4 * time.Second,
+		}, waits)
+		// Each retry fires exactly when the previous wait ends: the bubble's
+		// clock is exact, so these would catch a wait that ran long or short.
+		assert.Equal(t, []time.Duration{
+			0,
+			time.Second,
+			2 * time.Second,
+			4 * time.Second,
+			8 * time.Second,
+			12 * time.Second,
+		}, at)
+		assert.Equal(t, 12*time.Second, time.Since(start), "cancelling during a retry must not wait out its delay")
+	})
+}
+
+func TestRun_ShutdownDuringBackoffReturnsAtOnce(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		retried := make(chan struct{}, 1)
+		cfg := refusingConfig()
+		cfg.MinBackoff = time.Minute
+		cfg.MaxBackoff = time.Hour
+		cfg.OnRetry = func(int, time.Duration, error) { retried <- struct{}{} }
+		c, err := New(cfg)
+		require.NoError(t, err)
+
+		start := time.Now()
+		result := make(chan error, 1)
+		go func() { result <- c.Run(t.Context(), discard) }()
+
+		<-retried
+		synctest.Wait() // Run is now parked on its first backoff timer
+		c.Shutdown()
+
+		require.NoError(t, <-result)
+		assert.Zero(t, time.Since(start), "Shutdown must cut the backoff wait short, not wait out the minute")
+	})
+}
+
+// TestRun_JitterDesynchronizesClients is the point of the jitter: clients that
+// lose the backhaul at the same instant must not retry in lockstep. It samples
+// the third attempt, after two draws, because the first wait clamps half of all
+// draws to the same 1s floor and would understate the spread.
+func TestRun_JitterDesynchronizesClients(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const clients = 50
+		thirdAttempt := make(chan time.Duration, clients)
+		start := time.Now()
+		ctx, cancel := context.WithCancel(t.Context())
+
+		for range clients {
+			cfg := refusingConfig()
+			cfg.MinBackoff = time.Second
+			cfg.MaxBackoff = time.Minute
+			cfg.OnRetry = func(attempt int, _ time.Duration, _ error) {
+				if attempt == 3 {
+					thirdAttempt <- time.Since(start)
+				}
+			}
+			c, err := New(cfg)
+			require.NoError(t, err)
+			go func() { _ = c.Run(ctx, discard) }()
+		}
+
+		seen := map[time.Duration]bool{}
+		earliest, latest := time.Duration(1<<63-1), time.Duration(0)
+		for range clients {
+			d := <-thirdAttempt
+			seen[d] = true
+			earliest, latest = min(earliest, d), max(latest, d)
+		}
+		cancel()
+		synctest.Wait()
+
+		assert.Greater(t, len(seen), clients*9/10, "clients should retry at distinct instants")
+		assert.GreaterOrEqual(t, latest-earliest, time.Second, "the retries should spread across the jitter window")
+	})
+}

--- a/pkg/wsclient/reconnect_test.go
+++ b/pkg/wsclient/reconnect_test.go
@@ -112,6 +112,12 @@ func TestRun_ShutdownDuringBackoffReturnsAtOnce(t *testing.T) {
 // samples the very first wait, which is the one that matters after a fleet-
 // wide drop, and which a factor range starting below 1.0 would collapse onto
 // the floor for half the fleet.
+//
+// It reads that wait off the second retry rather than the first, because
+// OnRetry announces a wait before serving it: the clock when attempt 2 is
+// announced is exactly how long attempt 1's wait ran. Sampling the delay
+// attempt 1 reports would be the obvious spelling and a weaker test, proving
+// only what was announced rather than what the client waited.
 func TestRun_JitterDesynchronizesClients(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const clients = 50


### PR DESCRIPTION
## Summary

Adds `pkg/wsclient`, alpamon's WebSocket transport as a package a module outside this repository can import, and a CI job that keeps it that way. This is the first PR of the Kubernetes plan: `alpacax/alpamon-kube` cannot start until alpamon ships this and tags it.

Today the only WS client is in `pkg/runner/client.go`. `NewWebsocketClient` takes an `internal/pool.Pool`, so no other module can build an argument for it, and importing `pkg/runner` pulls in `internal/{pool,protocol,retry}`, `pkg/{agent,config,executor/handlers/common,scheduler,signing,utils}`, creack/pty and gopsutil. `alpamon-dhcp-plugin` is the standing evidence: pinned to pre-`/v2` `v1.3.0`, compiling the whole host stack to open a socket.

Measured with a throwaway module importing each:

| Imports | Module-backed packages compiled |
|---|---|
| `pkg/wsclient` | 3: gorilla/websocket, `pkg/version`, itself |
| `pkg/runner` | 63, including creack/pty, gopsutil, smux, zerolog, validator |

Nothing existing changes. `pkg/runner`, `pkg/plugin` and `pkg/pluginclient` are untouched, and no alpamon code calls the new package yet.

## Issue #452

#466 makes this a merge gate, because exporting a racy shape freezes it for every module that pins the tag. The new package does not reproduce any of the three defects: `conn` is unexported and guarded by a mutex, `Run` is the only reader, writes hold a write mutex, and `Shutdown` is a `sync.Once`. No exported method touches the read side — `Shutdown` and `Reconnect` push the read deadline into the past under the same mutex the read loop arms it with, so a request cannot be lost to a re-arm.

**#452 stays open.** This PR sidesteps those defects in new code; `pkg/runner` still has them.

## Deliberate differences from pkg/runner/client.go

None can regress a caller, because there is no caller yet.

- Nothing calls `os.Exit`, and there is no retry exhaustion. `pkg/runner`'s `Connect` gives up after `maxRetryTimeout` (3 days) and exits the process. `Run` keeps redialing until `Shutdown` (returns nil), its context ending (returns `ctx.Err()`), or a handler error (returns that error). A caller that wants a give-up policy counts attempts in `OnRetry` and calls `Shutdown`, or bounds the context.
- The backoff paces attempts, not just failed dials. A connection that ends before it proved itself waits like a failed dial does; a peer that accepts the handshake and closes at once would otherwise be redialed thousands of times a second, per agent. Proving itself means staying up for `MinBackoff`, measured before the close handshake. Carrying a frame does not count, because a peer that sends one byte and hangs up would otherwise reset the backoff every round. A drop after that, or a close the caller asked for with `Reconnect`, still redials immediately. A failed write is paced like any other failure.
- `HandshakeTimeout` defaults to 30s, and a dial stalled after TCP is aborted when `Shutdown` or the context ends. gorilla/websocket stops watching the context once the socket is up, so otherwise a shutdown waits out the handshake, or forever when a caller's dialer sets no timeout.
- Proxies from the environment are honored; every dialer in the repo ignores them today. gorilla/websocket v1.5.3 panics on a CONNECT status line with no reason phrase (`proxy.go` indexes the reason phrase unchecked), so a dial that panics is returned as an error rather than taking the agent down.
- Writes carry a deadline, and a failed write replaces the connection, since gorilla fails every later write on it. `WriteMessage` accepts data frames only: a close frame handed to it would end the connection behind the read loop's back.
- A server answering with an extension the client never offered is refused. gorilla enables decompression for it regardless of `EnableCompression`, and a read limit counts compressed bytes, so together they turn a small frame into an unbounded allocation.

Logging is by hooks (`OnConnect`, `OnDisconnect`, `OnRetry`) rather than a logger: `pkg/logger` would pull `pkg/config`, `pkg/scheduler`, `pkg/utils`, gopsutil and smux into the graph, and a library should not write into somebody else's global. alpamon-kube drives its `alpamonkube_backhaul_connected` gauge off the two edges.

The backoff is `internal/retry`'s jitter from #468, reimplemented rather than imported, because Go's internal rule puts `internal/retry` out of reach of the modules this package exists for.

## The guard

`leaf-guard` asserts the module-backed dependency graph of `pkg/wsclient` stays within `pkg/tunnel`, `pkg/version` and gorilla/websocket, and is in the `build-and-test` aggregator's `needs` list, which is the required status check. That set is a ceiling, not an inventory: what ships imports `pkg/version` and gorilla and nothing else, and `pkg/tunnel` is allowed for a caller that wants `tunnel.WebSocketConn` around what `Dial` returns without this package reaching for it. `release.yml` calls this workflow, so it gates tags too.

It is written not to pass on air (the package must appear in its own graph first), not to fail open (plain string comparison, because `if unexpected=$(grep -vE ...)` reads grep's exit 2 for a bad pattern the same as exit 1 for no matches), and not to check only one platform (every target `.goreleaser.yaml` ships, both architectures, plus a cgo-on pass).

Run locally against each violation it claims to catch. All fail:

| Case | Result |
|---|---|
| clean tree | pass |
| `import _ "pkg/config"` | fail, names `pkg/config` and its tail |
| `import _ "pkg/utils"` | fail |
| `import _ "internal/retry"` | fail |
| `import _ "zerolog"` | fail |
| `import _ "creack/pty"` | fail, with the pty and systemd message |
| `//go:build windows` file importing `pkg/config` | fail, on `windows/amd64/0` |
| `//go:build arm64` file importing `pkg/config` | fail, on `linux/arm64/0` |
| package renamed away | fail |
| pattern matching no packages | fail, as a vacuous pass |
| allowlist emptied or left as a stale regex | fail |
| `import _ "pkg/tunnel"` (allowed) | pass |

## Testing

84 tests. Backoff and config are table tests; the reconnect schedule is timed under `testing/synctest`'s fake clock, which works because the dialer fails in-process and the only thing `Run` blocks on is its backoff timer; everything socket-backed stays on the real clock, as `CLAUDE.md` requires.

- `go test ./... -p 1`: 48 packages, no failures.
- `go test -race ./pkg/wsclient -count=15`, four times over, plus `-cpu 1,2,8`: clean.
- Cross-compiles for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64.
- `go mod tidy` is a zero diff; no new module enters `go.mod`.
- 26 deliberate mutations of the code were each caught by a test: dropping the write mutex, an interrupt that frees nothing, a non-idempotent `Shutdown`, jitter fed back into the doubling base, a lost backoff reset, an overflowing double, a requested close reported as a failure, `armRead` ignoring requests, a missing write deadline, control frames let through, the unconditional `Close` moved back inside the success branch (the PR #444 fd leak), the header's comma, the pacing rule, the handshake abort, the panic recovery, the compression refusal, and the rest.

## Not in this PR

- The `v2.7.0` tag. Nothing needs editing to cut it: the version comes from ldflags and there is no CHANGELOG. **This issue stays open until that tag exists**, since `alpamon-kube` TASK-01 pins it.
- Moving dhcp-plugin onto this API, which happens in its own repo.

## Note for alpamon-kube TASK-01

Its env table lists `WS_MIN_BACKOFF`, `WS_MAX_BACKOFF` and `WS_MAX_BACKOFF_CEILING`, but this package exposes two knobs. Map `WS_MIN_BACKOFF` to `MinBackoff` and `WS_MAX_BACKOFF_CEILING` to `MaxBackoff`, and drop `WS_MAX_BACKOFF`: a 60s cap cannot spread a 500-cluster herd, so the ceiling is the number that matters. It must also set `UserAgent`, or it reports itself as alpamon.

Refs #466, #452

